### PR TITLE
feat: formalize lifecycle hook system in lib/hooks.sh

### DIFF
--- a/lib/backup/cmd.sh
+++ b/lib/backup/cmd.sh
@@ -39,6 +39,17 @@ backup_command() {
     compose_cmd=$(resolve_compose_cmd "$stack" "$env_file" "$services")
   fi
 
+  # Fire pre_backup hook for actual backup-creation targets (not list/verify/etc).
+  # Non-zero exit aborts. Skipped in DRY_RUN so dry-run stays side-effect-free.
+  local is_backup_target=false
+  case "$target" in
+    postgres|neo4j|mysql|sqlite|gdrive-transcripts|all) is_backup_target=true ;;
+  esac
+  if [ "$is_backup_target" = "true" ] && [ "$DRY_RUN" != "true" ]; then
+    BACKUP_TARGET="$target" fire_hook pre_backup "$stack_dir" || \
+      fail "pre_backup hook failed — aborting backup"
+  fi
+
   case "$target" in
     verify)
       [ -z "$arg2" ] && fail "Usage: strut $stack backup verify <backup-file> [--full]"
@@ -122,7 +133,9 @@ backup_command() {
         echo -e "${YELLOW}[DRY-RUN] No changes made.${NC}"
         return 0
       fi
-      backup_postgres "$stack" "$compose_cmd" ;;
+      backup_postgres "$stack" "$compose_cmd"
+      BACKUP_TARGET="postgres" fire_hook_or_warn post_backup "$stack_dir"
+      ;;
     neo4j)
       if [ "$DRY_RUN" = "true" ]; then
         echo ""
@@ -135,7 +148,9 @@ backup_command() {
         echo -e "${YELLOW}[DRY-RUN] No changes made.${NC}"
         return 0
       fi
-      backup_neo4j "$stack" "$compose_cmd" ;;
+      backup_neo4j "$stack" "$compose_cmd"
+      BACKUP_TARGET="neo4j" fire_hook_or_warn post_backup "$stack_dir"
+      ;;
     mysql)
       if [ "$DRY_RUN" = "true" ]; then
         echo ""
@@ -147,7 +162,9 @@ backup_command() {
         echo -e "${YELLOW}[DRY-RUN] No changes made.${NC}"
         return 0
       fi
-      backup_mysql "$stack" "$compose_cmd" ;;
+      backup_mysql "$stack" "$compose_cmd"
+      BACKUP_TARGET="mysql" fire_hook_or_warn post_backup "$stack_dir"
+      ;;
     sqlite)
       if [ "$DRY_RUN" = "true" ]; then
         echo ""
@@ -159,7 +176,9 @@ backup_command() {
         echo -e "${YELLOW}[DRY-RUN] No changes made.${NC}"
         return 0
       fi
-      backup_sqlite "$stack" "$compose_cmd" ;;
+      backup_sqlite "$stack" "$compose_cmd"
+      BACKUP_TARGET="sqlite" fire_hook_or_warn post_backup "$stack_dir"
+      ;;
     gdrive-transcripts)
       if [ "$DRY_RUN" = "true" ]; then
         echo ""
@@ -169,7 +188,9 @@ backup_command() {
         echo -e "${YELLOW}[DRY-RUN] No changes made.${NC}"
         return 0
       fi
-      backup_gdrive_transcripts "$stack" "$compose_cmd" ;;
+      backup_gdrive_transcripts "$stack" "$compose_cmd"
+      BACKUP_TARGET="gdrive-transcripts" fire_hook_or_warn post_backup "$stack_dir"
+      ;;
     all)
       if [ "$DRY_RUN" = "true" ]; then
         echo ""
@@ -196,6 +217,7 @@ backup_command() {
       [ "${BACKUP_MYSQL:-false}" = "true" ] && backup_mysql "$stack" "$compose_cmd"
       [ "${BACKUP_SQLITE:-false}" = "true" ] && backup_sqlite "$stack" "$compose_cmd"
       backup_gdrive_transcripts "$stack" "$compose_cmd"
+      BACKUP_TARGET="all" fire_hook_or_warn post_backup "$stack_dir"
       ;;
     *)
       fail "Unknown backup command: $target

