### PR TITLE
feat: pluggable reverse proxy support (nginx + caddy)

### DIFF
--- a/.kiro/specs/pluggable-reverse-proxy/.config.kiro
+++ b/.kiro/specs/pluggable-reverse-proxy/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "9a04f056-3028-40bb-a976-fa565aa82ff0", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/pluggable-reverse-proxy/design.md
+++ b/.kiro/specs/pluggable-reverse-proxy/design.md
@@ -1,0 +1,387 @@
+# Design Document: Pluggable Reverse Proxy
+
+## Overview
+
+This feature introduces a pluggable reverse proxy abstraction into strut's engine so that proxy-specific behavior (reload, scaffold, domain/SSL, drift, audit, health) is dispatched based on a `REVERSE_PROXY` config setting rather than hardcoded to nginx. Nginx remains the default; Caddy is the first alternative.
+
+The design follows strut's core principle: no hardcoded values in the engine — everything config-driven. The existing `lib/config.sh` → `strut.conf` pattern (used by `REGISTRY_TYPE`) serves as the blueprint. Each engine module that currently references nginx directly will be updated to read `REVERSE_PROXY` and dispatch accordingly.
+
+### Research Summary
+
+Key findings from codebase analysis:
+
+- **Config pattern**: `lib/config.sh` already implements the `load_strut_config` pattern — source `strut.conf`, apply defaults, export. Adding `REVERSE_PROXY` follows the same shape as `REGISTRY_TYPE`.
+- **Deploy reload**: `lib/deploy.sh` → `deploy_stack()` currently hardcodes `$compose_cmd ps nginx` and `$compose_cmd exec -T nginx nginx -s reload`. This is the primary dispatch point.
+- **Scaffold**: `lib/cmd_scaffold.sh` → `cmd_scaffold()` creates `nginx/` directory and writes a hardcoded `nginx.conf`. Needs a conditional branch.
+- **Domain/SSL**: `lib/cmd_domain.sh` → `cmd_domain()` calls `configure-domain.sh` on VPS, pulls back `nginx/conf.d/<stack>.conf`, and restarts `nginx`. Caddy path skips certbot (Caddy has built-in ACME) and pulls back `Caddyfile` instead.
+- **Drift**: `lib/drift.sh` has a hardcoded `DRIFT_TRACKED_FILES` array containing `nginx/nginx.conf`. Needs to swap to `caddy/Caddyfile` when `REVERSE_PROXY=caddy`. The `drift_validate_syntax` function already has a `nginx.conf)` case — needs a `Caddyfile)` case.
+- **Audit**: `lib/audit.sh` → `_audit_nginx()` collects nginx containers/configs. Needs a parallel `_audit_caddy()` function.
+- **Health**: `lib/health.sh` → `health_check_network()` hardcodes port 80. Caddy listens on both 80 and 443 by default. Also needs to support `PROXY_PORTS` override in `services.conf`.
+- **Dry-run**: `lib/deploy.sh` dry-run block shows `nginx -s reload`. Needs to show the correct reload command per proxy type.
+- **Template**: `templates/strut.conf.template` needs a `REVERSE_PROXY` entry.
+
+## Architecture
+
+The pluggable proxy follows a **dispatch-by-config** pattern, consistent with how `REGISTRY_TYPE` drives registry auth in `lib/registry.sh`.
+
+```mermaid
+flowchart TD
+    A[strut.conf] -->|REVERSE_PROXY=nginx/caddy| B[lib/config.sh]
+    B -->|exports REVERSE_PROXY| C{Engine Modules}
+    C --> D[lib/deploy.sh]
+    C --> E[lib/cmd_scaffold.sh]
+    C --> F[lib/cmd_domain.sh]
+    C --> G[lib/drift.sh]
+    C --> H[lib/audit.sh]
+    C --> I[lib/health.sh]
+
+    D -->|reload dispatch| D1[nginx -s reload]
+    D -->|reload dispatch| D2[caddy reload]
+
+    E -->|scaffold dispatch| E1[nginx/ + nginx.conf]
+    E -->|scaffold dispatch| E2[caddy/ + Caddyfile]
+
+    G -->|tracked files| G1[nginx/nginx.conf]
+    G -->|tracked files| G2[caddy/Caddyfile]
+```
+
+### Design Decisions
+
+1. **Config value doubles as compose service name** — `REVERSE_PROXY=nginx` means the compose service is named `nginx`; `REVERSE_PROXY=caddy` means the service is named `caddy`. This avoids a separate `PROXY_SERVICE_NAME` config key and matches how operators already name their services.
+
+2. **Validation at config load time** — Invalid `REVERSE_PROXY` values are caught in `load_strut_config` via `fail()`, not at each call site. This is consistent with how a bad `REGISTRY_TYPE` would be caught.
+
+3. **No proxy abstraction layer / interface file** — Each module handles its own `case "$REVERSE_PROXY"` dispatch inline. The proxy-specific logic in each module is small (2-5 lines per branch), so a shared abstraction would add indirection without reducing complexity. If a third proxy is added later, a shared `lib/proxy.sh` can be extracted.
+
+4. **Drift tracked files are dynamic** — Instead of a static array, `drift_get_tracked_files()` returns the list based on `REVERSE_PROXY`. The static `DRIFT_TRACKED_FILES` array is replaced with a function call.
+
+5. **Caddy auto-HTTPS** — When `REVERSE_PROXY=caddy`, the domain command skips certbot steps entirely. Caddy's built-in ACME handles certificate provisioning automatically when a domain is configured in the Caddyfile.
+
+## Components and Interfaces
+
+### 1. `lib/config.sh` — Config Loading
+
+**Modified function: `load_strut_config()`**
+
+Adds `REVERSE_PROXY` to the config loading and default-application logic.
+
+```bash
+# After existing defaults:
+REVERSE_PROXY="${REVERSE_PROXY:-nginx}"
+export REVERSE_PROXY
+
+# Validation
+case "$REVERSE_PROXY" in
+  nginx|caddy) ;;
+  *) fail "Invalid REVERSE_PROXY='$REVERSE_PROXY' in strut.conf (valid: nginx, caddy)" ;;
+esac
+```
+
+### 2. `templates/strut.conf.template` — Config Template
+
+Adds a commented `REVERSE_PROXY` entry:
+
+```
+# ── Reverse Proxy ──────────────────────────────────
+# Supported types: nginx | caddy
+# REVERSE_PROXY=nginx
+```
+
+### 3. `lib/deploy.sh` — Deploy Reload
+
+**Modified function: `deploy_stack()`**
+
+Replaces the hardcoded nginx reload block with a proxy-aware dispatch:
+
+```bash
+# Reload reverse proxy to pick up new container IPs
+local proxy="${REVERSE_PROXY:-nginx}"
+if $compose_cmd ps "$proxy" &>/dev/null && $compose_cmd ps "$proxy" | grep -q "Up"; then
+  log "Reloading $proxy to refresh backend IPs..."
+  case "$proxy" in
+    nginx) $compose_cmd exec -T nginx nginx -s reload 2>/dev/null && ok "nginx reloaded" || warn "nginx reload failed" ;;
+    caddy) $compose_cmd exec -T caddy caddy reload --config /etc/caddy/Caddyfile 2>/dev/null && ok "Caddy reloaded" || warn "Caddy reload failed" ;;
+  esac
+else
+  warn "$proxy container not running — skipping reload"
+fi
+```
+
+**Dry-run block** also updated to show the correct reload command.
+
+### 4. `lib/cmd_scaffold.sh` — Scaffold Templates
+
+**Modified function: `cmd_scaffold()`**
+
+Replaces the hardcoded nginx directory creation with a proxy-aware branch:
+
+```bash
+local proxy="${REVERSE_PROXY:-nginx}"
+case "$proxy" in
+  nginx)
+    mkdir -p "$target/nginx/conf.d"
+    # ... existing nginx.conf content ...
+    ;;
+  caddy)
+    mkdir -p "$target/caddy"
+    cat > "$target/caddy/Caddyfile" <<'CADDY_EOF'
+# Caddyfile — reverse proxy configuration
+# See https://caddyserver.com/docs/caddyfile
+{
+    # Global options
+}
+
+# :80 {
+#     reverse_proxy app:8000
+# }
+CADDY_EOF
+    ;;
+esac
+```
+
+The "Next steps" output references the correct proxy config directory.
+
+### 5. `lib/cmd_domain.sh` — Domain/SSL Configuration
+
+**Modified function: `cmd_domain()`**
+
+Adds a proxy-aware branch:
+
+- **nginx path**: Current behavior unchanged (calls `configure-domain.sh`, pulls nginx conf, restarts nginx).
+- **caddy path**: Updates the Caddyfile on VPS with the domain block, reloads Caddy (no certbot needed), pulls back the Caddyfile.
+
+```bash
+local proxy="${REVERSE_PROXY:-nginx}"
+case "$proxy" in
+  nginx)
+    # ... existing nginx domain logic ...
+    ;;
+  caddy)
+    # Update Caddyfile on VPS, reload Caddy, pull back Caddyfile
+    # Skip certbot — Caddy handles ACME automatically
+    ;;
+esac
+```
+
+### 6. `lib/drift.sh` — Drift Detection
+
+**New function: `drift_get_tracked_files()`**
+
+Returns the tracked files list dynamically based on `REVERSE_PROXY`:
+
+```bash
+drift_get_tracked_files() {
+  local base_files=(
+    "docker-compose.yml"
+    ".env.template"
+    "backup.conf"
+    "repos.conf"
+    "volume.conf"
+  )
+  local proxy="${REVERSE_PROXY:-nginx}"
+  case "$proxy" in
+    nginx) base_files+=("nginx/nginx.conf") ;;
+    caddy) base_files+=("caddy/Caddyfile") ;;
+  esac
+  echo "${base_files[@]}"
+}
+```
+
+The static `DRIFT_TRACKED_FILES` array is replaced with calls to this function.
+
+**Modified function: `drift_validate_syntax()`**
+
+Adds a `Caddyfile)` case:
+
+```bash
+Caddyfile)
+  if command -v caddy &>/dev/null; then
+    caddy validate --config "$file_path" >/dev/null 2>&1
+    return $?
+  fi
+  ;;
+```
+
+### 7. `lib/audit.sh` — VPS Audit
+
+**New function: `_audit_caddy()`**
+
+Parallel to `_audit_nginx()`, collects Caddy containers and Caddyfile configs:
+
+```bash
+_audit_caddy() {
+  local ssh_opts="$1" vps_user="$2" vps_host="$3" _sudo="$4" audit_dir="$5"
+  log "Collecting Caddy configuration..."
+  mkdir -p "$audit_dir/caddy"
+  ssh $ssh_opts "$vps_user@$vps_host" \
+    "${_sudo}docker ps --format '{{.Names}}' | grep -i caddy" \
+    > "$audit_dir/caddy/caddy-containers.txt" 2>/dev/null || true
+  # ... extract Caddyfile from containers, check system service ...
+}
+```
+
+**Modified function: `audit_vps()`** — calls `_audit_caddy` after `_audit_nginx`.
+
+**Modified function: `audit_generate_report()`** — includes Caddy section in report.
+
+### 8. `lib/health.sh` — Health Check Network
+
+**Modified function: `health_check_network()`**
+
+Replaces the hardcoded `local -a ports=(80)` with proxy-aware defaults:
+
+```bash
+local proxy="${REVERSE_PROXY:-nginx}"
+local -a ports=()
+
+# Check for PROXY_PORTS override in services.conf
+if [ -n "${PROXY_PORTS:-}" ]; then
+  IFS=' ' read -ra ports <<< "$PROXY_PORTS"
+else
+  case "$proxy" in
+    nginx) ports=(80) ;;
+    caddy) ports=(80 443) ;;
+  esac
+fi
+```
+
+## Data Models
+
+### Configuration Keys
+
+| Key | File | Type | Default | Valid Values |
+|-----|------|------|---------|-------------|
+| `REVERSE_PROXY` | `strut.conf` | string | `nginx` | `nginx`, `caddy` |
+| `PROXY_PORTS` | `services.conf` | space-separated ints | (derived from proxy type) | e.g. `80 443 8080` |
+
+### Proxy Config Directory Layout
+
+**nginx (existing)**:
+```
+stacks/<name>/
+  nginx/
+    nginx.conf
+    conf.d/
+      <stack>.conf
+```
+
+**caddy (new)**:
+```
+stacks/<name>/
+  caddy/
+    Caddyfile
+```
+
+### Proxy Dispatch Table
+
+| Operation | nginx | caddy |
+|-----------|-------|-------|
+| Reload command | `nginx -s reload` | `caddy reload --config /etc/caddy/Caddyfile` |
+| Compose service name | `nginx` | `caddy` |
+| Config file (scaffold) | `nginx/nginx.conf` | `caddy/Caddyfile` |
+| Drift tracked file | `nginx/nginx.conf` | `caddy/Caddyfile` |
+| Syntax validation | `nginx -t` | `caddy validate --config` |
+| SSL mechanism | certbot + `configure-domain.sh` | Caddy built-in ACME |
+| Default ports | 80 | 80, 443 |
+| Domain config pull path | `nginx/conf.d/<stack>.conf` | `caddy/Caddyfile` |
+
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Config parsing loads REVERSE_PROXY and defaults to nginx
+
+*For any* `strut.conf` containing a random subset of config keys (including `REVERSE_PROXY`), after calling `load_strut_config`, every present key should have its specified value and every absent key should have its default — with `REVERSE_PROXY` defaulting to `nginx` when absent.
+
+**Validates: Requirements 1.1, 1.2**
+
+### Property 2: Invalid REVERSE_PROXY values are rejected
+
+*For any* string that is not `nginx` or `caddy`, setting `REVERSE_PROXY` to that value in `strut.conf` and calling `load_strut_config` should cause a failure (via `fail()`).
+
+**Validates: Requirements 1.3**
+
+### Property 3: Scaffold creates correct proxy directory per REVERSE_PROXY
+
+*For any* valid `REVERSE_PROXY` value (`nginx` or `caddy`), running `cmd_scaffold` should create the proxy-specific config directory (`nginx/` with `nginx.conf` and `conf.d/` for nginx, `caddy/` with `Caddyfile` for caddy) and the scaffold output should reference the correct proxy config directory.
+
+**Validates: Requirements 3.1, 3.2, 3.3**
+
+### Property 4: Drift tracked files include correct proxy config per REVERSE_PROXY
+
+*For any* valid `REVERSE_PROXY` value, the drift tracked files list returned by `drift_get_tracked_files()` should include the proxy-specific config file (`nginx/nginx.conf` for nginx, `caddy/Caddyfile` for caddy) and should not include the other proxy's config file.
+
+**Validates: Requirements 5.1, 5.2**
+
+### Property 5: Health engine checks correct default ports per REVERSE_PROXY
+
+*For any* valid `REVERSE_PROXY` value with no `PROXY_PORTS` override, the health engine's network port list should include port 80 for nginx, and both port 80 and port 443 for caddy.
+
+**Validates: Requirements 7.1, 7.2**
+
+### Property 6: PROXY_PORTS override replaces default proxy ports
+
+*For any* space-separated list of valid port numbers set as `PROXY_PORTS` in `services.conf`, the health engine's network port list should contain exactly those ports, regardless of the `REVERSE_PROXY` value.
+
+**Validates: Requirements 7.3**
+
+### Property 7: Dry-run output shows correct proxy reload command per REVERSE_PROXY
+
+*For any* valid `REVERSE_PROXY` value with `DRY_RUN=true`, the deploy execution plan output should contain the proxy-specific reload command (`nginx -s reload` for nginx, `caddy reload` for caddy).
+
+**Validates: Requirements 8.1, 8.2**
+
+## Error Handling
+
+| Scenario | Handler | Behavior |
+|----------|---------|----------|
+| Invalid `REVERSE_PROXY` value in `strut.conf` | `load_strut_config()` | `fail()` with descriptive message listing valid values |
+| Proxy container not running during deploy reload | `deploy_stack()` | `warn()` and skip reload — deploy still succeeds |
+| Proxy reload command fails | `deploy_stack()` | `warn()` — non-fatal, deploy still reports success |
+| Caddy validate fails during drift check | `drift_validate_syntax()` | `warn()` and skip file — same as existing nginx behavior |
+| `PROXY_PORTS` contains non-numeric values | `health_check_network()` | Passed through to `ss`/`netstat` — will simply not match, reported as "not listening" |
+| `caddy` binary not available for drift validation | `drift_validate_syntax()` | Skip validation, assume valid — same pattern as existing nginx fallback |
+
+All error handling follows strut's existing conventions:
+- `fail()` for fatal errors that should stop execution (invalid config)
+- `warn()` for non-fatal issues that should be reported but not block operations
+- Never bare `|| return 1` without a message
+
+## Testing Strategy
+
+### Property-Based Tests (BATS)
+
+Each correctness property maps to a BATS test with 100 randomized iterations, following the existing pattern in `tests/test_config.bats`.
+
+**Library**: BATS (Bash Automated Testing System) — already used by the project.
+
+**Configuration**: 100 iterations per property test with randomized inputs.
+
+**Test file**: `tests/test_proxy_config.bats`
+
+| Property | Test Approach |
+|----------|--------------|
+| Property 1: Config parsing | Generate random strut.conf with random subset of keys including REVERSE_PROXY. Verify load_strut_config exports correct values and defaults. Tag: **Feature: pluggable-reverse-proxy, Property 1: Config parsing loads REVERSE_PROXY and defaults to nginx** |
+| Property 2: Invalid values rejected | Generate 100 random strings (excluding "nginx" and "caddy"). Verify load_strut_config fails for each. Tag: **Feature: pluggable-reverse-proxy, Property 2: Invalid REVERSE_PROXY values are rejected** |
+| Property 3: Scaffold dispatch | For each valid proxy type, run cmd_scaffold and verify correct directory structure and output text. Tag: **Feature: pluggable-reverse-proxy, Property 3: Scaffold creates correct proxy directory per REVERSE_PROXY** |
+| Property 4: Drift tracked files | For each valid proxy type, call drift_get_tracked_files and verify correct proxy config file is included. Tag: **Feature: pluggable-reverse-proxy, Property 4: Drift tracked files include correct proxy config per REVERSE_PROXY** |
+| Property 5: Health default ports | For each valid proxy type with no PROXY_PORTS, verify correct default ports. Tag: **Feature: pluggable-reverse-proxy, Property 5: Health engine checks correct default ports per REVERSE_PROXY** |
+| Property 6: PROXY_PORTS override | Generate random port lists, set as PROXY_PORTS, verify health engine uses exactly those ports. Tag: **Feature: pluggable-reverse-proxy, Property 6: PROXY_PORTS override replaces default proxy ports** |
+| Property 7: Dry-run output | For each valid proxy type with DRY_RUN=true, verify output contains correct reload command. Tag: **Feature: pluggable-reverse-proxy, Property 7: Dry-run output shows correct proxy reload command per REVERSE_PROXY** |
+
+### Unit Tests (Examples and Edge Cases)
+
+| Test | Type | Description |
+|------|------|-------------|
+| Template contains REVERSE_PROXY | Example | Verify `strut.conf.template` contains commented `REVERSE_PROXY` entry (Req 1.4) |
+| Caddyfile template content | Example | Verify scaffolded Caddyfile contains placeholder reverse_proxy block (Req 3.4) |
+| Drift syntax validation dispatch | Example | Verify `drift_validate_syntax` routes to correct validator for `nginx.conf` vs `Caddyfile` (Req 5.3, 5.4) |
+| Default when REVERSE_PROXY absent | Edge case | Verify `REVERSE_PROXY` defaults to `nginx` when not in strut.conf (Req 1.2) |
+| Proxy container not running | Edge case | Verify deploy skips reload with warning when proxy container is down (Req 2.3) |
+
+### Existing Test Updates
+
+- `tests/test_config.bats` Property 2 should be extended to include `REVERSE_PROXY` in the randomized key set
+- `tests/test_scaffold.bats` should verify proxy-aware scaffold output
+- `tests/test_no_hardcodes.bats` should verify no remaining hardcoded `nginx` references in engine dispatch paths (excluding the nginx-specific case branches)

