### PR TITLE
security: remove eval with user-controlled input in config validation

### DIFF
--- a/lib/cmd_validate.sh
+++ b/lib/cmd_validate.sh
@@ -187,9 +187,12 @@ _validate_volume_conf() {
 
     # Path validation — check *_DATA_PATH and *_PATH keys
     if [[ "$key" == *_DATA_PATH || "$key" == *_PATH ]]; then
-      # Check if value is an absolute path or a variable reference
-      # Safe: no eval — just check the literal value pattern
-      if [[ "$val" != /* ]] && [[ "$val" != \$* ]]; then
+      # Check if value is an absolute path or a safe variable reference
+      # Reject command substitutions $(…) and backticks as dangerous
+      # shellcheck disable=SC2016
+      if [[ "$val" == *'$('* ]] || [[ "$val" == *'`'* ]]; then
+        _val_error "volume.conf" "$key='$val' contains command substitution (dangerous)"
+      elif [[ "$val" != /* ]] && [[ "$val" != \$* ]]; then
         _val_warn "volume.conf" "$key='$val' (should be an absolute path or variable reference)"
       fi
     fi

--- a/lib/cmd_validate.sh
+++ b/lib/cmd_validate.sh
@@ -187,11 +187,10 @@ _validate_volume_conf() {
 
     # Path validation — check *_DATA_PATH and *_PATH keys
     if [[ "$key" == *_DATA_PATH || "$key" == *_PATH ]]; then
-      # Expand variables in val
-      local expanded
-      expanded=$(eval echo "$val" 2>/dev/null || echo "$val")
-      if [[ "$expanded" != /* ]]; then
-        _val_warn "volume.conf" "$key='$val' (should be an absolute path)"
+      # Check if value is an absolute path or a variable reference
+      # Safe: no eval — just check the literal value pattern
+      if [[ "$val" != /* ]] && [[ "$val" != \$* ]]; then
+        _val_warn "volume.conf" "$key='$val' (should be an absolute path or variable reference)"
       fi
     fi
 
@@ -287,7 +286,8 @@ _validate_required_vars() {
     [[ "$var" =~ ^# ]] && continue
 
     local val
-    val=$(eval echo "\${${var}:-}" 2>/dev/null || echo "")
+    # Safe: use printenv instead of eval to read variable values
+    val=$(printenv "$var" 2>/dev/null || echo "")
     if [ -z "$val" ]; then
       missing+=("$var")
       valid=false

--- a/tests/test_validate.bats
+++ b/tests/test_validate.bats
@@ -273,10 +273,12 @@ EOF
 
   _VALIDATE_ERRORS=0
   _VALIDATE_WARNINGS=0
-  _validate_volume_conf "$stack_dir" 2>/dev/null || true
+  run _validate_volume_conf "$stack_dir"
 
   # The marker file must NOT exist — eval was not called
   [ ! -f "$marker" ]
+  # Should report an error for command substitution
+  [[ "$output" == *"command substitution"* ]]
 }
 
 @test "volume.conf: variable references accepted without eval" {
@@ -294,6 +296,7 @@ EOF
   # ${DATA_DIR}/postgres starts with $ — should not warn
   # /mnt/backups starts with / — should not warn
   [ "$_VALIDATE_ERRORS" -eq 0 ]
+  [ "$_VALIDATE_WARNINGS" -eq 0 ]
 }
 
 # ── cmd_validate integration ─────────────────────────────────────────────────

--- a/tests/test_validate.bats
+++ b/tests/test_validate.bats
@@ -259,6 +259,43 @@ EOF
   [ "$_VALIDATE_ERRORS" -gt 0 ]
 }
 
+# ── Security: eval hardening ─────────────────────────────────────────────────
+
+@test "volume.conf: malicious value does not execute commands" {
+  local stack_dir="$TEST_TMP/stack"
+  mkdir -p "$stack_dir"
+  local marker="$TEST_TMP/pwned"
+
+  # This would create a file if eval were used
+  cat > "$stack_dir/volume.conf" <<EOF
+POSTGRES_DATA_PATH=\$(touch $marker)
+EOF
+
+  _VALIDATE_ERRORS=0
+  _VALIDATE_WARNINGS=0
+  _validate_volume_conf "$stack_dir" 2>/dev/null || true
+
+  # The marker file must NOT exist — eval was not called
+  [ ! -f "$marker" ]
+}
+
+@test "volume.conf: variable references accepted without eval" {
+  local stack_dir="$TEST_TMP/stack"
+  mkdir -p "$stack_dir"
+  cat > "$stack_dir/volume.conf" <<'EOF'
+POSTGRES_DATA_PATH=${DATA_DIR}/postgres
+BACKUP_PATH=/mnt/backups
+EOF
+
+  _VALIDATE_ERRORS=0
+  _VALIDATE_WARNINGS=0
+  _validate_volume_conf "$stack_dir" 2>/dev/null || true
+
+  # ${DATA_DIR}/postgres starts with $ — should not warn
+  # /mnt/backups starts with / — should not warn
+  [ "$_VALIDATE_ERRORS" -eq 0 ]
+}
+
 # ── cmd_validate integration ─────────────────────────────────────────────────
 
 @test "cmd_validate: returns 0 for valid stack" {


### PR DESCRIPTION
Removes `eval` usage in volume.conf path expansion and required_vars variable lookup. Replaced with safe pattern matching and `printenv`.

Includes a test proving command injection via malicious volume.conf values is blocked.

Closes #30