### PR TITLE
feat: add stack/env/command error context to fail/warn/error

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -21,13 +21,23 @@ BLUE='\033[0;34m'
 NC='\033[0m'  # No Color
 
 # ── Log helpers ───────────────────────────────────────────────────────────────
+# When _error_context is set (e.g. "my-stack/prod/deploy") by the strut
+# entrypoint, warn/fail/error prepend "[${_error_context}]" so CI logs and
+# group deploys surface which stack/env/command triggered the message.
+_error_prefix() {
+  if [ -n "${_error_context:-}" ]; then
+    printf '[%s] ' "$_error_context"
+  fi
+  return 0
+}
+
 log()  { echo -e "${BLUE}[strut]${NC} $1"; }
 ok()   { echo -e "${GREEN}✓${NC} $1"; }
-warn() { echo -e "${YELLOW}⚠${NC}  $1"; }
-fail() { echo -e "${RED}✗${NC}  $1" >&2; exit 1; }
+warn() { echo -e "${YELLOW}⚠${NC}  $(_error_prefix)$1"; }
+fail() { echo -e "${RED}✗${NC}  $(_error_prefix)$1" >&2; exit 1; }
 
 # Like fail() but without exit — for non-fatal errors
-error() { echo -e "${RED}✗${NC}  $1" >&2; }
+error() { echo -e "${RED}✗${NC}  $(_error_prefix)$1" >&2; }
 
 # ── Banner helpers ────────────────────────────────────────────────────────────
 

--- a/strut
+++ b/strut
@@ -444,6 +444,14 @@ export CMD_ENV_NAME="$ENV_NAME"
 export CMD_SERVICES="$SERVICES"
 export CMD_JSON="$JSON_FLAG"
 
+# Error context for fail/warn/error messages. Formats as
+# "stack/env/command" when all three are known, else falls back.
+if [ -n "$ENV_NAME" ]; then
+  export _error_context="$STACK/$ENV_NAME/$COMMAND"
+else
+  export _error_context="$STACK/$COMMAND"
+fi
+
 # parse_common_flags already consumed --help/-h into FLAGS_HELP
 if [ "$FLAGS_HELP" = "true" ]; then
   case "$COMMAND" in

--- a/tests/test_error_context.bats
+++ b/tests/test_error_context.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_error_context.bats — _error_context prefix on warn/fail/error
+# ==================================================
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  # Source utils.sh directly (NOT via load_utils which overrides fail)
+  source "$CLI_ROOT/lib/utils.sh"
+
+  # Override fail so `run` can capture stderr without killing the process
+  fail() { echo -e "${RED}✗${NC}  $(_error_prefix)$1" >&2; return 1; }
+  export -f fail
+}
+
+teardown() {
+  common_teardown
+  unset _error_context
+}
+
+@test "_error_prefix: empty when _error_context unset" {
+  unset _error_context
+  run _error_prefix
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "_error_prefix: formats bracketed prefix when set" {
+  export _error_context="my-stack/prod/deploy"
+  run _error_prefix
+  [ "$status" -eq 0 ]
+  [ "$output" = "[my-stack/prod/deploy] " ]
+}
+
+@test "fail: no prefix when _error_context unset" {
+  unset _error_context
+  run fail "bad"
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"["*"]"* ]]
+  [[ "$output" == *"bad"* ]]
+}
+
+@test "fail: prepends [ctx] when _error_context set" {
+  export _error_context="my-stack/staging/deploy"
+  run fail "Env file not found: .staging.env"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"[my-stack/staging/deploy]"* ]]
+  [[ "$output" == *"Env file not found"* ]]
+}
+
+@test "warn: prepends [ctx] when _error_context set" {
+  export _error_context="my-stack/prod/health"
+  run warn "service unhealthy"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[my-stack/prod/health]"* ]]
+  [[ "$output" == *"service unhealthy"* ]]
+}
+
+@test "error: prepends [ctx] when _error_context set" {
+  export _error_context="my-stack/prod/backup"
+  run error "pg_dump failed"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[my-stack/prod/backup]"* ]]
+  [[ "$output" == *"pg_dump failed"* ]]
+}
+
+@test "log: does not get prefix (informational output stays clean)" {
+  export _error_context="my-stack/prod/deploy"
+  run log "starting deploy"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"my-stack/prod/deploy"* ]]
+  [[ "$output" == *"[strut]"* ]]
+  [[ "$output" == *"starting deploy"* ]]
+}
+
+@test "ok: does not get prefix (success output stays clean)" {
+  export _error_context="my-stack/prod/deploy"
+  run ok "done"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"my-stack/prod/deploy"* ]]
+}


### PR DESCRIPTION
## Summary
- `fail()`, `warn()`, and `error()` in `lib/utils.sh` now prepend a `[stack/env/command]` context via a new `_error_prefix` helper
- The strut entrypoint exports `_error_context` right before dispatch — `"$STACK/$ENV_NAME/$COMMAND"` when env is set, `"$STACK/$COMMAND"` otherwise
- Top-level commands (init, list, doctor, etc.) bypass the dispatch block, so no empty context appears
- `log()` and `ok()` remain unprefixed — informational/success output stays clean

## Before / after
```
# before
✗  Env file not found: .staging.env

# after
✗  [my-stack/staging/deploy] Env file not found: .staging.env
```

## Motivation
Closes #28. In CI logs and group deploys, errors deep in the call stack were ambiguous about which stack/env triggered them. A single-line prefix makes failures triageable without changing any call site.

## Test plan
- [x] New `tests/test_error_context.bats` — 8 tests covering prefix presence/absence across `fail`, `warn`, `error`, and the cleanliness of `log`/`ok`
- [x] Full BATS suite: **651 ok, 0 failed** (643 prior + 8 new)
- [x] No existing test required modification — the prefix is purely additive

🤖 Generated with [Claude Code](https://claude.com/claude-code)