--- a/.kiro/specs/pluggable-reverse-proxy/requirements.md
+++ b/.kiro/specs/pluggable-reverse-proxy/requirements.md
@@ -1,0 +1,103 @@
+# Requirements Document
+
+## Introduction
+
+Strut currently hardcodes nginx as the reverse proxy in several engine modules: deploy reload, domain/SSL configuration, scaffold templates, drift detection, and VPS audit. This feature introduces a pluggable reverse proxy abstraction so that the engine dispatches proxy-specific behavior based on a `REVERSE_PROXY` config setting, with nginx as the default and Caddy as the first alternative. This follows strut's core design principle: no hardcoded values in the engine — everything config-driven.
+
+## Glossary
+
+- **Engine**: The strut shell library modules under `lib/` that implement CLI commands and orchestration logic
+- **Reverse_Proxy_Config**: The `REVERSE_PROXY` key in `strut.conf` that selects which reverse proxy type the stack uses (valid values: `nginx`, `caddy`)
+- **Proxy_Reload**: The operation that refreshes the reverse proxy's backend routing after a deploy (e.g., `nginx -s reload` or `caddy reload`)
+- **Proxy_Config_Dir**: The directory within a stack that holds reverse proxy configuration files (e.g., `nginx/` or `caddy/`)
+- **Drift_Tracked_File**: A configuration file monitored by the drift detection engine for changes between git-committed and VPS-runtime versions
+- **Stack_Dir**: The directory `stacks/<name>/` containing all per-stack configuration, compose files, and proxy config
+- **Config_Loader**: The `load_strut_config` function in `lib/config.sh` that sources `strut.conf` and applies defaults
+
+## Requirements
+
+### Requirement 1: Reverse Proxy Configuration Setting
+
+**User Story:** As a stack operator, I want to declare which reverse proxy my stack uses in `strut.conf`, so that all engine commands automatically use the correct proxy type.
+
+#### Acceptance Criteria
+
+1. THE Config_Loader SHALL read a `REVERSE_PROXY` key from `strut.conf` and export it as an environment variable
+2. WHEN `REVERSE_PROXY` is not set in `strut.conf`, THE Config_Loader SHALL default the value to `nginx`
+3. IF `REVERSE_PROXY` is set to an unsupported value (not `nginx` or `caddy`), THEN THE Engine SHALL exit with a descriptive error message via `fail()`
+4. THE `strut.conf.template` SHALL include a commented-out `REVERSE_PROXY` entry with documentation of valid values
+
+### Requirement 2: Deploy Reload Dispatch
+
+**User Story:** As a stack operator, I want the deploy command to reload whichever reverse proxy my stack uses, so that new container IPs are picked up after deploy regardless of proxy type.
+
+#### Acceptance Criteria
+
+1. WHEN `REVERSE_PROXY` is `nginx` and the nginx container is running, THE Engine SHALL execute `nginx -s reload` inside the nginx container after deploy
+2. WHEN `REVERSE_PROXY` is `caddy` and the caddy container is running, THE Engine SHALL execute `caddy reload --config /etc/caddy/Caddyfile` inside the caddy container after deploy
+3. WHEN the configured reverse proxy container is not running after deploy, THE Engine SHALL skip the reload step and emit a warning via `warn()`
+4. THE deploy reload logic SHALL read the container service name from `REVERSE_PROXY` (the config value doubles as the compose service name)
+
+### Requirement 3: Scaffold Proxy Templates
+
+**User Story:** As a developer scaffolding a new stack, I want the scaffold command to generate the correct reverse proxy directory and config files based on `REVERSE_PROXY`, so that I start with a working proxy setup.
+
+#### Acceptance Criteria
+
+1. WHEN `REVERSE_PROXY` is `nginx`, THE Scaffold Command SHALL create an `nginx/` directory with a default `nginx.conf` and `conf.d/` subdirectory (current behavior)
+2. WHEN `REVERSE_PROXY` is `caddy`, THE Scaffold Command SHALL create a `caddy/` directory with a default `Caddyfile`
+3. THE scaffold "Next steps" output SHALL reference the correct proxy config directory based on `REVERSE_PROXY`
+4. THE default Caddyfile template SHALL contain a placeholder reverse proxy block with a commented upstream target
+
+### Requirement 4: Domain and SSL Configuration
+
+**User Story:** As a stack operator, I want the `domain` command to configure SSL for both nginx and Caddy stacks, so that I can set up HTTPS regardless of which proxy I use.
+
+#### Acceptance Criteria
+
+1. WHEN `REVERSE_PROXY` is `nginx`, THE Domain Command SHALL execute the `configure-domain.sh` script on the VPS and pull back the nginx conf file (current behavior)
+2. WHEN `REVERSE_PROXY` is `caddy`, THE Domain Command SHALL update the Caddyfile on the VPS with the domain configuration and reload Caddy
+3. WHEN `REVERSE_PROXY` is `caddy`, THE Domain Command SHALL skip certbot-based SSL steps because Caddy handles automatic HTTPS via ACME
+4. THE Domain Command SHALL pull back the updated proxy config file (nginx conf or Caddyfile) to the local repo after configuration
+5. THE Domain Command SHALL restart the correct proxy container service name based on `REVERSE_PROXY` when committing SSL config changes
+
+### Requirement 5: Drift Detection for Proxy Config
+
+**User Story:** As a stack operator, I want drift detection to track the correct proxy config files based on my `REVERSE_PROXY` setting, so that configuration drift is caught for whichever proxy I use.
+
+#### Acceptance Criteria
+
+1. WHEN `REVERSE_PROXY` is `nginx`, THE Drift Engine SHALL include `nginx/nginx.conf` in the tracked files list (current behavior)
+2. WHEN `REVERSE_PROXY` is `caddy`, THE Drift Engine SHALL include `caddy/Caddyfile` in the tracked files list instead of `nginx/nginx.conf`
+3. WHEN `REVERSE_PROXY` is `nginx`, THE Drift Engine SHALL validate nginx config syntax using `nginx -t`
+4. WHEN `REVERSE_PROXY` is `caddy`, THE Drift Engine SHALL validate Caddy config syntax using `caddy validate --config /etc/caddy/Caddyfile`
+
+### Requirement 6: VPS Audit Proxy Detection
+
+**User Story:** As a stack operator running a VPS audit, I want the audit to detect both nginx and Caddy containers and configurations, so that the audit report is accurate regardless of which proxy is in use.
+
+#### Acceptance Criteria
+
+1. THE Audit Engine SHALL detect running Caddy containers in addition to nginx containers
+2. THE Audit Engine SHALL collect Caddy configuration files (`Caddyfile`) from detected Caddy containers
+3. THE Audit Report SHALL include a section for Caddy configuration when Caddy containers are detected
+4. THE Audit Engine SHALL check for both `nginx` and `caddy` system services when collecting service status
+
+### Requirement 7: Health Check Network Port Discovery
+
+**User Story:** As a stack operator, I want the health check network probe to detect the correct reverse proxy port dynamically, so that it works for proxies that may listen on ports other than 80.
+
+#### Acceptance Criteria
+
+1. WHEN `REVERSE_PROXY` is `nginx`, THE Health Engine SHALL include port 80 in the network port check (current behavior)
+2. WHEN `REVERSE_PROXY` is `caddy`, THE Health Engine SHALL include both port 80 and port 443 in the network port check because Caddy listens on both by default
+3. THE Health Engine SHALL read the reverse proxy ports from a `PROXY_PORTS` variable in `services.conf` when present, overriding the defaults
+
+### Requirement 8: Dry-Run Proxy Awareness
+
+**User Story:** As a stack operator previewing a deploy, I want the dry-run output to show the correct proxy reload command, so that I can verify the right proxy will be reloaded.
+
+#### Acceptance Criteria
+
+1. WHEN `DRY_RUN` is `true` and `REVERSE_PROXY` is `nginx`, THE Deploy Command SHALL show `nginx -s reload` in the execution plan
+2. WHEN `DRY_RUN` is `true` and `REVERSE_PROXY` is `caddy`, THE Deploy Command SHALL show `caddy reload` in the execution plan

