### PR TITLE
feat: add SSH key permission checks to strut doctor

### DIFF
--- a/lib/cmd_doctor.sh
+++ b/lib/cmd_doctor.sh
@@ -130,7 +130,7 @@ _doc_check_ssh_key() {
       case "$perms" in
         600|400) _doc_pass "SSH key permissions" "$(basename "$key") is $perms" ;;
         unknown) ;; # stat failed, skip
-        *) _doc_warn "SSH key permissions" "$(basename "$key") is $perms (should be 600)" "chmod 600 $key" ;;
+        *) _doc_warn "SSH key permissions" "$(basename "$key") is $perms (should be 600 or 400)" "chmod 600 \"$key\"" ;;
       esac
 
       break
@@ -145,7 +145,7 @@ _doc_check_ssh_key() {
     case "$dir_perms" in
       700) ;; # OK, don't clutter output
       unknown) ;; # stat failed, skip
-      *) _doc_warn "SSH directory permissions" "$HOME/.ssh is $dir_perms (should be 700)" "chmod 700 $HOME/.ssh" ;;
+      *) _doc_warn "SSH directory permissions" "$HOME/.ssh is $dir_perms (should be 700)" "chmod 700 \"$HOME/.ssh\"" ;;
     esac
   fi
 }

--- a/lib/cmd_doctor.sh
+++ b/lib/cmd_doctor.sh
@@ -123,10 +123,31 @@ _doc_check_ssh_key() {
     if [ -f "$key" ]; then
       _doc_pass "SSH key" "found ($(basename "$key"))"
       found=true
+
+      # Check private key permissions (should be 600 or 400)
+      local perms
+      perms=$(stat -f "%Lp" "$key" 2>/dev/null || stat -c "%a" "$key" 2>/dev/null || echo "unknown")
+      case "$perms" in
+        600|400) _doc_pass "SSH key permissions" "$(basename "$key") is $perms" ;;
+        unknown) ;; # stat failed, skip
+        *) _doc_warn "SSH key permissions" "$(basename "$key") is $perms (should be 600)" "chmod 600 $key" ;;
+      esac
+
       break
     fi
   done
   $found || _doc_warn "SSH key" "no default SSH key found in ~/.ssh/" "ssh-keygen -t ed25519"
+
+  # Check ~/.ssh directory permissions (should be 700)
+  if [ -d "$HOME/.ssh" ]; then
+    local dir_perms
+    dir_perms=$(stat -f "%Lp" "$HOME/.ssh" 2>/dev/null || stat -c "%a" "$HOME/.ssh" 2>/dev/null || echo "unknown")
+    case "$dir_perms" in
+      700) ;; # OK, don't clutter output
+      unknown) ;; # stat failed, skip
+      *) _doc_warn "SSH directory permissions" "$HOME/.ssh is $dir_perms (should be 700)" "chmod 700 $HOME/.ssh" ;;
+    esac
+  fi
 }
 
 _doc_check_tool() {

--- a/tests/test_doctor.bats
+++ b/tests/test_doctor.bats
@@ -182,3 +182,13 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"Usage"* ]]
 }
+
+# ── SSH permission checks ─────────────────────────────────────────────────────
+
+@test "cmd_doctor --json: includes SSH key permission check" {
+  export STRUT_HOME="$CLI_ROOT"
+  run cmd_doctor --json
+  [ "$status" -eq 0 ]
+  # Should have an SSH-related check in the output
+  echo "$output" | jq -e '.checks[] | select(.name | test("SSH"))' >/dev/null
+}

--- a/tests/test_doctor.bats
+++ b/tests/test_doctor.bats
@@ -185,10 +185,30 @@ teardown() {
 
 # ── SSH permission checks ─────────────────────────────────────────────────────
 
-@test "cmd_doctor --json: includes SSH key permission check" {
+@test "cmd_doctor --json: includes SSH key permissions check for secure key perms" {
   export STRUT_HOME="$CLI_ROOT"
+  export HOME="$TEST_TMP/home-pass"
+  mkdir -p "$HOME/.ssh"
+  touch "$HOME/.ssh/id_rsa"
+  chmod 700 "$HOME/.ssh"
+  chmod 600 "$HOME/.ssh/id_rsa"
+
   run cmd_doctor --json
-  [ "$status" -eq 0 ]
-  # Should have an SSH-related check in the output
-  echo "$output" | jq -e '.checks[] | select(.name | test("SSH"))' >/dev/null
+  # May return 1 due to Docker/other checks failing with fake HOME — that's OK
+  echo "$output" | jq -e '.checks[] | select(.name == "SSH key permissions")' >/dev/null
+}
+
+@test "cmd_doctor --json: reports SSH key permissions fix for insecure key perms" {
+  export STRUT_HOME="$CLI_ROOT"
+  export HOME="$TEST_TMP/home-fail"
+  mkdir -p "$HOME/.ssh"
+  touch "$HOME/.ssh/id_rsa"
+  chmod 755 "$HOME/.ssh"
+  chmod 644 "$HOME/.ssh/id_rsa"
+
+  # Run in text mode — easier to assert on output
+  _DOC_PASSED=0; _DOC_WARNED=0; _DOC_FAILED=0; _DOC_JSON=false; _DOC_FIX=true
+  run _doc_check_ssh_key
+  [[ "$output" == *"should be 600 or 400"* ]]
+  [[ "$output" == *"chmod"* ]]
 }


### PR DESCRIPTION
Checks private key permissions (should be 600/400) and ~/.ssh directory permissions (should be 700). Warns with chmod fix command. Supports both macOS and Linux stat syntax.

Closes #29