--- a/lib/deploy.sh
+++ b/lib/deploy.sh
@@ -82,17 +82,11 @@ deploy_stack() {
       warn "docker-compose.yml: syntax check failed (may still work)"
     fi
 
-    # Run custom pre-deploy hooks
+    # Run custom pre_deploy hook via the generic lifecycle dispatcher
+    # (falls back to legacy pre-deploy.sh for backward compat with #18)
     if [ "${PRE_DEPLOY_HOOKS:-true}" = "true" ]; then
-      local hook_file="$stack_dir/hooks/pre-deploy.sh"
-      if [ -f "$hook_file" ]; then
-        log "Running custom pre-deploy hook..."
-        if bash "$hook_file"; then
-          ok "Custom pre-deploy hook passed"
-        else
-          fail "Custom pre-deploy hook failed: $hook_file"
-        fi
-      fi
+      fire_hook pre_deploy "$stack_dir" || \
+        fail "pre_deploy hook failed — aborting deploy"
     fi
 
     ok "Pre-deploy validation passed"
@@ -198,6 +192,9 @@ deploy_stack() {
   echo "  Logs:   $compose_cmd logs -f"
   echo "  Status: $compose_cmd ps"
   echo ""
+
+  # Fire post_deploy lifecycle hook (non-fatal on failure)
+  DEPLOY_STATUS="ok" fire_hook_or_warn post_deploy "$stack_dir"
 }
 
 # vps_update_repo <stack> <env_file>

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# ==================================================
+# lib/hooks.sh — Lifecycle hook dispatcher
+# ==================================================
+# Generalizes the pre-deploy hook (originally from #18) into a formal
+# lifecycle system. Projects drop executable scripts into:
+#
+#   stacks/<stack>/hooks/<event>.sh
+#
+# and strut fires them at the right moment.
+#
+# Events:
+#   pre_deploy         — before deploy_stack runs (can abort via non-zero)
+#   post_deploy        — after deploy_stack succeeds (warn-only on failure)
+#   pre_backup         — before any backup runs (can abort)
+#   post_backup        — after backup succeeds (warn-only)
+#   on_health_fail     — after a health check fails (warn-only)
+#   on_drift_detected  — when drift is found (warn-only)
+#
+# Event env vars: whatever the caller has already exported — typically
+# CMD_STACK, CMD_ENV_NAME, CMD_STACK_DIR. Event-specific env vars
+# (DEPLOY_STATUS, UNHEALTHY_SERVICES, etc.) are listed per call site.
+#
+# Naming: hook files may use either `pre_deploy.sh` (snake_case, preferred)
+# or `pre-deploy.sh` (legacy dash form, for backward compatibility with #18).
+
+set -euo pipefail
+
+# fire_hook <event> <stack_dir>
+#
+# Looks for an executable hook matching <event> under <stack_dir>/hooks/ and
+# runs it with the current environment. Returns 0 if no hook found, 0 if hook
+# runs successfully, or the hook's exit code on failure.
+#
+# Pre-* hooks: caller should propagate non-zero exit (abort action).
+# Post-/on-* hooks: caller should warn but continue on non-zero.
+fire_hook() {
+  local event="$1"
+  local stack_dir="$2"
+  local hooks_dir="$stack_dir/hooks"
+
+  # Try snake_case first, fall back to dash form (legacy)
+  local hook_file=""
+  local dash_event="${event//_/-}"
+  for candidate in "$hooks_dir/${event}.sh" "$hooks_dir/${dash_event}.sh"; do
+    if [ -f "$candidate" ]; then
+      hook_file="$candidate"
+      break
+    fi
+  done
+
+  # No hook present — nothing to do
+  [ -z "$hook_file" ] && return 0
+
+  log "Running ${event} hook: $hook_file"
+  if bash "$hook_file"; then
+    ok "${event} hook passed"
+    return 0
+  else
+    local rc=$?
+    return "$rc"
+  fi
+}
+
+# fire_hook_or_warn <event> <stack_dir>
+#
+# Convenience wrapper for post/on hooks — runs the hook but emits a warn
+# (not fail) if it exits non-zero, and always returns 0 so callers can
+# continue normal flow.
+fire_hook_or_warn() {
+  local event="$1"
+  local stack_dir="$2"
+
+  if ! fire_hook "$event" "$stack_dir"; then
+    warn "${event} hook failed (continuing)"
+  fi
+  return 0
+}

--- a/strut
+++ b/strut
@@ -72,6 +72,7 @@ load_strut_config
 
 source "$LIB/utils.sh"
 source "$LIB/flags.sh"
+source "$LIB/hooks.sh"
 source "$LIB/docker.sh"
 source "$LIB/deploy.sh"
 source "$LIB/health.sh"

--- a/tests/test_cmd_backup.bats
+++ b/tests/test_cmd_backup.bats
@@ -7,6 +7,7 @@ setup() {
   source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
   load_utils
 
+  source "$CLI_ROOT/lib/hooks.sh"
   source "$CLI_ROOT/lib/backup/cmd.sh"
   source "$CLI_ROOT/lib/cmd_backup.sh"
 

--- a/tests/test_hooks.bats
+++ b/tests/test_hooks.bats
@@ -1,0 +1,116 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_hooks.bats — lib/hooks.sh fire_hook dispatcher
+# ==================================================
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_utils
+  source "$CLI_ROOT/lib/hooks.sh"
+
+  export STACK_DIR="$TEST_TMP/stack"
+  mkdir -p "$STACK_DIR/hooks"
+}
+
+teardown() {
+  common_teardown
+}
+
+@test "fire_hook: no-op when hook file absent" {
+  run fire_hook pre_deploy "$STACK_DIR"
+  [ "$status" -eq 0 ]
+}
+
+@test "fire_hook: runs snake_case hook when present" {
+  cat > "$STACK_DIR/hooks/pre_deploy.sh" <<'EOF'
+#!/bin/bash
+echo "snake case hook ran"
+EOF
+  run fire_hook pre_deploy "$STACK_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"snake case hook ran"* ]]
+}
+
+@test "fire_hook: falls back to dash-case hook (legacy #18 compat)" {
+  cat > "$STACK_DIR/hooks/pre-deploy.sh" <<'EOF'
+#!/bin/bash
+echo "dash case hook ran"
+EOF
+  run fire_hook pre_deploy "$STACK_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dash case hook ran"* ]]
+}
+
+@test "fire_hook: prefers snake_case over dash-case when both present" {
+  cat > "$STACK_DIR/hooks/pre_deploy.sh" <<'EOF'
+#!/bin/bash
+echo "snake"
+EOF
+  cat > "$STACK_DIR/hooks/pre-deploy.sh" <<'EOF'
+#!/bin/bash
+echo "dash"
+EOF
+  run fire_hook pre_deploy "$STACK_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"snake"* ]]
+  [[ "$output" != *"dash"* ]]
+}
+
+@test "fire_hook: propagates non-zero exit from hook" {
+  cat > "$STACK_DIR/hooks/pre_deploy.sh" <<'EOF'
+#!/bin/bash
+echo "failing hook" >&2
+exit 42
+EOF
+  run fire_hook pre_deploy "$STACK_DIR"
+  [ "$status" -eq 42 ]
+}
+
+@test "fire_hook: passes env vars through to hook" {
+  cat > "$STACK_DIR/hooks/pre_deploy.sh" <<'EOF'
+#!/bin/bash
+echo "stack=$CMD_STACK env=$CMD_ENV_NAME"
+EOF
+  export CMD_STACK="my-stack"
+  export CMD_ENV_NAME="prod"
+  run fire_hook pre_deploy "$STACK_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"stack=my-stack env=prod"* ]]
+}
+
+@test "fire_hook: works for all event names" {
+  for event in pre_deploy post_deploy pre_backup post_backup on_health_fail on_drift_detected; do
+    cat > "$STACK_DIR/hooks/${event}.sh" <<EOF
+#!/bin/bash
+echo "fired $event"
+EOF
+    run fire_hook "$event" "$STACK_DIR"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"fired $event"* ]]
+  done
+}
+
+@test "fire_hook_or_warn: returns 0 even when hook fails" {
+  cat > "$STACK_DIR/hooks/post_deploy.sh" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+  run fire_hook_or_warn post_deploy "$STACK_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"failed (continuing)"* ]]
+}
+
+@test "fire_hook_or_warn: succeeds normally when hook passes" {
+  cat > "$STACK_DIR/hooks/post_deploy.sh" <<'EOF'
+#!/bin/bash
+echo "all good"
+EOF
+  run fire_hook_or_warn post_deploy "$STACK_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"all good"* ]]
+}
+
+@test "fire_hook_or_warn: returns 0 when no hook file exists" {
+  run fire_hook_or_warn post_deploy "$STACK_DIR"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- New `lib/hooks.sh` with `fire_hook <event> <stack_dir>` and `fire_hook_or_warn` — generalizes the pre-deploy hook from #18 into a formal six-event lifecycle system
- Events: `pre_deploy`, `post_deploy`, `pre_backup`, `post_backup`, `on_health_fail`, `on_drift_detected`
- Hooks live in `stacks/<stack>/hooks/<event>.sh`; both `pre_deploy.sh` (preferred) and `pre-deploy.sh` (legacy dash form from #18) are supported — snake_case wins when both exist
- Blocking (`pre_*`) hooks propagate non-zero exit; non-fatal (`post_*`, `on_*`) hooks warn but continue

## Retrofits
- `lib/deploy.sh` — replaces the inline `bash $stack_dir/hooks/pre-deploy.sh` block with `fire_hook pre_deploy`, and fires `post_deploy` at the end of a successful `deploy_stack`
- `lib/backup/cmd.sh` — fires `pre_backup` (blocking, skipped in `DRY_RUN`) and `post_backup` for each service target (postgres/neo4j/mysql/sqlite/gdrive-transcripts/all) with `BACKUP_TARGET=<service>` in env

## Motivation
Closes #50. Formalizing this is the foundation for #35 (notification providers) in the next PR, and any future operator automation.

## Test plan
- [x] New `tests/test_hooks.bats` — 10 tests: no-op, snake/dash fallback, snake-wins precedence, exit propagation, env passthrough, all six event names, `fire_hook_or_warn` semantics
- [x] Full BATS suite: **661 ok, 0 failed** (651 prior + 10 new)
- [x] `test_cmd_backup.bats` updated to also source `lib/hooks.sh` (19/19 pass)
- [x] Existing pre-deploy hook mechanism still works via dash-case fallback — no existing stack hook needs renaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)