--- a/.kiro/specs/pluggable-reverse-proxy/tasks.md
+++ b/.kiro/specs/pluggable-reverse-proxy/tasks.md
@@ -1,0 +1,139 @@
+# Implementation Plan: Pluggable Reverse Proxy
+
+## Overview
+
+Add pluggable reverse proxy support to strut so that proxy-specific behavior (reload, scaffold, domain/SSL, drift, audit, health) dispatches based on a `REVERSE_PROXY` config setting. Nginx remains the default; Caddy is the first alternative. Each engine module that currently hardcodes nginx will be updated to read `REVERSE_PROXY` and dispatch accordingly via `case` statements.
+
+## Tasks
+
+- [x] 1. Add REVERSE_PROXY to config loading and template
+  - [x] 1.1 Add REVERSE_PROXY default and validation to `lib/config.sh`
+    - In `load_strut_config()`, after existing defaults, add `REVERSE_PROXY="${REVERSE_PROXY:-nginx}"` and `export REVERSE_PROXY`
+    - Add a `case` validation block that calls `fail()` for values other than `nginx` or `caddy`
+    - _Requirements: 1.1, 1.2, 1.3_
+
+  - [x] 1.2 Write property test: Config parsing loads REVERSE_PROXY and defaults to nginx
+    - **Property 1: Config parsing loads REVERSE_PROXY and defaults to nginx**
+    - Create `tests/test_proxy_config.bats` with 100-iteration randomized test
+    - Generate random `strut.conf` with random subset of config keys including `REVERSE_PROXY`
+    - Verify `load_strut_config` exports correct values and defaults `REVERSE_PROXY` to `nginx` when absent
+    - **Validates: Requirements 1.1, 1.2**
+
+  - [x] 1.3 Write property test: Invalid REVERSE_PROXY values are rejected
+    - **Property 2: Invalid REVERSE_PROXY values are rejected**
+    - Generate 100 random strings (excluding "nginx" and "caddy")
+    - Verify `load_strut_config` fails for each invalid value
+    - **Validates: Requirements 1.3**
+
+  - [x] 1.4 Add REVERSE_PROXY entry to `templates/strut.conf.template`
+    - Add a commented `# ── Reverse Proxy ──` section with `# REVERSE_PROXY=nginx` and documentation of valid values (`nginx | caddy`)
+    - _Requirements: 1.4_
+
+- [x] 2. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 3. Implement proxy-aware deploy reload in `lib/deploy.sh`
+  - [x] 3.1 Replace hardcoded nginx reload in `deploy_stack()` with proxy dispatch
+    - Read `local proxy="${REVERSE_PROXY:-nginx}"` and use it as the compose service name in `$compose_cmd ps` and `$compose_cmd exec`
+    - Add `case "$proxy"` with `nginx)` branch (`nginx -s reload`) and `caddy)` branch (`caddy reload --config /etc/caddy/Caddyfile`)
+    - Emit `warn()` when proxy container is not running, skip reload
+    - _Requirements: 2.1, 2.2, 2.3, 2.4_
+
+  - [x] 3.2 Update dry-run block in `deploy_stack()` to show correct proxy reload command
+    - Add a `run_cmd` line that shows the proxy-specific reload command based on `REVERSE_PROXY`
+    - _Requirements: 8.1, 8.2_
+
+  - [x] 3.3 Write property test: Dry-run output shows correct proxy reload command
+    - **Property 7: Dry-run output shows correct proxy reload command per REVERSE_PROXY**
+    - For each valid `REVERSE_PROXY` value with `DRY_RUN=true`, verify output contains the proxy-specific reload command
+    - **Validates: Requirements 8.1, 8.2**
+
+- [x] 4. Implement proxy-aware scaffold in `lib/cmd_scaffold.sh`
+  - [x] 4.1 Replace hardcoded nginx directory creation with proxy dispatch
+    - Read `local proxy="${REVERSE_PROXY:-nginx}"` and add `case "$proxy"` block
+    - `nginx)` branch: keep existing `mkdir -p "$target/nginx/conf.d"` and `nginx.conf` creation
+    - `caddy)` branch: `mkdir -p "$target/caddy"` and write a default `Caddyfile` with placeholder reverse_proxy block
+    - Update "Next steps" echo to reference the correct proxy config directory
+    - _Requirements: 3.1, 3.2, 3.3, 3.4_
+
+  - [x] 4.2 Write property test: Scaffold creates correct proxy directory
+    - **Property 3: Scaffold creates correct proxy directory per REVERSE_PROXY**
+    - For each valid proxy type, run `cmd_scaffold` and verify correct directory structure and config file content
+    - **Validates: Requirements 3.1, 3.2, 3.3**
+
+- [x] 5. Implement proxy-aware domain/SSL in `lib/cmd_domain.sh`
+  - [x] 5.1 Add proxy dispatch to `cmd_domain()`
+    - Read `local proxy="${REVERSE_PROXY:-nginx}"` and wrap existing nginx logic in `case "$proxy"` `nginx)` branch
+    - Add `caddy)` branch: update Caddyfile on VPS with domain block, reload Caddy (skip certbot), pull back Caddyfile
+    - Update the git commit/push section to restart the correct proxy service name and pull back the correct config file
+    - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5_
+
+- [x] 6. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 7. Implement proxy-aware drift detection in `lib/drift.sh`
+  - [x] 7.1 Replace static `DRIFT_TRACKED_FILES` array with `drift_get_tracked_files()` function
+    - Create `drift_get_tracked_files()` that returns base files plus the proxy-specific config file based on `REVERSE_PROXY`
+    - `nginx)` → append `nginx/nginx.conf`; `caddy)` → append `caddy/Caddyfile`
+    - Update all references to `DRIFT_TRACKED_FILES` array to call `drift_get_tracked_files()` instead (in `drift_detect`, `drift_fix`, `drift_report`, `drift_monitor`)
+    - _Requirements: 5.1, 5.2_
+
+  - [x] 7.2 Add Caddyfile validation case to `drift_validate_syntax()`
+    - Add `Caddyfile)` case that runs `caddy validate --config "$file_path"` when `caddy` binary is available
+    - _Requirements: 5.3, 5.4_
+
+  - [x] 7.3 Write property test: Drift tracked files include correct proxy config
+    - **Property 4: Drift tracked files include correct proxy config per REVERSE_PROXY**
+    - For each valid proxy type, call `drift_get_tracked_files` and verify correct proxy config file is included and the other proxy's file is not
+    - **Validates: Requirements 5.1, 5.2**
+
+- [x] 8. Implement proxy-aware health check network in `lib/health.sh`
+  - [x] 8.1 Replace hardcoded port 80 in `health_check_network()` with proxy-aware defaults
+    - Read `local proxy="${REVERSE_PROXY:-nginx}"` and check for `PROXY_PORTS` override from `services.conf`
+    - If `PROXY_PORTS` is set, use those ports; otherwise `nginx)` → `(80)`, `caddy)` → `(80 443)`
+    - _Requirements: 7.1, 7.2, 7.3_
+
+  - [x] 8.2 Write property test: Health engine checks correct default ports
+    - **Property 5: Health engine checks correct default ports per REVERSE_PROXY**
+    - For each valid proxy type with no `PROXY_PORTS`, verify correct default ports
+    - **Validates: Requirements 7.1, 7.2**
+
+  - [x] 8.3 Write property test: PROXY_PORTS override replaces default proxy ports
+    - **Property 6: PROXY_PORTS override replaces default proxy ports**
+    - Generate random port lists, set as `PROXY_PORTS`, verify health engine uses exactly those ports
+    - **Validates: Requirements 7.3**
+
+- [x] 9. Implement Caddy audit detection in `lib/audit.sh`
+  - [x] 9.1 Add `_audit_caddy()` function and wire into `audit_vps()`
+    - Create `_audit_caddy()` parallel to `_audit_nginx()`: detect Caddy containers, extract Caddyfile configs, check system service
+    - Call `_audit_caddy` after `_audit_nginx` in `audit_vps()`
+    - _Requirements: 6.1, 6.2, 6.4_
+
+  - [x] 9.2 Add Caddy section to `audit_generate_report()`
+    - Include Caddy containers and configuration in the audit report markdown, parallel to the existing nginx section
+    - _Requirements: 6.3_
+
+- [x] 10. Update existing tests for proxy awareness
+  - [x] 10.1 Extend `tests/test_config.bats` to include REVERSE_PROXY in randomized key set
+    - Add `REVERSE_PROXY` to the config keys tested in existing property tests
+    - _Requirements: 1.1, 1.2_
+
+  - [x] 10.2 Update `tests/test_scaffold.bats` to verify proxy-aware scaffold output
+    - Add test cases that verify scaffold creates correct proxy directory for both nginx and caddy
+    - _Requirements: 3.1, 3.2_
+
+  - [x] 10.3 Update `tests/test_no_hardcodes.bats` to verify no remaining hardcoded nginx in dispatch paths
+    - Ensure grep patterns exclude the nginx-specific case branches but catch any remaining hardcoded nginx references in engine dispatch logic
+    - _Requirements: 1.1, 2.1, 3.1_
+
+- [x] 11. Final checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests validate universal correctness properties from the design document
+- Unit tests validate specific examples and edge cases
+- All code is Bash; tests use BATS with 100-iteration randomized property tests

