### PR TITLE
feat: add secret scanning to validate and pre-deploy

### DIFF
--- a/lib/cmd_validate.sh
+++ b/lib/cmd_validate.sh
@@ -353,8 +353,7 @@ _is_weak_password() {
 # _validate_secrets <stack_dir> <env_file>
 # Scans for accidentally committed secrets and weak passwords.
 _validate_secrets() {
-  local stack_dir="$1"
-  local env_file="$2"
+  local env_file="$1"
   local cli_root="${CLI_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 
   # Check if env files are git-tracked (they shouldn't be)
@@ -377,7 +376,7 @@ _validate_secrets() {
       val=$(echo "$val" | xargs | tr -d '"' | tr -d "'")
       [ -z "$val" ] && continue
 
-      # Check for known secret patterns in tracked config files
+      # Check for known secret patterns in env file values
       local pattern_name=""
       if pattern_name=$(_is_secret_pattern "$val"); then
         _val_warn "secrets" "$key matches $pattern_name — ensure $(basename "$env_file") is gitignored"
@@ -419,7 +418,7 @@ cmd_validate() {
   _validate_volume_conf "$stack_dir"
   _validate_backup_conf "$stack_dir"
   _validate_required_vars "$stack_dir" "$env_file"
-  _validate_secrets "$stack_dir" "$env_file"
+  _validate_secrets "$env_file"
 
   echo ""
   if [ $_VALIDATE_ERRORS -gt 0 ]; then

--- a/lib/cmd_validate.sh
+++ b/lib/cmd_validate.sh
@@ -305,6 +305,100 @@ _validate_required_vars() {
   fi
 }
 
+# ── Secret scanning ───────────────────────────────────────────────────────────
+
+# _is_secret_pattern <value>
+# Returns 0 if value matches a known secret pattern, echoes the pattern name.
+_is_secret_pattern() {
+  local val="$1"
+
+  # GitHub PAT
+  if [[ "$val" =~ ^ghp_[A-Za-z0-9]{36}$ ]]; then
+    echo "GitHub Personal Access Token (ghp_)"; return 0
+  fi
+  # GitHub fine-grained PAT
+  if [[ "$val" =~ ^github_pat_ ]]; then
+    echo "GitHub Fine-Grained PAT (github_pat_)"; return 0
+  fi
+  # AWS Access Key
+  if [[ "$val" =~ ^AKIA[0-9A-Z]{16}$ ]]; then
+    echo "AWS Access Key (AKIA...)"; return 0
+  fi
+  # OpenAI / Stripe sk- prefix
+  if [[ "$val" =~ ^sk-[A-Za-z0-9]{20,}$ ]]; then
+    echo "API secret key (sk-)"; return 0
+  fi
+  # Slack webhook
+  if [[ "$val" =~ ^https://hooks\.slack\.com/ ]]; then
+    echo "Slack webhook URL"; return 0
+  fi
+
+  return 1
+}
+
+# _is_weak_password <value>
+# Returns 0 if value is a common weak/placeholder password.
+_is_weak_password() {
+  local val="$1"
+  local lower
+  lower=$(echo "$val" | tr '[:upper:]' '[:lower:]')
+
+  case "$lower" in
+    password|password1|changeme|change-me|secret|secret123|admin|test|12345*|qwerty|letmein|placeholder|todo|fixme)
+      return 0 ;;
+  esac
+  return 1
+}
+
+# _validate_secrets <stack_dir> <env_file>
+# Scans for accidentally committed secrets and weak passwords.
+_validate_secrets() {
+  local stack_dir="$1"
+  local env_file="$2"
+  local cli_root="${CLI_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+  # Check if env files are git-tracked (they shouldn't be)
+  if [ -f "$env_file" ] && command -v git &>/dev/null; then
+    local relative_env
+    relative_env="${env_file#$cli_root/}"
+    if git -C "$cli_root" ls-files --error-unmatch "$relative_env" &>/dev/null 2>&1; then
+      _val_error "secrets" "$(basename "$env_file") is tracked by git (should be in .gitignore)"
+    fi
+  fi
+
+  # Scan env file values for known secret patterns and weak passwords
+  if [ -f "$env_file" ]; then
+    # Scan env file values for known secret patterns and weak passwords
+    local secret_found=false
+    # shellcheck disable=SC2094
+    while IFS='=' read -r key val; do
+      [[ -z "$key" || "$key" =~ ^[[:space:]]*# ]] && continue
+      key=$(echo "$key" | xargs)
+      val=$(echo "$val" | xargs | tr -d '"' | tr -d "'")
+      [ -z "$val" ] && continue
+
+      # Check for known secret patterns in tracked config files
+      local pattern_name=""
+      if pattern_name=$(_is_secret_pattern "$val"); then
+        _val_warn "secrets" "$key matches $pattern_name — ensure $(basename "$env_file") is gitignored"
+        secret_found=true
+      fi
+
+      # Check for weak passwords in password-like keys
+      if [[ "$key" == *PASSWORD* || "$key" == *SECRET* || "$key" == *TOKEN* || "$key" == *KEY* ]]; then
+        if _is_weak_password "$val"; then
+          _val_warn "secrets" "$key='$val' is a weak/placeholder password"
+          secret_found=true
+        fi
+      fi
+    done < "$env_file"
+
+    if ! $secret_found; then
+      _val_ok "secrets" "no issues detected"
+    fi
+  fi
+}
+
 # ── Main command ──────────────────────────────────────────────────────────────
 
 cmd_validate() {
@@ -325,6 +419,7 @@ cmd_validate() {
   _validate_volume_conf "$stack_dir"
   _validate_backup_conf "$stack_dir"
   _validate_required_vars "$stack_dir" "$env_file"
+  _validate_secrets "$stack_dir" "$env_file"
 
   echo ""
   if [ $_VALIDATE_ERRORS -gt 0 ]; then

--- a/tests/test_secret_scan.bats
+++ b/tests/test_secret_scan.bats
@@ -1,0 +1,182 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_secret_scan.bats — Tests for secret scanning
+# ==================================================
+# Run:  bats tests/test_secret_scan.bats
+# Covers: _is_secret_pattern, _is_weak_password, _validate_secrets
+
+setup() {
+  export CLI_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  TEST_TMP="$(mktemp -d)"
+
+  source "$CLI_ROOT/lib/utils.sh"
+  fail() { echo "$1" >&2; return 1; }
+  error() { echo "$1" >&2; }
+
+  source "$CLI_ROOT/lib/cmd_validate.sh"
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+}
+
+# ── _is_secret_pattern ────────────────────────────────────────────────────────
+
+@test "detects GitHub PAT (ghp_)" {
+  run _is_secret_pattern "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"GitHub"* ]]
+}
+
+@test "detects GitHub fine-grained PAT" {
+  run _is_secret_pattern "github_pat_11ABCDEF_abcdefghijklmnop"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"GitHub"* ]]
+}
+
+@test "detects AWS access key" {
+  run _is_secret_pattern "AKIAIOSFODNN7EXAMPLE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"AWS"* ]]
+}
+
+@test "detects sk- API key" {
+  run _is_secret_pattern "sk-proj1234567890abcdefghij"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"secret key"* ]]
+}
+
+@test "detects Slack webhook" {
+  run _is_secret_pattern "https://hooks.slack.com/services/T00/B00/xxxx"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Slack"* ]]
+}
+
+@test "ignores normal values" {
+  run _is_secret_pattern "my-app-name"
+  [ "$status" -eq 1 ]
+}
+
+@test "ignores empty string" {
+  run _is_secret_pattern ""
+  [ "$status" -eq 1 ]
+}
+
+@test "ignores numeric values" {
+  run _is_secret_pattern "8000"
+  [ "$status" -eq 1 ]
+}
+
+# ── _is_weak_password ─────────────────────────────────────────────────────────
+
+@test "detects 'password'" {
+  run _is_weak_password "password"
+  [ "$status" -eq 0 ]
+}
+
+@test "detects 'changeme'" {
+  run _is_weak_password "changeme"
+  [ "$status" -eq 0 ]
+}
+
+@test "detects 'change-me'" {
+  run _is_weak_password "change-me"
+  [ "$status" -eq 0 ]
+}
+
+@test "detects 'secret'" {
+  run _is_weak_password "secret"
+  [ "$status" -eq 0 ]
+}
+
+@test "detects case-insensitive 'PASSWORD'" {
+  run _is_weak_password "PASSWORD"
+  [ "$status" -eq 0 ]
+}
+
+@test "accepts strong password" {
+  run _is_weak_password "xK9#mP2vL8qR4nW6"
+  [ "$status" -eq 1 ]
+}
+
+@test "accepts UUID-like password" {
+  run _is_weak_password "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+  [ "$status" -eq 1 ]
+}
+
+# ── _validate_secrets integration ─────────────────────────────────────────────
+
+@test "validate_secrets: warns on weak password in env file" {
+  cat > "$TEST_TMP/test.env" <<'EOF'
+POSTGRES_PASSWORD=changeme
+API_SECRET_KEY=password
+EOF
+
+  _VALIDATE_ERRORS=0
+  _VALIDATE_WARNINGS=0
+  _DOC_JSON=false 2>/dev/null || true
+
+  run _validate_secrets "$TEST_TMP" "$TEST_TMP/test.env"
+  [[ "$output" == *"weak"* ]] || [[ "$output" == *"placeholder"* ]]
+}
+
+@test "validate_secrets: clean env file shows no issues" {
+  cat > "$TEST_TMP/test.env" <<'EOF'
+POSTGRES_DB=myapp
+API_PORT=8000
+VPS_HOST=10.0.0.1
+EOF
+
+  _VALIDATE_ERRORS=0
+  _VALIDATE_WARNINGS=0
+
+  run _validate_secrets "$TEST_TMP" "$TEST_TMP/test.env"
+  [[ "$output" == *"no issues"* ]]
+}
+
+# ── Property: known secret patterns always detected ───────────────────────────
+
+@test "Property: all known secret patterns detected (exhaustive)" {
+  local secrets=(
+    "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"
+    "github_pat_11ABCDEF_something"
+    "AKIAIOSFODNN7EXAMPLE"
+    "sk-abcdefghijklmnopqrstuvwxyz"
+    "https://hooks.slack.com/services/T00/B00/xxxx"
+  )
+
+  for secret in "${secrets[@]}"; do
+    run _is_secret_pattern "$secret"
+    [ "$status" -eq 0 ] || {
+      echo "FAILED: secret pattern not detected: $secret"
+      return 1
+    }
+  done
+}
+
+@test "Property: weak passwords always detected (exhaustive)" {
+  local weak=("password" "Password" "PASSWORD" "changeme" "change-me" "secret" "secret123" "admin" "test" "12345" "qwerty" "letmein" "placeholder" "todo" "fixme")
+
+  for pw in "${weak[@]}"; do
+    run _is_weak_password "$pw"
+    [ "$status" -eq 0 ] || {
+      echo "FAILED: weak password not detected: $pw"
+      return 1
+    }
+  done
+}
+
+@test "Property: random strong passwords never flagged (100 iterations)" {
+  for i in $(seq 1 100); do
+    local pw
+    pw=$(head -c 16 /dev/urandom | base64 | tr -d '/+=' | head -c 20)
+    # Ensure it doesn't accidentally match a weak pattern
+    pw="Str0ng_${pw}"
+
+    run _is_weak_password "$pw"
+    [ "$status" -eq 1 ] || {
+      echo "FAILED iteration $i: strong password '$pw' flagged as weak"
+      return 1
+    }
+  done
+}

--- a/tests/test_secret_scan.bats
+++ b/tests/test_secret_scan.bats
@@ -116,7 +116,7 @@ EOF
   _VALIDATE_WARNINGS=0
   _DOC_JSON=false 2>/dev/null || true
 
-  run _validate_secrets "$TEST_TMP" "$TEST_TMP/test.env"
+  run _validate_secrets "$TEST_TMP/test.env"
   [[ "$output" == *"weak"* ]] || [[ "$output" == *"placeholder"* ]]
 }
 
@@ -130,7 +130,7 @@ EOF
   _VALIDATE_ERRORS=0
   _VALIDATE_WARNINGS=0
 
-  run _validate_secrets "$TEST_TMP" "$TEST_TMP/test.env"
+  run _validate_secrets "$TEST_TMP/test.env"
   [[ "$output" == *"no issues"* ]]
 }
 


### PR DESCRIPTION
## Summary

Adds secret scanning to `strut validate` and the pre-deploy validation pipeline. Detects accidentally committed credentials and weak passwords before they hit production.

## What it detects

| Pattern | Example |
|---|---|
| GitHub PAT | `ghp_ABCDEF...` |
| GitHub fine-grained PAT | `github_pat_11...` |
| AWS Access Key | `AKIA...` |
| API secret key (sk-) | `sk-proj...` |
| Slack webhook URL | `https://hooks.slack.com/...` |
| Weak passwords | `password`, `changeme`, `secret`, `admin`, etc. |
| Git-tracked env files | `.prod.env` in git (should be gitignored) |

## Tests

20 new tests including exhaustive pattern detection and 100-iteration property test for false-positive avoidance.

Closes #25
