### PR TITLE
feat: add config schema validation (strut validate command)

### DIFF
--- a/lib/cmd_validate.sh
+++ b/lib/cmd_validate.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+# ==================================================
+# cmd_validate.sh — Config validation command handler
+# ==================================================
+# Validates strut.conf, services.conf, volume.conf, backup.conf,
+# and required_vars for a stack.
+#
+# Provides:
+#   cmd_validate <stack> <stack_dir> <env_file> <env_name>
+#   _validate_strut_conf
+#   _validate_services_conf <stack_dir>
+#   _validate_volume_conf <stack_dir>
+#   _validate_backup_conf <stack_dir>
+#   _validate_required_vars <stack_dir> <env_file>
+
+set -euo pipefail
+
+# ── Counters ──────────────────────────────────────────────────────────────────
+_VALIDATE_ERRORS=0
+_VALIDATE_WARNINGS=0
+
+_val_error() {
+  local file="$1" msg="$2"
+  echo -e "  ${RED}✗${NC} $file: $msg"
+  _VALIDATE_ERRORS=$((_VALIDATE_ERRORS + 1))
+}
+
+_val_warn() {
+  local file="$1" msg="$2"
+  echo -e "  ${YELLOW}⚠${NC} $file: $msg"
+  _VALIDATE_WARNINGS=$((_VALIDATE_WARNINGS + 1))
+}
+
+_val_ok() {
+  local file="$1" msg="$2"
+  echo -e "  ${GREEN}✓${NC} $file: $msg"
+}
+
+_usage_validate() {
+  echo ""
+  echo "Usage: strut <stack> validate [--env <name>]"
+  echo ""
+  echo "Validate all config files for a stack."
+  echo "Checks strut.conf, services.conf, volume.conf, backup.conf,"
+  echo "and required_vars against expected schemas."
+  echo ""
+  echo "Exit code 0 if valid, 1 if errors found."
+  echo ""
+  echo "Examples:"
+  echo "  strut my-stack validate"
+  echo "  strut my-stack validate --env prod"
+  echo ""
+}
+
+# ── Validation helpers ────────────────────────────────────────────────────────
+
+# _is_valid_port <value>
+# Returns 0 if value is a numeric port in range 1-65535
+_is_valid_port() {
+  local val="$1"
+  [[ "$val" =~ ^[0-9]+$ ]] || return 1
+  [ "$val" -ge 1 ] && [ "$val" -le 65535 ]
+}
+
+# _is_valid_boolean <value>
+# Returns 0 if value is "true" or "false"
+_is_valid_boolean() {
+  local val="$1"
+  [[ "$val" == "true" || "$val" == "false" ]]
+}
+
+# ── strut.conf validation ─────────────────────────────────────────────────────
+
+_validate_strut_conf() {
+  local conf_file="${PROJECT_ROOT:-$CLI_ROOT}/strut.conf"
+
+  if [ ! -f "$conf_file" ]; then
+    _val_warn "strut.conf" "not found (using defaults)"
+    return
+  fi
+
+  # Source it to get values
+  local _registry_type="" _reverse_proxy="" _default_branch=""
+  while IFS='=' read -r key val; do
+    # Skip comments and empty lines
+    [[ -z "$key" || "$key" =~ ^[[:space:]]*# ]] && continue
+    key=$(echo "$key" | xargs)
+    val=$(echo "$val" | xargs)
+    case "$key" in
+      REGISTRY_TYPE)   _registry_type="$val" ;;
+      REVERSE_PROXY)   _reverse_proxy="$val" ;;
+      DEFAULT_BRANCH)  _default_branch="$val" ;;
+    esac
+  done < "$conf_file"
+
+  local valid=true
+
+  if [ -n "$_registry_type" ]; then
+    case "$_registry_type" in
+      ghcr|dockerhub|ecr|none) ;;
+      *) _val_error "strut.conf" "REGISTRY_TYPE='$_registry_type' (valid: ghcr, dockerhub, ecr, none)"; valid=false ;;
+    esac
+  fi
+
+  if [ -n "$_reverse_proxy" ]; then
+    case "$_reverse_proxy" in
+      nginx|caddy) ;;
+      *) _val_error "strut.conf" "REVERSE_PROXY='$_reverse_proxy' (valid: nginx, caddy)"; valid=false ;;
+    esac
+  fi
+
+  if [ -n "$_default_branch" ]; then
+    if [[ "$_default_branch" =~ [[:space:]] ]]; then
+      _val_error "strut.conf" "DEFAULT_BRANCH='$_default_branch' contains spaces"
+      valid=false
+    fi
+  fi
+
+  $valid && _val_ok "strut.conf" "valid"
+}
+
+# ── services.conf validation ──────────────────────────────────────────────────
+
+_validate_services_conf() {
+  local stack_dir="$1"
+  local conf_file="$stack_dir/services.conf"
+
+  if [ ! -f "$conf_file" ]; then
+    _val_warn "services.conf" "not found (health checks will use defaults)"
+    return
+  fi
+
+  local valid=true
+  local service_count=0
+  local db_count=0
+
+  while IFS='=' read -r key val; do
+    [[ -z "$key" || "$key" =~ ^[[:space:]]*# ]] && continue
+    key=$(echo "$key" | xargs)
+    val=$(echo "$val" | xargs)
+
+    # Port validation
+    if [[ "$key" == *_PORT ]]; then
+      service_count=$((service_count + 1))
+      if ! _is_valid_port "$val"; then
+        _val_error "services.conf" "$key='$val' (must be numeric, 1-65535)"
+        valid=false
+      fi
+    fi
+
+    # Health path validation
+    if [[ "$key" == HEALTH_PATH_* || "$key" == *_HEALTH_PATH ]]; then
+      if [[ "$val" != /* ]]; then
+        _val_warn "services.conf" "$key='$val' (should start with /)"
+      fi
+    fi
+
+    # DB flag validation
+    if [[ "$key" == DB_* ]]; then
+      db_count=$((db_count + 1))
+      if ! _is_valid_boolean "$val"; then
+        _val_error "services.conf" "$key='$val' (must be true or false)"
+        valid=false
+      fi
+    fi
+  done < "$conf_file"
+
+  $valid && _val_ok "services.conf" "valid ($service_count services, $db_count databases)"
+}
+
+# ── volume.conf validation ────────────────────────────────────────────────────
+
+_validate_volume_conf() {
+  local stack_dir="$1"
+  local conf_file="$stack_dir/volume.conf"
+
+  if [ ! -f "$conf_file" ]; then
+    return  # volume.conf is optional, no warning needed
+  fi
+
+  local valid=true
+
+  while IFS='=' read -r key val; do
+    [[ -z "$key" || "$key" =~ ^[[:space:]]*# ]] && continue
+    key=$(echo "$key" | xargs)
+    val=$(echo "$val" | xargs)
+
+    # Path validation — check *_DATA_PATH and *_PATH keys
+    if [[ "$key" == *_DATA_PATH || "$key" == *_PATH ]]; then
+      # Expand variables in val
+      local expanded
+      expanded=$(eval echo "$val" 2>/dev/null || echo "$val")
+      if [[ "$expanded" != /* ]]; then
+        _val_warn "volume.conf" "$key='$val' (should be an absolute path)"
+      fi
+    fi
+
+    # VOLUME_OWNERS format: path:uid:gid
+    if [[ "$key" == "VOLUME_OWNERS" ]]; then
+      IFS=' ' read -ra entries <<< "$val"
+      for entry in "${entries[@]}"; do
+        if [[ ! "$entry" =~ ^[^:]+:[0-9]+:[0-9]+$ ]]; then
+          _val_error "volume.conf" "VOLUME_OWNERS entry '$entry' (expected path:uid:gid)"
+          valid=false
+        fi
+      done
+    fi
+  done < "$conf_file"
+
+  $valid && _val_ok "volume.conf" "valid"
+}
+
+# ── backup.conf validation ────────────────────────────────────────────────────
+
+_validate_backup_conf() {
+  local stack_dir="$1"
+  local conf_file="$stack_dir/backup.conf"
+
+  if [ ! -f "$conf_file" ]; then
+    return  # backup.conf is optional
+  fi
+
+  local valid=true
+
+  while IFS='=' read -r key val; do
+    [[ -z "$key" || "$key" =~ ^[[:space:]]*# ]] && continue
+    key=$(echo "$key" | xargs)
+    val=$(echo "$val" | xargs | tr -d '"')
+
+    # Boolean flags
+    if [[ "$key" == BACKUP_POSTGRES || "$key" == BACKUP_NEO4J || "$key" == BACKUP_MYSQL || "$key" == BACKUP_SQLITE ]]; then
+      if ! _is_valid_boolean "$val"; then
+        _val_error "backup.conf" "$key='$val' (must be true or false)"
+        valid=false
+      fi
+    fi
+
+    # Numeric values
+    if [[ "$key" == BACKUP_RETAIN_DAYS || "$key" == BACKUP_RETAIN_COUNT ]]; then
+      if ! [[ "$val" =~ ^[0-9]+$ ]]; then
+        _val_error "backup.conf" "$key='$val' (must be numeric)"
+        valid=false
+      fi
+    fi
+
+    # Cron schedule validation (5 fields)
+    if [[ "$key" == BACKUP_SCHEDULE_* ]]; then
+      local field_count
+      field_count=$(echo "$val" | awk '{print NF}')
+      if [ "$field_count" -ne 5 ]; then
+        _val_error "backup.conf" "$key='$val' (must be a 5-field cron expression)"
+        valid=false
+      fi
+    fi
+  done < "$conf_file"
+
+  $valid && _val_ok "backup.conf" "valid"
+}
+
+# ── required_vars validation ──────────────────────────────────────────────────
+
+_validate_required_vars() {
+  local stack_dir="$1"
+  local env_file="$2"
+  local vars_file="$stack_dir/required_vars"
+
+  if [ ! -f "$vars_file" ]; then
+    return  # required_vars is optional
+  fi
+
+  if [ ! -f "$env_file" ]; then
+    _val_warn "required_vars" "env file not found: $env_file (skipping validation)"
+    return
+  fi
+
+  local valid=true
+  local missing=()
+
+  # Source env file to get values
+  set -a
+  source "$env_file" 2>/dev/null || true
+  set +a
+
+  while IFS= read -r var || [ -n "$var" ]; do
+    var=$(echo "$var" | xargs)
+    [ -z "$var" ] && continue
+    [[ "$var" =~ ^# ]] && continue
+
+    local val
+    val=$(eval echo "\${${var}:-}" 2>/dev/null || echo "")
+    if [ -z "$val" ]; then
+      missing+=("$var")
+      valid=false
+    fi
+  done < "$vars_file"
+
+  if [ ${#missing[@]} -gt 0 ]; then
+    for var in "${missing[@]}"; do
+      _val_error "required_vars" "missing or empty: $var (in $(basename "$env_file"))"
+    done
+  else
+    local var_count
+    var_count=$(grep -cve '^\s*$' "$vars_file" 2>/dev/null || echo 0)
+    _val_ok "required_vars" "all $var_count required vars present"
+  fi
+}
+
+# ── Main command ──────────────────────────────────────────────────────────────
+
+cmd_validate() {
+  local stack="$1"
+  local stack_dir="$2"
+  local env_file="$3"
+  local env_name="$4"
+
+  _VALIDATE_ERRORS=0
+  _VALIDATE_WARNINGS=0
+
+  echo ""
+  echo -e "${BLUE}Validating configuration for stack: $stack${NC}"
+  echo ""
+
+  _validate_strut_conf
+  _validate_services_conf "$stack_dir"
+  _validate_volume_conf "$stack_dir"
+  _validate_backup_conf "$stack_dir"
+  _validate_required_vars "$stack_dir" "$env_file"
+
+  echo ""
+  if [ $_VALIDATE_ERRORS -gt 0 ]; then
+    echo -e "${RED}$_VALIDATE_ERRORS error(s)${NC}, $_VALIDATE_WARNINGS warning(s)"
+    return 1
+  elif [ $_VALIDATE_WARNINGS -gt 0 ]; then
+    echo -e "${GREEN}Valid${NC} with $_VALIDATE_WARNINGS warning(s)"
+    return 0
+  else
+    echo -e "${GREEN}All config files valid${NC}"
+    return 0
+  fi
+}

--- a/strut
+++ b/strut
@@ -101,6 +101,7 @@ source "$LIB/cmd_remote.sh"
 source "$LIB/cmd_init.sh"
 source "$LIB/cmd_stop.sh"
 source "$LIB/cmd_skills.sh"
+source "$LIB/cmd_validate.sh"
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
@@ -460,6 +461,7 @@ if _has_help_flag; then
     local|prod|staging|dev) _usage_local ;;
     scaffold) _usage_scaffold ;;
     volumes)  _usage_volumes ;;
+    validate) _usage_validate ;;
     *)        usage ;;
   esac
   exit 0
@@ -489,6 +491,7 @@ case "$COMMAND" in
   local|prod|staging|dev) cmd_local_env "$STACK" "$COMMAND" "${CMD_ARGS[@]}" ;;
   debug)               cmd_debug "$STACK" "$ENV_FILE" "${CMD_ARGS[@]}" ;;
   keys)                cmd_keys "$STACK" "$ENV_FILE" "${CMD_ARGS[@]}" ;;
+  validate)            cmd_validate "$STACK" "$STACK_DIR" "$ENV_FILE" "$ENV_NAME" ;;
   domain)              cmd_domain "$STACK" "$ENV_FILE" "$ENV_NAME" "${CMD_ARGS[@]}" ;;
   *)                   usage; fail "Unknown command: '$COMMAND'" ;;
 esac

--- a/tests/test_validate.bats
+++ b/tests/test_validate.bats
@@ -1,0 +1,352 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_validate.bats — Tests for config validation
+# ==================================================
+# Run:  bats tests/test_validate.bats
+# Covers: _validate_strut_conf, _validate_services_conf,
+#         _validate_volume_conf, _validate_backup_conf,
+#         _validate_required_vars, _is_valid_port, _is_valid_boolean
+
+setup() {
+  export CLI_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  TEST_TMP="$(mktemp -d)"
+
+  source "$CLI_ROOT/lib/utils.sh"
+  fail() { echo "$1" >&2; return 1; }
+  error() { echo "$1" >&2; }
+
+  source "$CLI_ROOT/lib/cmd_validate.sh"
+}
+
+teardown() {
+  rm -rf "$CLI_ROOT/stacks/test-val-"*
+  rm -rf "$TEST_TMP"
+}
+
+# ── _is_valid_port ────────────────────────────────────────────────────────────
+
+@test "_is_valid_port: accepts port 80" {
+  run _is_valid_port "80"
+  [ "$status" -eq 0 ]
+}
+
+@test "_is_valid_port: accepts port 8080" {
+  run _is_valid_port "8080"
+  [ "$status" -eq 0 ]
+}
+
+@test "_is_valid_port: accepts port 65535" {
+  run _is_valid_port "65535"
+  [ "$status" -eq 0 ]
+}
+
+@test "_is_valid_port: rejects port 0" {
+  run _is_valid_port "0"
+  [ "$status" -eq 1 ]
+}
+
+@test "_is_valid_port: rejects port 70000" {
+  run _is_valid_port "70000"
+  [ "$status" -eq 1 ]
+}
+
+@test "_is_valid_port: rejects non-numeric" {
+  run _is_valid_port "abc"
+  [ "$status" -eq 1 ]
+}
+
+@test "_is_valid_port: rejects empty" {
+  run _is_valid_port ""
+  [ "$status" -eq 1 ]
+}
+
+# ── Property: valid ports accepted, invalid rejected ──────────────────────────
+
+@test "Property: ports 1-65535 accepted, others rejected (100 iterations)" {
+  for i in $(seq 1 100); do
+    local port=$(( (RANDOM % 70000) ))
+
+    if [ "$port" -ge 1 ] && [ "$port" -le 65535 ]; then
+      run _is_valid_port "$port"
+      [ "$status" -eq 0 ] || {
+        echo "FAILED: port $port should be valid"
+        return 1
+      }
+    else
+      run _is_valid_port "$port"
+      [ "$status" -eq 1 ] || {
+        echo "FAILED: port $port should be invalid"
+        return 1
+      }
+    fi
+  done
+}
+
+# ── _is_valid_boolean ─────────────────────────────────────────────────────────
+
+@test "_is_valid_boolean: accepts true" {
+  run _is_valid_boolean "true"
+  [ "$status" -eq 0 ]
+}
+
+@test "_is_valid_boolean: accepts false" {
+  run _is_valid_boolean "false"
+  [ "$status" -eq 0 ]
+}
+
+@test "_is_valid_boolean: rejects yes" {
+  run _is_valid_boolean "yes"
+  [ "$status" -eq 1 ]
+}
+
+@test "_is_valid_boolean: rejects 1" {
+  run _is_valid_boolean "1"
+  [ "$status" -eq 1 ]
+}
+
+@test "_is_valid_boolean: rejects empty" {
+  run _is_valid_boolean ""
+  [ "$status" -eq 1 ]
+}
+
+# ── _validate_services_conf ──────────────────────────────────────────────────
+
+@test "validate_services_conf: valid config passes" {
+  local stack_dir="$TEST_TMP/stack"
+  mkdir -p "$stack_dir"
+  cat > "$stack_dir/services.conf" <<'EOF'
+API_PORT=8000
+API_HEALTH_PATH=/health
+WORKER_PORT=8001
+DB_POSTGRES=true
+DB_NEO4J=false
+EOF
+
+  _VALIDATE_ERRORS=0
+  _VALIDATE_WARNINGS=0
+  _validate_services_conf "$stack_dir"
+  [ "$_VALIDATE_ERRORS" -eq 0 ]
+}
+
+@test "validate_services_conf: invalid port detected" {
+  local stack_dir="$TEST_TMP/stack"
+  mkdir -p "$stack_dir"
+  cat > "$stack_dir/services.conf" <<'EOF'
+API_PORT=not_a_number
+EOF
+
+  _VALIDATE_ERRORS=0
+  run _validate_services_conf "$stack_dir"
+  [[ "$output" == *"must be numeric"* ]]
+}
+
+@test "validate_services_conf: port out of range detected" {
+  local stack_dir="$TEST_TMP/stack"
+  mkdir -p "$stack_dir"
+  cat > "$stack_dir/services.conf" <<'EOF'
+API_PORT=99999
+EOF
+
+  _VALIDATE_ERRORS=0
+  run _validate_services_conf "$stack_dir"
+  [[ "$output" == *"must be numeric"* ]]
+}
+
+@test "validate_services_conf: invalid DB flag detected" {
+  local stack_dir="$TEST_TMP/stack"
+  mkdir -p "$stack_dir"
+  cat > "$stack_dir/services.conf" <<'EOF'
+DB_POSTGRES=yes
+EOF
+
+  _VALIDATE_ERRORS=0
+  run _validate_services_conf "$stack_dir"
+  [[ "$output" == *"must be true or false"* ]]
+}
+
+@test "validate_services_conf: health path without leading slash warns" {
+  local stack_dir="$TEST_TMP/stack"
+  mkdir -p "$stack_dir"
+  cat > "$stack_dir/services.conf" <<'EOF'
+API_PORT=8000
+API_HEALTH_PATH=health
+EOF
+
+  _VALIDATE_ERRORS=0
+  _VALIDATE_WARNINGS=0
+  _validate_services_conf "$stack_dir"
+  [ "$_VALIDATE_WARNINGS" -gt 0 ]
+}
+
+@test "validate_services_conf: missing file warns" {
+  _VALIDATE_WARNINGS=0
+  _validate_services_conf "$TEST_TMP/nonexistent"
+  [ "$_VALIDATE_WARNINGS" -gt 0 ]
+}
+
+# ── _validate_backup_conf ────────────────────────────────────────────────────
+
+@test "validate_backup_conf: valid config passes" {
+  local stack_dir="$TEST_TMP/stack"
+  mkdir -p "$stack_dir"
+  cat > "$stack_dir/backup.conf" <<'EOF'
+BACKUP_POSTGRES=true
+BACKUP_NEO4J=false
+BACKUP_RETAIN_DAYS=30
+BACKUP_RETAIN_COUNT=10
+BACKUP_SCHEDULE_POSTGRES="0 2 * * *"
+EOF
+
+  _VALIDATE_ERRORS=0
+  _validate_backup_conf "$stack_dir"
+  [ "$_VALIDATE_ERRORS" -eq 0 ]
+}
+
+@test "validate_backup_conf: non-numeric retention days detected" {
+  local stack_dir="$TEST_TMP/stack"
+  mkdir -p "$stack_dir"
+  cat > "$stack_dir/backup.conf" <<'EOF'
+BACKUP_RETAIN_DAYS=thirty
+EOF
+
+  run _validate_backup_conf "$stack_dir"
+  [[ "$output" == *"must be numeric"* ]]
+}
+
+@test "validate_backup_conf: invalid boolean flag detected" {
+  local stack_dir="$TEST_TMP/stack"
+  mkdir -p "$stack_dir"
+  cat > "$stack_dir/backup.conf" <<'EOF'
+BACKUP_POSTGRES=yes
+EOF
+
+  run _validate_backup_conf "$stack_dir"
+  [[ "$output" == *"must be true or false"* ]]
+}
+
+@test "validate_backup_conf: invalid cron expression detected" {
+  local stack_dir="$TEST_TMP/stack"
+  mkdir -p "$stack_dir"
+  cat > "$stack_dir/backup.conf" <<'EOF'
+BACKUP_SCHEDULE_POSTGRES="daily"
+EOF
+
+  run _validate_backup_conf "$stack_dir"
+  [[ "$output" == *"5-field cron"* ]]
+}
+
+# ── _validate_required_vars ──────────────────────────────────────────────────
+
+@test "validate_required_vars: all vars present passes" {
+  local stack_dir="$TEST_TMP/stack"
+  mkdir -p "$stack_dir"
+  echo "MY_VAR" > "$stack_dir/required_vars"
+  echo "MY_VAR=hello" > "$TEST_TMP/test.env"
+
+  _VALIDATE_ERRORS=0
+  _validate_required_vars "$stack_dir" "$TEST_TMP/test.env"
+  [ "$_VALIDATE_ERRORS" -eq 0 ]
+}
+
+@test "validate_required_vars: missing var detected" {
+  local stack_dir="$TEST_TMP/stack"
+  mkdir -p "$stack_dir"
+  echo "MISSING_VAR" > "$stack_dir/required_vars"
+  echo "OTHER_VAR=hello" > "$TEST_TMP/test.env"
+
+  _VALIDATE_ERRORS=0
+  _validate_required_vars "$stack_dir" "$TEST_TMP/test.env"
+  [ "$_VALIDATE_ERRORS" -gt 0 ]
+}
+
+# ── cmd_validate integration ─────────────────────────────────────────────────
+
+@test "cmd_validate: returns 0 for valid stack" {
+  local stack="test-val-ok-$$"
+  local stack_dir="$CLI_ROOT/stacks/$stack"
+  mkdir -p "$stack_dir"
+  cat > "$stack_dir/services.conf" <<'EOF'
+API_PORT=8000
+DB_POSTGRES=true
+EOF
+
+  export PROJECT_ROOT="$TEST_TMP"
+  # No strut.conf → uses defaults (valid)
+
+  run cmd_validate "$stack" "$stack_dir" "$TEST_TMP/nonexistent.env" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"valid"* ]] || [[ "$output" == *"Valid"* ]]
+
+  rm -rf "$stack_dir"
+}
+
+@test "cmd_validate: returns 1 for invalid config" {
+  local stack="test-val-bad-$$"
+  local stack_dir="$CLI_ROOT/stacks/$stack"
+  mkdir -p "$stack_dir"
+  cat > "$stack_dir/services.conf" <<'EOF'
+API_PORT=not_a_port
+DB_POSTGRES=maybe
+EOF
+
+  export PROJECT_ROOT="$TEST_TMP"
+
+  run cmd_validate "$stack" "$stack_dir" "$TEST_TMP/nonexistent.env" ""
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"error"* ]]
+
+  rm -rf "$stack_dir"
+}
+
+# ── Property: random valid configs always pass ────────────────────────────────
+
+@test "Property: valid services.conf always passes validation (100 iterations)" {
+  for i in $(seq 1 100); do
+    local stack_dir="$TEST_TMP/prop-$i"
+    mkdir -p "$stack_dir"
+
+    # Generate random valid config
+    local port=$(( (RANDOM % 65534) + 1 ))
+    local db_flag="true"
+    (( RANDOM % 2 == 0 )) && db_flag="false"
+
+    cat > "$stack_dir/services.conf" <<EOF
+APP_PORT=$port
+APP_HEALTH_PATH=/health
+DB_POSTGRES=$db_flag
+EOF
+
+    _VALIDATE_ERRORS=0
+    _VALIDATE_WARNINGS=0
+    _validate_services_conf "$stack_dir"
+
+    [ "$_VALIDATE_ERRORS" -eq 0 ] || {
+      echo "FAILED iteration $i: port=$port db_flag=$db_flag had errors"
+      return 1
+    }
+
+    rm -rf "$stack_dir"
+  done
+}
+
+# ── Property: random invalid ports always fail ────────────────────────────────
+
+@test "Property: non-numeric ports always fail validation (100 iterations)" {
+  for i in $(seq 1 100); do
+    local bad_port
+    bad_port=$(head -c 5 /dev/urandom | base64 | tr -d '/+=' | head -c 4)
+    bad_port="x${bad_port}"
+
+    local stack_dir="$TEST_TMP/prop-bad-$i"
+    mkdir -p "$stack_dir"
+    echo "APP_PORT=$bad_port" > "$stack_dir/services.conf"
+
+    run _validate_services_conf "$stack_dir"
+    [[ "$output" == *"must be numeric"* ]] || {
+      echo "FAILED iteration $i: bad_port='$bad_port' should have failed"
+      return 1
+    }
+
+    rm -rf "$stack_dir"
+  done
+}


### PR DESCRIPTION
## Summary

Adds `strut <stack> validate [--env <name>]` command that checks all config files against expected schemas and reports errors/warnings with clear messages.

## What it validates

| File | Checks |
|---|---|
| `strut.conf` | REGISTRY_TYPE enum, REVERSE_PROXY enum, DEFAULT_BRANCH format |
| `services.conf` | Port range 1-65535, DB_* boolean flags, health path starts with `/` |
| `volume.conf` | Absolute paths for *_DATA_PATH/*_PATH, VOLUME_OWNERS path:uid:gid format |
| `backup.conf` | Boolean flags, numeric retention days/count, 5-field cron expressions |
| `required_vars` | All listed vars present and non-empty in env file |

## Example output

```
Validating configuration for stack: my-app

  ✓ strut.conf: valid
  ✓ services.conf: valid (3 services, 2 databases)
  ✗ backup.conf: BACKUP_RETAIN_DAYS='thirty' (must be numeric)
  ✗ backup.conf: BACKUP_POSTGRES='yes' (must be true or false)

2 error(s), 0 warning(s)
```

Exit code 0 for valid, 1 for errors. Warnings don't fail.

## Tests

29 new tests including property-based tests for port validation (100 iterations) and random invalid port detection (100 iterations). 438 total tests, 0 failures.

Closes #5