--- a/lib/audit.sh
+++ b/lib/audit.sh
@@ -85,6 +85,35 @@ _audit_nginx() {
   log "  ✓ Nginx configuration collected"
 }
 
+# _audit_caddy <ssh_opts> <vps_user> <vps_host> <_sudo> <audit_dir>
+# Collects Caddy configuration from containers and system service
+_audit_caddy() {
+  local ssh_opts="$1" vps_user="$2" vps_host="$3" _sudo="$4" audit_dir="$5"
+
+  log "Collecting Caddy configuration..."
+  mkdir -p "$audit_dir/caddy"
+
+  ssh $ssh_opts "$vps_user@$vps_host" "${_sudo}docker ps --format '{{.Names}}' | grep -i caddy" > "$audit_dir/caddy/caddy-containers.txt" 2>/dev/null || true
+  ssh $ssh_opts "$vps_user@$vps_host" "systemctl is-active caddy 2>/dev/null || echo 'not-running'" > "$audit_dir/caddy/caddy-service-status.txt" 2>/dev/null || true
+
+  local caddy_containers
+  caddy_containers=$(cat "$audit_dir/caddy/caddy-containers.txt" 2>/dev/null)
+  if [ -n "$caddy_containers" ]; then
+    for caddy_container in $caddy_containers; do
+      log "  Extracting Caddy config from container: $caddy_container"
+      ssh $ssh_opts "$vps_user@$vps_host" "${_sudo}docker exec $caddy_container cat /etc/caddy/Caddyfile 2>/dev/null" > "$audit_dir/caddy/${caddy_container}-Caddyfile" 2>/dev/null || true
+      ssh $ssh_opts "$vps_user@$vps_host" "${_sudo}docker exec $caddy_container ls -la /data/caddy/certificates 2>/dev/null" > "$audit_dir/caddy/${caddy_container}-ssl-certs.txt" 2>/dev/null || true
+    done
+  fi
+
+  if grep -q "active" "$audit_dir/caddy/caddy-service-status.txt" 2>/dev/null; then
+    log "  Extracting system Caddy config"
+    ssh $ssh_opts "$vps_user@$vps_host" "sudo cat /etc/caddy/Caddyfile 2>/dev/null" > "$audit_dir/caddy/system-Caddyfile" 2>/dev/null || true
+    ssh $ssh_opts "$vps_user@$vps_host" "sudo ls -la /var/lib/caddy/.local/share/caddy/certificates 2>/dev/null" > "$audit_dir/caddy/system-ssl-certs.txt" 2>/dev/null || true
+  fi
+  log "  ✓ Caddy configuration collected"
+}
+
 # _audit_systemd <ssh_opts> <vps_user> <vps_host> <audit_dir>
 # Collects systemd service information
 _audit_systemd() {
@@ -331,6 +360,7 @@ audit_vps() {
   # Run each audit category
   _audit_docker   "$ssh_opts" "$vps_user" "$vps_host" "$_sudo" "$audit_dir"
   _audit_nginx    "$ssh_opts" "$vps_user" "$vps_host" "$_sudo" "$audit_dir"
+  _audit_caddy    "$ssh_opts" "$vps_user" "$vps_host" "$_sudo" "$audit_dir"
   _audit_systemd  "$ssh_opts" "$vps_user" "$vps_host" "$audit_dir"
   _audit_cron     "$ssh_opts" "$vps_user" "$vps_host" "$audit_dir"
   _audit_firewall "$ssh_opts" "$vps_user" "$vps_host" "$audit_dir"
@@ -510,6 +540,44 @@ EOF
 
   if [ ! -s "$audit_dir/nginx/nginx-containers.txt" ] && [ ! -f "$audit_dir/nginx/system-nginx.conf" ]; then
     echo "No nginx configuration found." >> "$report"
+    echo "" >> "$report"
+  fi
+
+  cat >> "$report" <<EOF
+
+---
+
+## Caddy Configuration
+
+EOF
+
+  # Caddy containers
+  if [ -s "$audit_dir/caddy/caddy-containers.txt" ]; then
+    echo "**Caddy Containers:**" >> "$report"
+    echo "" >> "$report"
+    while IFS= read -r caddy_container; do
+      echo "- \`$caddy_container\`" >> "$report"
+      if [ -f "$audit_dir/caddy/${caddy_container}-Caddyfile" ]; then
+        echo "  - Config: \`caddy/${caddy_container}-Caddyfile\`" >> "$report"
+      fi
+      if [ -f "$audit_dir/caddy/${caddy_container}-ssl-certs.txt" ]; then
+        echo "  - SSL Certs: \`caddy/${caddy_container}-ssl-certs.txt\`" >> "$report"
+      fi
+    done < "$audit_dir/caddy/caddy-containers.txt"
+    echo "" >> "$report"
+  fi
+
+  # System caddy
+  if [ -f "$audit_dir/caddy/system-Caddyfile" ]; then
+    echo "**System Caddy:**" >> "$report"
+    echo "" >> "$report"
+    echo "- Config: \`caddy/system-Caddyfile\`" >> "$report"
+    echo "- SSL: \`caddy/system-ssl-certs.txt\`" >> "$report"
+    echo "" >> "$report"
+  fi
+
+  if [ ! -s "$audit_dir/caddy/caddy-containers.txt" ] && [ ! -f "$audit_dir/caddy/system-Caddyfile" ]; then
+    echo "No Caddy configuration found." >> "$report"
     echo "" >> "$report"
   fi
 

--- a/lib/cmd_domain.sh
+++ b/lib/cmd_domain.sh
@@ -50,37 +50,68 @@ cmd_domain() {
   [ -n "$vps_port" ] && scp_opts="-P $vps_port $scp_opts"
   [ -n "$vps_ssh_key" ] && scp_opts="$scp_opts -i $vps_ssh_key"
 
-  log "Running configure-domain.sh on $vps_user@$vps_host..."
-  # shellcheck disable=SC2029
-  ssh $ssh_opts "$vps_user@$vps_host" \
-    "bash '$deploy_dir/scripts/configure-domain.sh' '$stack' '$domain' '$email' --env '${env_name:-prod}' $skip_ssl_flag"
+  local proxy="${REVERSE_PROXY:-nginx}"
+  local conf_local=""
+  local conf_remote=""
 
-  # Pull the updated nginx conf back locally
-  local nginx_conf_local="$CLI_ROOT/stacks/$stack/nginx/conf.d/${stack}.conf"
-  local nginx_conf_remote="$deploy_dir/stacks/$stack/nginx/conf.d/${stack}.conf"
-  log "Pulling updated nginx conf back to local repo..."
-  scp $scp_opts \
-    "$vps_user@$vps_host:$nginx_conf_remote" \
-    "$nginx_conf_local" \
-    && ok "nginx conf updated locally"
+  case "$proxy" in
+    nginx)
+      log "Running configure-domain.sh on $vps_user@$vps_host..."
+      # shellcheck disable=SC2029
+      ssh $ssh_opts "$vps_user@$vps_host" \
+        "bash '$deploy_dir/scripts/configure-domain.sh' '$stack' '$domain' '$email' --env '${env_name:-prod}' $skip_ssl_flag"
+
+      conf_local="$CLI_ROOT/stacks/$stack/nginx/conf.d/${stack}.conf"
+      conf_remote="$deploy_dir/stacks/$stack/nginx/conf.d/${stack}.conf"
+      log "Pulling updated nginx conf back to local repo..."
+      scp $scp_opts \
+        "$vps_user@$vps_host:$conf_remote" \
+        "$conf_local" \
+        && ok "nginx conf updated locally"
+      ;;
+    caddy)
+      conf_local="$CLI_ROOT/stacks/$stack/caddy/Caddyfile"
+      conf_remote="$deploy_dir/stacks/$stack/caddy/Caddyfile"
+
+      # Update Caddyfile on VPS with domain block — Caddy handles ACME automatically
+      log "Updating Caddyfile on VPS for domain $domain..."
+      # shellcheck disable=SC2029
+      ssh $ssh_opts "$vps_user@$vps_host" \
+        "cd '$deploy_dir/stacks/$stack' && sed -i 's/^# *:80 {/$domain {/' caddy/Caddyfile"
+
+      log "Reloading Caddy on VPS..."
+      # shellcheck disable=SC2029
+      ssh $ssh_opts "$vps_user@$vps_host" \
+        "cd '$deploy_dir' && docker compose --project-name ${env_name:-prod} exec -T caddy caddy reload --config /etc/caddy/Caddyfile" \
+        && ok "Caddy reloaded with domain $domain" \
+        || warn "Caddy reload failed — check Caddyfile syntax"
+
+      log "Pulling updated Caddyfile back to local repo..."
+      scp $scp_opts \
+        "$vps_user@$vps_host:$conf_remote" \
+        "$conf_local" \
+        && ok "Caddyfile updated locally"
+      ;;
+  esac
 
   # Auto-commit and push the SSL config unless --skip-ssl was used
+  # (For caddy, --skip-ssl skips the git commit/push, not certbot — Caddy handles ACME natively)
   if ! $skip_ssl; then
     log "Committing SSL configuration to git..."
-    if git -C "$CLI_ROOT" diff --quiet "$nginx_conf_local"; then
+    if git -C "$CLI_ROOT" diff --quiet "$conf_local"; then
       ok "No changes to commit (SSL config already in git)"
     else
-      git -C "$CLI_ROOT" add "$nginx_conf_local"
+      git -C "$CLI_ROOT" add "$conf_local"
       git -C "$CLI_ROOT" commit -m "[SSL] Configure HTTPS for $domain on $stack stack"
       if git -C "$CLI_ROOT" push; then
         ok "SSL config committed and pushed to git"
         log "Updating VPS repo to sync SSL config..."
         ssh $ssh_opts "$vps_user@$vps_host" \
           "cd '$deploy_dir' && git pull origin main"
-        log "Restarting nginx to load updated config..."
+        log "Restarting $proxy to load updated config..."
         ssh $ssh_opts "$vps_user@$vps_host" \
-          "cd '$deploy_dir' && docker compose --project-name ${env_name:-prod} restart nginx"
-        ok "VPS nginx restarted with SSL config"
+          "cd '$deploy_dir' && docker compose --project-name ${env_name:-prod} restart $proxy"
+        ok "VPS $proxy restarted with SSL config"
       else
         warn "Failed to push to git — you may need to manually push and update VPS"
       fi

--- a/lib/cmd_scaffold.sh
+++ b/lib/cmd_scaffold.sh
@@ -46,9 +46,12 @@ cmd_scaffold() {
       > "$target/required_vars"
   fi
 
-  # Create nginx placeholder
-  mkdir -p "$target/nginx/conf.d"
-  cat > "$target/nginx/nginx.conf" <<'NGINX_EOF'
+  # Create reverse proxy placeholder based on REVERSE_PROXY config
+  local proxy="${REVERSE_PROXY:-nginx}"
+  case "$proxy" in
+    nginx)
+      mkdir -p "$target/nginx/conf.d"
+      cat > "$target/nginx/nginx.conf" <<'NGINX_EOF'
 user  nginx;
 worker_processes  auto;
 error_log  /var/log/nginx/error.log warn;
@@ -63,6 +66,22 @@ http {
     include /etc/nginx/conf.d/*.conf;
 }
 NGINX_EOF
+      ;;
+    caddy)
+      mkdir -p "$target/caddy"
+      cat > "$target/caddy/Caddyfile" <<'CADDY_EOF'
+# Caddyfile — reverse proxy configuration
+# See https://caddyserver.com/docs/caddyfile
+{
+    # Global options
+}
+
+# :80 {
+#     reverse_proxy app:8000
+# }
+CADDY_EOF
+      ;;
+  esac
 
   # Create sql/init placeholder
   mkdir -p "$target/sql/init"
@@ -96,7 +115,10 @@ BACKUP_EOF
   echo "  1. Edit $target/.env.template → copy to .prod.env and fill secrets"
   echo "  2. Edit $target/docker-compose.yml → add your services"
   echo "  3. Edit $target/services.conf → declare your service ports and DB flags"
-  echo "  4. Edit $target/nginx/conf.d/ → add your reverse proxy config"
+  case "$proxy" in
+    nginx) echo "  4. Edit $target/nginx/conf.d/ → add your reverse proxy config" ;;
+    caddy) echo "  4. Edit $target/caddy/Caddyfile → configure your reverse proxy" ;;
+  esac
   echo "  5. strut $new_name deploy --env prod"
   echo ""
 }

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -60,8 +60,15 @@ load_strut_config() {
   DEFAULT_ORG="${DEFAULT_ORG:-}"
   DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
   BANNER_TEXT="${BANNER_TEXT:-strut}"
+  REVERSE_PROXY="${REVERSE_PROXY:-nginx}"
 
-  export REGISTRY_TYPE REGISTRY_HOST DEFAULT_ORG DEFAULT_BRANCH BANNER_TEXT
+  export REGISTRY_TYPE REGISTRY_HOST DEFAULT_ORG DEFAULT_BRANCH BANNER_TEXT REVERSE_PROXY
+
+  # Validate REVERSE_PROXY
+  case "$REVERSE_PROXY" in
+    nginx|caddy) ;;
+    *) fail "Invalid REVERSE_PROXY='$REVERSE_PROXY' in strut.conf (valid: nginx, caddy)" ;;
+  esac
 }
 
 # resolve_strut_home <script_path>

--- a/lib/deploy.sh
+++ b/lib/deploy.sh
@@ -77,6 +77,11 @@ deploy_stack() {
     run_cmd "Create data directories" mkdir -p "$stack_dir/data/..."
     run_cmd "Stop existing containers" $compose_cmd down --remove-orphans
     run_cmd "Start services" $compose_cmd up -d --remove-orphans
+    local proxy="${REVERSE_PROXY:-nginx}"
+    case "$proxy" in
+      nginx) run_cmd "Reload reverse proxy" $compose_cmd exec -T nginx nginx -s reload ;;
+      caddy) run_cmd "Reload reverse proxy" $compose_cmd exec -T caddy caddy reload --config /etc/caddy/Caddyfile ;;
+    esac
     echo ""
     echo -e "${YELLOW}[DRY-RUN] No changes made.${NC}"
     return 0
@@ -128,10 +133,16 @@ deploy_stack() {
   for i in $(seq 1 12); do sleep 5; echo -n "."; done
   echo ""
 
-  # Reload nginx to pick up any new container IPs
-  if $compose_cmd ps nginx &>/dev/null && $compose_cmd ps nginx | grep -q "Up"; then
-    log "Reloading nginx to refresh backend IPs..."
-    $compose_cmd exec -T nginx nginx -s reload 2>/dev/null && ok "Nginx reloaded" || warn "Nginx reload failed (may not be critical)"
+  # Reload reverse proxy to pick up any new container IPs
+  local proxy="${REVERSE_PROXY:-nginx}"
+  if $compose_cmd ps "$proxy" &>/dev/null && $compose_cmd ps "$proxy" | grep -q "Up"; then
+    log "Reloading $proxy to refresh backend IPs..."
+    case "$proxy" in
+      nginx) $compose_cmd exec -T nginx nginx -s reload 2>/dev/null && ok "nginx reloaded" || warn "nginx reload failed (may not be critical)" ;;
+      caddy) $compose_cmd exec -T caddy caddy reload --config /etc/caddy/Caddyfile 2>/dev/null && ok "Caddy reloaded" || warn "Caddy reload failed (may not be critical)" ;;
+    esac
+  else
+    warn "$proxy container not running — skipping reload"
   fi
 
   echo ""

--- a/lib/drift.sh
+++ b/lib/drift.sh
@@ -17,15 +17,24 @@ fi
 
 # ── Configuration ─────────────────────────────────────────────────────────────
 
-# Files to track for drift detection (relative to stack directory)
-DRIFT_TRACKED_FILES=(
-  "docker-compose.yml"
-  ".env.template"
-  "backup.conf"
-  "repos.conf"
-  "volume.conf"
-  "nginx/nginx.conf"
-)
+# drift_get_tracked_files
+# Returns the list of files to track for drift detection (relative to stack directory)
+# Dynamically includes the correct proxy config file based on REVERSE_PROXY
+drift_get_tracked_files() {
+  local base_files=(
+    "docker-compose.yml"
+    ".env.template"
+    "backup.conf"
+    "repos.conf"
+    "volume.conf"
+  )
+  local proxy="${REVERSE_PROXY:-nginx}"
+  case "$proxy" in
+    nginx) base_files+=("nginx/nginx.conf") ;;
+    caddy) base_files+=("caddy/Caddyfile") ;;
+  esac
+  echo "${base_files[@]}"
+}
 
 # ── Drift Detection Functions ─────────────────────────────────────────────────
 
@@ -140,6 +149,13 @@ drift_validate_syntax() {
         return $?
       fi
       ;;
+    Caddyfile)
+      # Validate Caddy config if caddy is available
+      if command -v caddy &>/dev/null; then
+        caddy validate --config "$file_path" >/dev/null 2>&1
+        return $?
+      fi
+      ;;
     *.json)
       # Validate JSON syntax
       if command -v jq &>/dev/null; then
@@ -210,8 +226,12 @@ drift_detect() {
   # Load ignore patterns
   drift_load_ignore_patterns "$stack_dir"
 
+  # Get tracked files dynamically based on REVERSE_PROXY
+  local -a tracked_files
+  IFS=' ' read -ra tracked_files <<< "$(drift_get_tracked_files)"
+
   # Check each tracked file
-  for tracked_file in "${DRIFT_TRACKED_FILES[@]}"; do
+  for tracked_file in "${tracked_files[@]}"; do
     local git_file="$stack_dir/$tracked_file"
     local vps_file="$stack_dir/$tracked_file"
 
@@ -374,7 +394,11 @@ drift_fix() {
 
   drift_load_ignore_patterns "$stack_dir"
 
-  for tracked_file in "${DRIFT_TRACKED_FILES[@]}"; do
+  # Get tracked files dynamically based on REVERSE_PROXY
+  local -a tracked_files
+  IFS=' ' read -ra tracked_files <<< "$(drift_get_tracked_files)"
+
+  for tracked_file in "${tracked_files[@]}"; do
     local git_file="$stack_dir/$tracked_file"
     local vps_file="$stack_dir/$tracked_file"
 
@@ -515,7 +539,11 @@ drift_report() {
 
   drift_load_ignore_patterns "$stack_dir"
 
-  for tracked_file in "${DRIFT_TRACKED_FILES[@]}"; do
+  # Get tracked files dynamically based on REVERSE_PROXY
+  local -a tracked_files
+  IFS=' ' read -ra tracked_files <<< "$(drift_get_tracked_files)"
+
+  for tracked_file in "${tracked_files[@]}"; do
     local git_file="$stack_dir/$tracked_file"
     local vps_file="$stack_dir/$tracked_file"
 
@@ -567,7 +595,7 @@ drift_report() {
       echo ""
 
       # Show each drifted file with its diff
-      for tracked_file in "${DRIFT_TRACKED_FILES[@]}"; do
+      for tracked_file in "${tracked_files[@]}"; do
         local git_file="$stack_dir/$tracked_file"
         local vps_file="$stack_dir/$tracked_file"
 
@@ -732,7 +760,11 @@ drift_monitor() {
   local drifted_files=()
   drift_load_ignore_patterns "$stack_dir"
 
-  for tracked_file in "${DRIFT_TRACKED_FILES[@]}"; do
+  # Get tracked files dynamically based on REVERSE_PROXY
+  local -a tracked_files
+  IFS=' ' read -ra tracked_files <<< "$(drift_get_tracked_files)"
+
+  for tracked_file in "${tracked_files[@]}"; do
     local git_file="$stack_dir/$tracked_file"
     local vps_file="$stack_dir/$tracked_file"
 

--- a/lib/drift/metrics.sh
+++ b/lib/drift/metrics.sh
@@ -36,7 +36,11 @@ drift_metrics_export() {
 
   drift_load_ignore_patterns "$stack_dir"
 
-  for tracked_file in "${DRIFT_TRACKED_FILES[@]}"; do
+  # Get tracked files dynamically based on REVERSE_PROXY
+  local -a tracked_files
+  IFS=' ' read -ra tracked_files <<< "$(drift_get_tracked_files)"
+
+  for tracked_file in "${tracked_files[@]}"; do
     local git_file="$stack_dir/$tracked_file"
     local vps_file="$stack_dir/$tracked_file"
 

--- a/lib/health.sh
+++ b/lib/health.sh
@@ -307,7 +307,8 @@ health_check_resources() {
 # health_check_network <stack_dir>
 #
 # Dynamically reads all *_PORT entries from services.conf and verifies each
-# declared port is listening. Always includes port 80 (reverse proxy).
+# declared port is listening. Includes reverse proxy ports based on REVERSE_PROXY
+# setting (nginx: 80, caddy: 80+443), overridable via PROXY_PORTS.
 # Also checks outbound internet connectivity.
 #
 # Args:
@@ -319,8 +320,18 @@ health_check_network() {
   local conf="${stack_dir:+$stack_dir/services.conf}"
   $HEALTH_JSON_OUTPUT || echo -e "${BLUE}Checking Network...${NC}"
 
-  # Collect ports: always start with 80
-  local -a ports=(80)
+  # Collect reverse proxy ports based on REVERSE_PROXY setting
+  local proxy="${REVERSE_PROXY:-nginx}"
+  local -a ports=()
+
+  if [ -n "${PROXY_PORTS:-}" ]; then
+    IFS=' ' read -ra ports <<< "$PROXY_PORTS"
+  else
+    case "$proxy" in
+      nginx) ports=(80) ;;
+      caddy) ports=(80 443) ;;
+    esac
+  fi
 
   if [ -n "$conf" ] && [ -f "$conf" ]; then
     while IFS='=' read -r key value; do
@@ -329,8 +340,12 @@ health_check_network() {
       value=$(echo "$value" | xargs)
       [[ "$key" == DB_* ]] && continue
       [[ "$key" != *_PORT ]] && continue
-      # Avoid duplicates with port 80
-      [[ "$value" == "80" ]] && continue
+      # Avoid duplicates with proxy ports
+      local is_proxy_port=false
+      for pp in "${ports[@]}"; do
+        [[ "$value" == "$pp" ]] && { is_proxy_port=true; break; }
+      done
+      $is_proxy_port && continue
       ports+=("$value")
     done < "$conf"
   fi

--- a/templates/strut.conf.template
+++ b/templates/strut.conf.template
@@ -20,6 +20,10 @@
 # Default git branch for VPS repo sync
 # DEFAULT_BRANCH=main
 
+# ── Reverse Proxy ──────────────────────────────────
+# Supported types: nginx | caddy
+# REVERSE_PROXY=nginx
+
 # ── Branding ───────────────────────────────────────
 # Banner text shown in deploy/release output
 # BANNER_TEXT=strut

--- a/tests/test_config.bats
+++ b/tests/test_config.bats
@@ -89,8 +89,9 @@ _rand_str() {
 @test "Property 2: Config parsing loads present keys and defaults absent keys (100 iterations)" {
   _load_config
 
-  local keys=("REGISTRY_TYPE" "REGISTRY_HOST" "DEFAULT_ORG" "DEFAULT_BRANCH" "BANNER_TEXT")
-  local defaults=("none" "" "" "main" "strut")
+  local keys=("REGISTRY_TYPE" "REGISTRY_HOST" "DEFAULT_ORG" "DEFAULT_BRANCH" "BANNER_TEXT" "REVERSE_PROXY")
+  local defaults=("none" "" "" "main" "strut" "nginx")
+  local valid_proxies=("nginx" "caddy")
 
   for i in $(seq 1 100); do
     local project_dir="$TEST_TMP/parse_$i"
@@ -106,7 +107,13 @@ _rand_str() {
 
     for idx in "${!keys[@]}"; do
       if (( RANDOM % 2 )); then
-        local val="val_${RANDOM}_$(_rand_str 4)"
+        local val
+        if [ "${keys[$idx]}" = "REVERSE_PROXY" ]; then
+          # Pick a valid proxy value when present
+          val="${valid_proxies[$((RANDOM % 2))]}"
+        else
+          val="val_${RANDOM}_$(_rand_str 4)"
+        fi
         echo "${keys[$idx]}=$val" >> "$conf"
         present_keys+=("${keys[$idx]}")
         present_vals+=("$val")
@@ -119,7 +126,7 @@ _rand_str() {
     # Source config in a subshell to avoid polluting state
     (
       # Clear all config vars
-      unset REGISTRY_TYPE REGISTRY_HOST DEFAULT_ORG DEFAULT_BRANCH BANNER_TEXT PROJECT_ROOT
+      unset REGISTRY_TYPE REGISTRY_HOST DEFAULT_ORG DEFAULT_BRANCH BANNER_TEXT REVERSE_PROXY PROJECT_ROOT
 
       PROJECT_ROOT="$project_dir"
       export PROJECT_ROOT
@@ -150,7 +157,7 @@ _rand_str() {
   > "$project_dir/strut.conf"
 
   (
-    unset REGISTRY_TYPE REGISTRY_HOST DEFAULT_ORG DEFAULT_BRANCH BANNER_TEXT
+    unset REGISTRY_TYPE REGISTRY_HOST DEFAULT_ORG DEFAULT_BRANCH BANNER_TEXT REVERSE_PROXY
     PROJECT_ROOT="$project_dir"
     export PROJECT_ROOT
     load_strut_config
@@ -160,6 +167,7 @@ _rand_str() {
     [ "$DEFAULT_ORG" = "" ]
     [ "$DEFAULT_BRANCH" = "main" ]
     [ "$BANNER_TEXT" = "strut" ]
+    [ "$REVERSE_PROXY" = "nginx" ]
   )
 }
 
@@ -176,10 +184,11 @@ REGISTRY_HOST=ghcr.io
 DEFAULT_ORG=my-org
 DEFAULT_BRANCH=develop
 BANNER_TEXT=my-project
+REVERSE_PROXY=caddy
 EOF
 
   (
-    unset REGISTRY_TYPE REGISTRY_HOST DEFAULT_ORG DEFAULT_BRANCH BANNER_TEXT
+    unset REGISTRY_TYPE REGISTRY_HOST DEFAULT_ORG DEFAULT_BRANCH BANNER_TEXT REVERSE_PROXY
     PROJECT_ROOT="$project_dir"
     export PROJECT_ROOT
     load_strut_config
@@ -189,6 +198,7 @@ EOF
     [ "$DEFAULT_ORG" = "my-org" ]
     [ "$DEFAULT_BRANCH" = "develop" ]
     [ "$BANNER_TEXT" = "my-project" ]
+    [ "$REVERSE_PROXY" = "caddy" ]
   )
 }
 

--- a/tests/test_drift_helpers.bats
+++ b/tests/test_drift_helpers.bats
@@ -3,7 +3,7 @@
 # tests/test_drift_helpers.bats — Tests for lib/drift.sh pure functions
 # ==================================================
 # Run:  bats tests/test_drift_helpers.bats
-# Covers: drift_load_ignore_patterns, drift_should_ignore, DRIFT_TRACKED_FILES
+# Covers: drift_load_ignore_patterns, drift_should_ignore, drift_get_tracked_files
 
 setup() {
   export CLI_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
@@ -22,31 +22,39 @@ teardown() {
   rm -rf "$TEST_TMP"
 }
 
-# ── DRIFT_TRACKED_FILES ──────────────────────────────────────────────────────
+# ── drift_get_tracked_files ──────────────────────────────────────────────────
 
-@test "DRIFT_TRACKED_FILES: array is non-empty" {
-  [ "${#DRIFT_TRACKED_FILES[@]}" -gt 0 ]
+@test "drift_get_tracked_files: returns non-empty list" {
+  local -a tracked_files
+  IFS=' ' read -ra tracked_files <<< "$(drift_get_tracked_files)"
+  [ "${#tracked_files[@]}" -gt 0 ]
 }
 
-@test "DRIFT_TRACKED_FILES: contains docker-compose.yml" {
+@test "drift_get_tracked_files: contains docker-compose.yml" {
+  local -a tracked_files
+  IFS=' ' read -ra tracked_files <<< "$(drift_get_tracked_files)"
   local found=false
-  for f in "${DRIFT_TRACKED_FILES[@]}"; do
+  for f in "${tracked_files[@]}"; do
     [[ "$f" == "docker-compose.yml" ]] && found=true
   done
   [ "$found" = "true" ]
 }
 
-@test "DRIFT_TRACKED_FILES: contains .env.template" {
+@test "drift_get_tracked_files: contains .env.template" {
+  local -a tracked_files
+  IFS=' ' read -ra tracked_files <<< "$(drift_get_tracked_files)"
   local found=false
-  for f in "${DRIFT_TRACKED_FILES[@]}"; do
+  for f in "${tracked_files[@]}"; do
     [[ "$f" == ".env.template" ]] && found=true
   done
   [ "$found" = "true" ]
 }
 
-@test "DRIFT_TRACKED_FILES: contains backup.conf" {
+@test "drift_get_tracked_files: contains backup.conf" {
+  local -a tracked_files
+  IFS=' ' read -ra tracked_files <<< "$(drift_get_tracked_files)"
   local found=false
-  for f in "${DRIFT_TRACKED_FILES[@]}"; do
+  for f in "${tracked_files[@]}"; do
     [[ "$f" == "backup.conf" ]] && found=true
   done
   [ "$found" = "true" ]

--- a/tests/test_no_hardcodes.bats
+++ b/tests/test_no_hardcodes.bats
@@ -248,6 +248,43 @@ grep_lib() {
   fi
 }
 
+# ── Reverse proxy: no hardcoded nginx outside dispatch branches ──────
+# Feature: pluggable-reverse-proxy, Requirements 1.1, 2.1, 3.1
+# Verifies that engine dispatch files don't reference nginx outside of
+# case branches or REVERSE_PROXY default assignments.
+
+@test "no hardcoded nginx outside proxy dispatch in deploy.sh — Req 2.1" {
+  # Grep for 'nginx' but exclude:
+  #   - case branch labels: nginx) or nginx|caddy)
+  #   - REVERSE_PROXY default: ${REVERSE_PROXY:-nginx}
+  #   - comments (lines starting with #)
+  #   - ok/warn messages that reference the proxy by $proxy variable result
+  if matches=$(grep -nE 'nginx' "$CLI_ROOT"/lib/deploy.sh 2>/dev/null \
+    | grep -vE '(nginx\)|nginx\|caddy|REVERSE_PROXY:-nginx|^\s*#|"nginx reloaded"|"nginx reload failed")'); then
+    echo "Found hardcoded nginx outside dispatch in deploy.sh:" >&2
+    echo "$matches" >&2
+    return 1
+  fi
+}
+
+@test "no hardcoded nginx outside proxy dispatch in health.sh — Req 7.1" {
+  if matches=$(grep -nE 'nginx' "$CLI_ROOT"/lib/health.sh 2>/dev/null \
+    | grep -vE '(nginx\)|nginx\|caddy|REVERSE_PROXY:-nginx|^\s*#|^[0-9]+:\s*#)'); then
+    echo "Found hardcoded nginx outside dispatch in health.sh:" >&2
+    echo "$matches" >&2
+    return 1
+  fi
+}
+
+@test "no hardcoded nginx outside proxy dispatch in drift.sh — Req 5.1" {
+  if matches=$(grep -nE 'nginx' "$CLI_ROOT"/lib/drift.sh 2>/dev/null \
+    | grep -vE '(nginx\)|nginx\|caddy|REVERSE_PROXY:-nginx|^\s*#|^[0-9]+:\s*#|nginx\.conf|nginx -t|command -v nginx)'); then
+    echo "Found hardcoded nginx outside dispatch in drift.sh:" >&2
+    echo "$matches" >&2
+    return 1
+  fi
+}
+
 # ── Entrypoint: no old cli.sh references in user-facing output ───────
 
 @test "no './cli.sh' references in any lib module" {

--- a/tests/test_proxy_config.bats
+++ b/tests/test_proxy_config.bats
@@ -1,0 +1,448 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_proxy_config.bats — Property tests for pluggable reverse proxy config
+# ==================================================
+# Run:  bats tests/test_proxy_config.bats
+# Feature: pluggable-reverse-proxy, Properties 1, 2
+
+# ── Setup ─────────────────────────────────────────────────────────────────────
+
+setup() {
+  export CLI_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  TEST_TMP="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+}
+
+_load_utils() {
+  source "$CLI_ROOT/lib/utils.sh"
+  fail() { echo "$1" >&2; return 1; }
+}
+
+_load_config() {
+  _load_utils
+  source "$CLI_ROOT/lib/config.sh"
+}
+
+# ── Helper: generate random alphanumeric string ──────────────────────────────
+
+_rand_str() {
+  local len="${1:-8}"
+  LC_ALL=C tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c "$len" 2>/dev/null || true
+}
+
+# ── Property 1: Config parsing loads REVERSE_PROXY and defaults to nginx ─────
+# Feature: pluggable-reverse-proxy, Property 1: Config parsing loads REVERSE_PROXY and defaults to nginx
+# Validates: Requirements 1.1, 1.2
+
+@test "Property 1: Config parsing loads REVERSE_PROXY and defaults to nginx (100 iterations)" {
+  _load_config
+
+  local keys=("REGISTRY_TYPE" "REGISTRY_HOST" "DEFAULT_ORG" "DEFAULT_BRANCH" "BANNER_TEXT" "REVERSE_PROXY")
+  local defaults=("none" "" "" "main" "strut" "nginx")
+  local valid_proxies=("nginx" "caddy")
+
+  for i in $(seq 1 100); do
+    local project_dir="$TEST_TMP/proxy_parse_$i"
+    mkdir -p "$project_dir"
+    local conf="$project_dir/strut.conf"
+    > "$conf"
+
+    local -a present_keys=()
+    local -a present_vals=()
+    local -a absent_keys=()
+    local -a absent_defaults=()
+
+    for idx in "${!keys[@]}"; do
+      if (( RANDOM % 2 )); then
+        local val
+        if [ "${keys[$idx]}" = "REVERSE_PROXY" ]; then
+          # Pick a valid proxy value when present
+          val="${valid_proxies[$((RANDOM % 2))]}"
+        else
+          val="val_${RANDOM}_$(_rand_str 4)"
+        fi
+        echo "${keys[$idx]}=$val" >> "$conf"
+        present_keys+=("${keys[$idx]}")
+        present_vals+=("$val")
+      else
+        absent_keys+=("${keys[$idx]}")
+        absent_defaults+=("${defaults[$idx]}")
+      fi
+    done
+
+    (
+      unset REGISTRY_TYPE REGISTRY_HOST DEFAULT_ORG DEFAULT_BRANCH BANNER_TEXT REVERSE_PROXY PROJECT_ROOT
+      PROJECT_ROOT="$project_dir"
+      export PROJECT_ROOT
+      load_strut_config
+
+      # Verify present keys have their specified values
+      for idx in "${!present_keys[@]}"; do
+        local actual="${!present_keys[$idx]}"
+        [ "$actual" = "${present_vals[$idx]}" ]
+      done
+
+      # Verify absent keys have their defaults
+      for idx in "${!absent_keys[@]}"; do
+        local actual="${!absent_keys[$idx]}"
+        [ "$actual" = "${absent_defaults[$idx]}" ]
+      done
+    )
+  done
+}
+
+
+# ── Property 2: Invalid REVERSE_PROXY values are rejected ────────────────────
+# Feature: pluggable-reverse-proxy, Property 2: Invalid REVERSE_PROXY values are rejected
+# Validates: Requirements 1.3
+
+@test "Property 2: Invalid REVERSE_PROXY values are rejected (100 iterations)" {
+  _load_config
+
+  for i in $(seq 1 100); do
+    # Generate a random string that is NOT "nginx" or "caddy"
+    local bad_val
+    while true; do
+      bad_val="$(_rand_str $(( (RANDOM % 12) + 1 )))"
+      [[ "$bad_val" != "nginx" && "$bad_val" != "caddy" ]] && break
+    done
+
+    local project_dir="$TEST_TMP/bad_proxy_$i"
+    mkdir -p "$project_dir"
+    echo "REVERSE_PROXY=$bad_val" > "$project_dir/strut.conf"
+
+    (
+      unset REGISTRY_TYPE REGISTRY_HOST DEFAULT_ORG DEFAULT_BRANCH BANNER_TEXT REVERSE_PROXY PROJECT_ROOT
+      PROJECT_ROOT="$project_dir"
+      export PROJECT_ROOT
+      run load_strut_config
+      [ "$status" -ne 0 ]
+    )
+  done
+}
+
+
+# ── Helper: capture deploy_stack dry-run output with a given REVERSE_PROXY ───
+
+_capture_proxy_deploy_dryrun() {
+  local proxy_type="$1"
+
+  _load_utils
+  source "$CLI_ROOT/lib/config.sh"
+  source "$CLI_ROOT/lib/docker.sh"
+  source "$CLI_ROOT/lib/deploy.sh"
+
+  export REVERSE_PROXY="$proxy_type"
+  export REGISTRY_TYPE="none"
+  export DRY_RUN="true"
+
+  # Create a minimal stack structure
+  local stack_dir="$TEST_TMP/stacks/test-stack"
+  mkdir -p "$stack_dir"
+  cat > "$stack_dir/docker-compose.yml" <<'YAML'
+version: "3"
+services:
+  app:
+    image: test:latest
+YAML
+
+  # Create a minimal env file
+  local env_file="$TEST_TMP/.env.test"
+  echo "VPS_HOST=10.0.0.1" > "$env_file"
+
+  # Stub export_volume_paths
+  export_volume_paths() { :; }
+
+  # Stub docker compose version check
+  docker() {
+    if [ "$1" = "compose" ] && [ "$2" = "version" ]; then
+      echo "Docker Compose version v2.20.0"
+      return 0
+    fi
+    echo "docker $*"
+    return 0
+  }
+  export -f docker
+
+  export CLI_ROOT="$TEST_TMP"
+
+  deploy_stack "test-stack" "$env_file" ""
+}
+
+# ── Property 7: Dry-run output shows correct proxy reload command per REVERSE_PROXY ──
+# Feature: pluggable-reverse-proxy, Property 7: Dry-run output shows correct proxy reload command per REVERSE_PROXY
+# Validates: Requirements 8.1, 8.2
+
+@test "Property 7: Dry-run output shows correct proxy reload command per REVERSE_PROXY (100 iterations)" {
+  local proxies=("nginx" "caddy")
+
+  for i in $(seq 1 100); do
+    local idx=$(( RANDOM % 2 ))
+    local proxy="${proxies[$idx]}"
+
+    run _capture_proxy_deploy_dryrun "$proxy"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN]"* ]]
+
+    case "$proxy" in
+      nginx)
+        [[ "$output" == *"nginx -s reload"* ]]
+        ;;
+      caddy)
+        [[ "$output" == *"caddy reload"* ]]
+        ;;
+    esac
+  done
+}
+
+# ── Helper: run scaffold with a given REVERSE_PROXY and return target dir ────
+
+_scaffold_with_proxy() {
+  local proxy_type="$1"
+  local stack_name="$2"
+
+  _load_utils
+  source "$CLI_ROOT/lib/config.sh"
+  source "$CLI_ROOT/lib/cmd_scaffold.sh"
+
+  export REVERSE_PROXY="$proxy_type"
+  export PROJECT_ROOT="$TEST_TMP"
+  export STRUT_HOME="$CLI_ROOT"
+
+  cmd_scaffold "$stack_name"
+}
+
+# ── Property 3: Scaffold creates correct proxy directory per REVERSE_PROXY ───
+# Feature: pluggable-reverse-proxy, Property 3: Scaffold creates correct proxy directory per REVERSE_PROXY
+# Validates: Requirements 3.1, 3.2, 3.3
+
+@test "Property 3: Scaffold creates correct proxy directory per REVERSE_PROXY (100 iterations)" {
+  local proxies=("nginx" "caddy")
+
+  for i in $(seq 1 100); do
+    local idx=$(( RANDOM % 2 ))
+    local proxy="${proxies[$idx]}"
+    local stack_name="proxy-test-${i}-${RANDOM}"
+
+    run _scaffold_with_proxy "$proxy" "$stack_name"
+    [ "$status" -eq 0 ]
+
+    local target="$TEST_TMP/stacks/$stack_name"
+
+    case "$proxy" in
+      nginx)
+        # Req 3.1: nginx/ directory with nginx.conf and conf.d/
+        [ -d "$target/nginx" ]
+        [ -d "$target/nginx/conf.d" ]
+        [ -f "$target/nginx/nginx.conf" ]
+        # Must NOT have caddy directory
+        [ ! -d "$target/caddy" ]
+        # Next steps output references nginx
+        [[ "$output" == *"nginx"* ]]
+        ;;
+      caddy)
+        # Req 3.2: caddy/ directory with Caddyfile
+        [ -d "$target/caddy" ]
+        [ -f "$target/caddy/Caddyfile" ]
+        # Req 3.4: Caddyfile contains placeholder reverse_proxy block
+        grep -q "reverse_proxy" "$target/caddy/Caddyfile"
+        # Must NOT have nginx directory
+        [ ! -d "$target/nginx" ]
+        # Next steps output references caddy
+        [[ "$output" == *"caddy"* ]]
+        ;;
+    esac
+  done
+}
+
+# ── Helper: get drift tracked files for a given REVERSE_PROXY ────────────────
+
+_get_drift_tracked_files_for_proxy() {
+  local proxy_type="$1"
+
+  _load_utils
+  source "$CLI_ROOT/lib/drift.sh"
+
+  export REVERSE_PROXY="$proxy_type"
+  drift_get_tracked_files
+}
+
+# ── Property 4: Drift tracked files include correct proxy config per REVERSE_PROXY ──
+# Feature: pluggable-reverse-proxy, Property 4: Drift tracked files include correct proxy config per REVERSE_PROXY
+# Validates: Requirements 5.1, 5.2
+
+@test "Property 4: Drift tracked files include correct proxy config per REVERSE_PROXY (100 iterations)" {
+  local proxies=("nginx" "caddy")
+
+  for i in $(seq 1 100); do
+    local idx=$(( RANDOM % 2 ))
+    local proxy="${proxies[$idx]}"
+
+    run _get_drift_tracked_files_for_proxy "$proxy"
+    [ "$status" -eq 0 ]
+
+    case "$proxy" in
+      nginx)
+        # Req 5.1: nginx tracked files include nginx/nginx.conf
+        [[ "$output" == *"nginx/nginx.conf"* ]]
+        # Must NOT include caddy config
+        [[ "$output" != *"caddy/Caddyfile"* ]]
+        ;;
+      caddy)
+        # Req 5.2: caddy tracked files include caddy/Caddyfile
+        [[ "$output" == *"caddy/Caddyfile"* ]]
+        # Must NOT include nginx config
+        [[ "$output" != *"nginx/nginx.conf"* ]]
+        ;;
+    esac
+
+    # Both should always include base files
+    [[ "$output" == *"docker-compose.yml"* ]]
+    [[ "$output" == *".env.template"* ]]
+    [[ "$output" == *"backup.conf"* ]]
+    [[ "$output" == *"repos.conf"* ]]
+    [[ "$output" == *"volume.conf"* ]]
+  done
+}
+
+# ── Helper: load health.sh with stubs and capture checked ports ──────────────
+
+_load_health_stubbed() {
+  source "$CLI_ROOT/lib/utils.sh"
+  fail() { echo "$1" >&2; return 1; }
+  source "$CLI_ROOT/lib/health.sh"
+
+  # Reset health state
+  HEALTH_OVERALL="healthy"
+  HEALTH_PASSED=0
+  HEALTH_FAILED=0
+  HEALTH_WARNED=0
+  HEALTH_JSON_OUTPUT=false
+
+  # Stub ss to report all ports as listening
+  ss() { echo ":99999 "; }
+  export -f ss
+  # Stub ping to succeed
+  ping() { return 0; }
+  export -f ping
+}
+
+# ── Property 5: Health engine checks correct default ports per REVERSE_PROXY ─
+# Feature: pluggable-reverse-proxy, Property 5: Health engine checks correct default ports per REVERSE_PROXY
+# Validates: Requirements 7.1, 7.2
+
+@test "Property 5: Health engine checks correct default ports per REVERSE_PROXY (100 iterations)" {
+  _load_health_stubbed
+
+  local proxies=("nginx" "caddy")
+
+  for i in $(seq 1 100); do
+    local idx=$(( RANDOM % 2 ))
+    local proxy="${proxies[$idx]}"
+
+    # Ensure no PROXY_PORTS override
+    unset PROXY_PORTS
+
+    export REVERSE_PROXY="$proxy"
+
+    # Create a minimal stack dir (no services.conf so only proxy ports are checked)
+    local stack_dir="$TEST_TMP/health_default_$i"
+    mkdir -p "$stack_dir"
+
+    # Reset health state
+    HEALTH_OVERALL="healthy"
+    HEALTH_PASSED=0
+    HEALTH_FAILED=0
+    HEALTH_WARNED=0
+
+    local output
+    output=$(health_check_network "$stack_dir" 2>&1)
+
+    case "$proxy" in
+      nginx)
+        # Req 7.1: port 80 must be included
+        [[ "$output" == *"Port 80"* ]] || {
+          echo "FAIL iteration $i (nginx): Port 80 not found in output: $output" >&2
+          return 1
+        }
+        ;;
+      caddy)
+        # Req 7.2: both port 80 and 443 must be included
+        [[ "$output" == *"Port 80"* ]] || {
+          echo "FAIL iteration $i (caddy): Port 80 not found in output: $output" >&2
+          return 1
+        }
+        [[ "$output" == *"Port 443"* ]] || {
+          echo "FAIL iteration $i (caddy): Port 443 not found in output: $output" >&2
+          return 1
+        }
+        ;;
+    esac
+  done
+}
+
+# ── Property 6: PROXY_PORTS override replaces default proxy ports ────────────
+# Feature: pluggable-reverse-proxy, Property 6: PROXY_PORTS override replaces default proxy ports
+# Validates: Requirements 7.3
+
+@test "Property 6: PROXY_PORTS override replaces default proxy ports (100 iterations)" {
+  _load_health_stubbed
+
+  local proxies=("nginx" "caddy")
+
+  for i in $(seq 1 100); do
+    local idx=$(( RANDOM % 2 ))
+    local proxy="${proxies[$idx]}"
+
+    export REVERSE_PROXY="$proxy"
+
+    # Generate 1-4 random ports for PROXY_PORTS override
+    local num_ports=$(( (RANDOM % 4) + 1 ))
+    local -a override_ports=()
+    for p in $(seq 1 "$num_ports"); do
+      override_ports+=("$(( (RANDOM % 9000) + 1024 ))")
+    done
+    export PROXY_PORTS="${override_ports[*]}"
+
+    # Create a minimal stack dir (no services.conf)
+    local stack_dir="$TEST_TMP/health_override_$i"
+    mkdir -p "$stack_dir"
+
+    # Reset health state
+    HEALTH_OVERALL="healthy"
+    HEALTH_PASSED=0
+    HEALTH_FAILED=0
+    HEALTH_WARNED=0
+
+    local output
+    output=$(health_check_network "$stack_dir" 2>&1)
+
+    # Verify each override port appears in the output
+    for port in "${override_ports[@]}"; do
+      [[ "$output" == *"Port $port"* ]] || {
+        echo "FAIL iteration $i: override port $port not found in output: $output" >&2
+        return 1
+      }
+    done
+
+    # Verify default proxy ports are NOT present (unless they happen to be in override_ports)
+    # For caddy, port 443 should not appear unless it's in override_ports
+    if [[ "$proxy" == "caddy" ]]; then
+      local has_443=false
+      for port in "${override_ports[@]}"; do
+        [[ "$port" == "443" ]] && { has_443=true; break; }
+      done
+      if ! $has_443; then
+        [[ "$output" != *"Port 443"* ]] || {
+          echo "FAIL iteration $i (caddy): default port 443 should not appear when PROXY_PORTS is set: $output" >&2
+          return 1
+        }
+      fi
+    fi
+  done
+
+  unset PROXY_PORTS
+}

--- a/tests/test_scaffold.bats
+++ b/tests/test_scaffold.bats
@@ -152,3 +152,38 @@ teardown() {
   run grep -r "climate_hub" "$target"
   [ "$status" -ne 0 ]
 }
+
+# ── Proxy-aware scaffold tests ────────────────────────────────────────────────
+# Feature: pluggable-reverse-proxy, Requirements 3.1, 3.2
+
+@test "scaffold: REVERSE_PROXY=nginx creates nginx directory with nginx.conf and conf.d" {
+  export REVERSE_PROXY="nginx"
+  cmd_scaffold "nginx-stack"
+
+  local target="$TEST_TMP/stacks/nginx-stack"
+  [ -d "$target/nginx" ]
+  [ -d "$target/nginx/conf.d" ]
+  [ -f "$target/nginx/nginx.conf" ]
+  [ ! -d "$target/caddy" ]
+}
+
+@test "scaffold: REVERSE_PROXY=caddy creates caddy directory with Caddyfile" {
+  export REVERSE_PROXY="caddy"
+  cmd_scaffold "caddy-stack"
+
+  local target="$TEST_TMP/stacks/caddy-stack"
+  [ -d "$target/caddy" ]
+  [ -f "$target/caddy/Caddyfile" ]
+  grep -q "reverse_proxy" "$target/caddy/Caddyfile"
+  [ ! -d "$target/nginx" ]
+}
+
+@test "scaffold: default REVERSE_PROXY (unset) creates nginx directory" {
+  unset REVERSE_PROXY
+  cmd_scaffold "default-proxy-stack"
+
+  local target="$TEST_TMP/stacks/default-proxy-stack"
+  [ -d "$target/nginx" ]
+  [ -f "$target/nginx/nginx.conf" ]
+  [ ! -d "$target/caddy" ]
+}


### PR DESCRIPTION
## Summary

Adds pluggable reverse proxy support so that proxy-specific behavior dispatches based on a `REVERSE_PROXY` config setting instead of being hardcoded to nginx. Nginx remains the default; Caddy is the first alternative.

## What changed

**Config** (`lib/config.sh`, `templates/strut.conf.template`)
- New `REVERSE_PROXY` setting (defaults to `nginx`, validates `nginx | caddy`)
- Added to config template with documentation

**Deploy** (`lib/deploy.sh`)
- Proxy-aware reload: dispatches `nginx -s reload` or `caddy reload` based on config
- Dry-run output shows the correct reload command per proxy type
- Warns and skips reload when proxy container isn't running

**Scaffold** (`lib/cmd_scaffold.sh`)
- Creates `nginx/` or `caddy/` directory with appropriate config files
- "Next steps" output references the correct proxy config directory

**Domain/SSL** (`lib/cmd_domain.sh`)
- nginx path: unchanged (certbot + configure-domain.sh)
- caddy path: updates Caddyfile directly, skips certbot (Caddy handles ACME automatically)

**Drift** (`lib/drift.sh`)
- New `drift_get_tracked_files()` function replaces static array
- Tracks `nginx/nginx.conf` or `caddy/Caddyfile` based on config
- Added `Caddyfile` syntax validation via `caddy validate`

**Health** (`lib/health.sh`)
- Proxy-aware default ports: nginx → `80`, caddy → `80 443`
- Supports `PROXY_PORTS` override from `services.conf`

**Audit** (`lib/audit.sh`)
- New `_audit_caddy()` function detects Caddy containers and configs
- Caddy section included in audit report

## Tests

7 new property-based tests (100 iterations each) in `tests/test_proxy_config.bats`, plus updates to existing test files. All 326 tests pass, 0 failures.

| Property | What it validates |
|---|---|
| Config parsing defaults REVERSE_PROXY to nginx | Req 1.1, 1.2 |
| Invalid REVERSE_PROXY values rejected | Req 1.3 |
| Scaffold creates correct proxy directory | Req 3.1-3.3 |
| Drift tracks correct proxy config file | Req 5.1, 5.2 |
| Health checks correct default ports | Req 7.1, 7.2 |
| PROXY_PORTS override works | Req 7.3 |
| Dry-run shows correct reload command | Req 8.1, 8.2 |

## Diff stats

14 files changed, 794 insertions, 62 deletions
