### PR TITLE
feat: notification providers for lifecycle events (Slack/Discord/webhook)

### DIFF
--- a/lib/backup/cmd.sh
+++ b/lib/backup/cmd.sh
@@ -135,6 +135,7 @@ backup_command() {
       fi
       backup_postgres "$stack" "$compose_cmd"
       BACKUP_TARGET="postgres" fire_hook_or_warn post_backup "$stack_dir"
+      notify_event backup.success stack="$stack" env="$env_name" type=postgres
       ;;
     neo4j)
       if [ "$DRY_RUN" = "true" ]; then
@@ -150,6 +151,7 @@ backup_command() {
       fi
       backup_neo4j "$stack" "$compose_cmd"
       BACKUP_TARGET="neo4j" fire_hook_or_warn post_backup "$stack_dir"
+      notify_event backup.success stack="$stack" env="$env_name" type=neo4j
       ;;
     mysql)
       if [ "$DRY_RUN" = "true" ]; then
@@ -164,6 +166,7 @@ backup_command() {
       fi
       backup_mysql "$stack" "$compose_cmd"
       BACKUP_TARGET="mysql" fire_hook_or_warn post_backup "$stack_dir"
+      notify_event backup.success stack="$stack" env="$env_name" type=mysql
       ;;
     sqlite)
       if [ "$DRY_RUN" = "true" ]; then
@@ -178,6 +181,7 @@ backup_command() {
       fi
       backup_sqlite "$stack" "$compose_cmd"
       BACKUP_TARGET="sqlite" fire_hook_or_warn post_backup "$stack_dir"
+      notify_event backup.success stack="$stack" env="$env_name" type=sqlite
       ;;
     gdrive-transcripts)
       if [ "$DRY_RUN" = "true" ]; then
@@ -190,6 +194,7 @@ backup_command() {
       fi
       backup_gdrive_transcripts "$stack" "$compose_cmd"
       BACKUP_TARGET="gdrive-transcripts" fire_hook_or_warn post_backup "$stack_dir"
+      notify_event backup.success stack="$stack" env="$env_name" type=gdrive-transcripts
       ;;
     all)
       if [ "$DRY_RUN" = "true" ]; then
@@ -218,6 +223,7 @@ backup_command() {
       [ "${BACKUP_SQLITE:-false}" = "true" ] && backup_sqlite "$stack" "$compose_cmd"
       backup_gdrive_transcripts "$stack" "$compose_cmd"
       BACKUP_TARGET="all" fire_hook_or_warn post_backup "$stack_dir"
+      notify_event backup.success stack="$stack" env="$env_name" type=all
       ;;
     *)
       fail "Unknown backup command: $target

--- a/lib/deploy.sh
+++ b/lib/deploy.sh
@@ -195,6 +195,12 @@ deploy_stack() {
 
   # Fire post_deploy lifecycle hook (non-fatal on failure)
   DEPLOY_STATUS="ok" fire_hook_or_warn post_deploy "$stack_dir"
+
+  # Notification providers (Slack/Discord/webhook) subscribed to deploy.success
+  notify_event deploy.success \
+    stack="$stack" \
+    env="$env_name" \
+    services="${services_profile:-core}"
 }
 
 # vps_update_repo <stack> <env_file>

--- a/lib/notify.sh
+++ b/lib/notify.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# ==================================================
+# lib/notify.sh — Event notification dispatcher
+# ==================================================
+# Reads notifications.conf (from Project_Root), dispatches lifecycle
+# events (deploy.success, backup.success, health.fail, drift.detected,
+# etc.) to configured providers (Slack, Discord, generic webhook).
+#
+# Notification failures never fail the underlying action — the dispatcher
+# always returns 0.
+#
+# Config format (notifications.conf — shell-friendly, same style as
+# strut.conf):
+#
+#   SLACK_WEBHOOK=https://hooks.slack.com/services/...
+#   SLACK_EVENTS=deploy.success,deploy.fail,health.fail
+#   DISCORD_WEBHOOK=https://discord.com/api/webhooks/...
+#   DISCORD_EVENTS=deploy.fail
+#   WEBHOOK_URL=https://ops.example.com/strut
+#   WEBHOOK_EVENTS=*
+
+set -euo pipefail
+
+NOTIFY_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/notify"
+[ -f "$NOTIFY_LIB_DIR/slack.sh" ]   && source "$NOTIFY_LIB_DIR/slack.sh"
+[ -f "$NOTIFY_LIB_DIR/discord.sh" ] && source "$NOTIFY_LIB_DIR/discord.sh"
+[ -f "$NOTIFY_LIB_DIR/webhook.sh" ] && source "$NOTIFY_LIB_DIR/webhook.sh"
+
+# Path to the notifications config. Set by notify_load_config; callers
+# usually don't need to touch this directly.
+NOTIFY_CONFIG_LOADED="${NOTIFY_CONFIG_LOADED:-false}"
+
+# notify_load_config [path]
+#
+# Sources notifications.conf if present. Search order:
+#   1. Explicit path argument (if provided)
+#   2. $NOTIFICATIONS_CONF env var
+#   3. $PROJECT_ROOT/notifications.conf
+#   4. $CLI_ROOT/notifications.conf (fallback)
+#
+# Safe to call multiple times — idempotent.
+notify_load_config() {
+  [ "$NOTIFY_CONFIG_LOADED" = "true" ] && return 0
+
+  local conf="${1:-}"
+  if [ -z "$conf" ]; then
+    conf="${NOTIFICATIONS_CONF:-}"
+  fi
+  if [ -z "$conf" ] && [ -n "${PROJECT_ROOT:-}" ]; then
+    conf="$PROJECT_ROOT/notifications.conf"
+  fi
+  if [ -z "$conf" ] || [ ! -f "$conf" ]; then
+    conf="${CLI_ROOT:-}/notifications.conf"
+  fi
+
+  if [ -f "$conf" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$conf"
+    set +a
+  fi
+
+  NOTIFY_CONFIG_LOADED=true
+  return 0
+}
+
+# _notify_provider_subscribed <provider_events> <event>
+#
+# Returns 0 if the provider subscribes to <event> based on its comma-
+# separated event list. "*" means all events. Empty list means no match.
+_notify_provider_subscribed() {
+  local events_csv="$1"
+  local event="$2"
+  [ -z "$events_csv" ] && return 1
+  [ "$events_csv" = "*" ] && return 0
+
+  # Disable pathname expansion so a bare `*` in the CSV doesn't glob
+  # against the filesystem when the string is expanded by the for loop.
+  local _noglob_restore=0
+  case $- in *f*) ;; *) set -f; _noglob_restore=1 ;; esac
+
+  local IFS=','
+  local e rc=1
+  for e in $events_csv; do
+    # Trim whitespace
+    e="${e#"${e%%[![:space:]]*}"}"
+    e="${e%"${e##*[![:space:]]}"}"
+    if [ "$e" = "$event" ] || [ "$e" = "*" ]; then
+      rc=0
+      break
+    fi
+  done
+
+  [ "$_noglob_restore" = "1" ] && set +f
+  return "$rc"
+}
+
+# notify_event <event> [key=value ...]
+#
+# Fires <event> to every subscribed provider. Extra key=value pairs are
+# passed to each provider as the payload. Always returns 0.
+#
+# Example:
+#   notify_event deploy.success stack=my-stack env=prod duration=42s
+notify_event() {
+  local event="$1"
+  shift || true
+
+  notify_load_config || true
+
+  # In dry-run mode, just echo what would be sent
+  if [ "${DRY_RUN:-false}" = "true" ]; then
+    echo "[notify:dry-run] event=$event payload=$*"
+    return 0
+  fi
+
+  # Slack
+  if [ -n "${SLACK_WEBHOOK:-}" ] && \
+     _notify_provider_subscribed "${SLACK_EVENTS:-}" "$event"; then
+    notify_slack_send "$SLACK_WEBHOOK" "$event" "$@" || \
+      warn "Slack notification failed for event=$event (continuing)"
+  fi
+
+  # Discord
+  if [ -n "${DISCORD_WEBHOOK:-}" ] && \
+     _notify_provider_subscribed "${DISCORD_EVENTS:-}" "$event"; then
+    notify_discord_send "$DISCORD_WEBHOOK" "$event" "$@" || \
+      warn "Discord notification failed for event=$event (continuing)"
+  fi
+
+  # Generic webhook
+  if [ -n "${WEBHOOK_URL:-}" ] && \
+     _notify_provider_subscribed "${WEBHOOK_EVENTS:-}" "$event"; then
+    notify_webhook_send "$WEBHOOK_URL" "$event" "$@" || \
+      warn "Webhook notification failed for event=$event (continuing)"
+  fi
+
+  return 0
+}
+
+# notify_test <provider>
+#
+# Sends a deploy.success test event to the named provider. Used by
+# `strut notify test <provider>`.
+notify_test() {
+  local provider="${1:-}"
+  notify_load_config || true
+
+  case "$provider" in
+    slack)
+      [ -n "${SLACK_WEBHOOK:-}" ] || fail "SLACK_WEBHOOK not configured in notifications.conf"
+      notify_slack_send "$SLACK_WEBHOOK" "test.ping" \
+        stack=test env=test message="strut notify test message"
+      ;;
+    discord)
+      [ -n "${DISCORD_WEBHOOK:-}" ] || fail "DISCORD_WEBHOOK not configured in notifications.conf"
+      notify_discord_send "$DISCORD_WEBHOOK" "test.ping" \
+        stack=test env=test message="strut notify test message"
+      ;;
+    webhook)
+      [ -n "${WEBHOOK_URL:-}" ] || fail "WEBHOOK_URL not configured in notifications.conf"
+      notify_webhook_send "$WEBHOOK_URL" "test.ping" \
+        stack=test env=test message="strut notify test message"
+      ;;
+    "")
+      fail "Usage: strut notify test <slack|discord|webhook>"
+      ;;
+    *)
+      fail "Unknown provider: $provider (slack|discord|webhook)"
+      ;;
+  esac
+}
+
+# _notify_payload_json <event> [key=value ...]
+#
+# Builds a minimal JSON payload from the event name and key=value pairs.
+# Only explicit keys are included — never dumps env, protecting against
+# accidental secret leakage (related to #25).
+_notify_payload_json() {
+  local event="$1"
+  shift || true
+
+  local payload="{\"event\":\"$event\""
+  local kv key val
+  for kv in "$@"; do
+    key="${kv%%=*}"
+    val="${kv#*=}"
+    # Escape double quotes and backslashes in value
+    val="${val//\\/\\\\}"
+    val="${val//\"/\\\"}"
+    payload+=",\"$key\":\"$val\""
+  done
+  payload+="}"
+  echo "$payload"
+}

--- a/lib/notify/discord.sh
+++ b/lib/notify/discord.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# ==================================================
+# lib/notify/discord.sh — Discord webhook provider
+# ==================================================
+# Posts events as Discord webhook messages. Uses the `content` field
+# with a compact key/value rendering so messages are legible without
+# requiring embeds.
+
+set -euo pipefail
+
+# notify_discord_send <webhook_url> <event> [key=value ...]
+notify_discord_send() {
+  local url="$1"
+  local event="$2"
+  shift 2 || true
+
+  command -v curl >/dev/null 2>&1 || {
+    warn "curl not available — skipping Discord notification"
+    return 1
+  }
+
+  local summary="**strut event: ${event}**"
+  local detail=""
+  local kv key val
+  for kv in "$@"; do
+    key="${kv%%=*}"
+    val="${kv#*=}"
+    detail+="• ${key}: \`${val}\`\\n"
+  done
+
+  summary="${summary//\\/\\\\}"
+  summary="${summary//\"/\\\"}"
+  detail="${detail//\\/\\\\}"
+  detail="${detail//\"/\\\"}"
+
+  local payload="{\"content\":\"${summary}\\n${detail}\"}"
+
+  curl -sS -X POST -H 'Content-Type: application/json' \
+    --max-time 5 \
+    -d "$payload" "$url" >/dev/null
+}

--- a/lib/notify/slack.sh
+++ b/lib/notify/slack.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# ==================================================
+# lib/notify/slack.sh — Slack webhook provider
+# ==================================================
+# Posts events as Slack Incoming Webhook messages. The payload is a
+# minimal JSON with `text` and a compact key/value block so messages
+# are legible in Slack without custom formatting.
+
+set -euo pipefail
+
+# notify_slack_send <webhook_url> <event> [key=value ...]
+notify_slack_send() {
+  local url="$1"
+  local event="$2"
+  shift 2 || true
+
+  command -v curl >/dev/null 2>&1 || {
+    warn "curl not available — skipping Slack notification"
+    return 1
+  }
+
+  # Build a human-readable summary line
+  local summary="strut event: *${event}*"
+  local detail=""
+  local kv key val
+  for kv in "$@"; do
+    key="${kv%%=*}"
+    val="${kv#*=}"
+    detail+="• ${key}: \`${val}\`\\n"
+  done
+
+  # Escape for JSON embedding
+  summary="${summary//\\/\\\\}"
+  summary="${summary//\"/\\\"}"
+  detail="${detail//\\/\\\\}"
+  detail="${detail//\"/\\\"}"
+
+  local payload="{\"text\":\"${summary}\\n${detail}\"}"
+
+  curl -sS -X POST -H 'Content-Type: application/json' \
+    --max-time 5 \
+    -d "$payload" "$url" >/dev/null
+}

--- a/lib/notify/webhook.sh
+++ b/lib/notify/webhook.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# ==================================================
+# lib/notify/webhook.sh — Generic JSON webhook provider
+# ==================================================
+# Posts events as a raw JSON POST with `{"event": "...", ...kv}` body.
+# Use for integrating with custom ops systems, PagerDuty-compatible
+# endpoints, or anything that speaks JSON-over-HTTP.
+
+set -euo pipefail
+
+# notify_webhook_send <url> <event> [key=value ...]
+notify_webhook_send() {
+  local url="$1"
+  local event="$2"
+  shift 2 || true
+
+  command -v curl >/dev/null 2>&1 || {
+    warn "curl not available — skipping webhook notification"
+    return 1
+  }
+
+  local payload
+  payload=$(_notify_payload_json "$event" "$@")
+
+  curl -sS -X POST -H 'Content-Type: application/json' \
+    --max-time 5 \
+    -d "$payload" "$url" >/dev/null
+}

--- a/strut
+++ b/strut
@@ -73,6 +73,7 @@ load_strut_config
 source "$LIB/utils.sh"
 source "$LIB/flags.sh"
 source "$LIB/hooks.sh"
+source "$LIB/notify.sh"
 source "$LIB/docker.sh"
 source "$LIB/deploy.sh"
 source "$LIB/health.sh"
@@ -191,6 +192,9 @@ usage() {
   echo "  migrate <vps-host> [vps-user] [ssh-port] [ssh-key] [--yes]    Run migration wizard"
   echo "          --yes, -y                                              Auto-answer yes to all prompts"
   echo "  migrate:status                                                 Show migration status"
+  echo ""
+  echo "Notification Commands:"
+  echo "  notify test <slack|discord|webhook>                            Send a test notification"
   echo ""
   echo "Service profiles (--services):"
   echo "  (none)      Core services (as defined in docker-compose.yml)"
@@ -403,6 +407,21 @@ case "${1:-}" in
     ;;
   migrate:status)
     migrate_status
+    exit 0
+    ;;
+  notify)
+    # notify test <slack|discord|webhook>
+    NOTIFY_SUBCMD="${2:-}"
+    shift 2 || true
+    case "$NOTIFY_SUBCMD" in
+      test)
+        notify_test "${1:-}"
+        ;;
+      *)
+        echo "Usage: strut notify test <slack|discord|webhook>"
+        exit 1
+        ;;
+    esac
     exit 0
     ;;
   --help|-h|help) usage; exit 0 ;;

--- a/templates/notifications.conf.template
+++ b/templates/notifications.conf.template
@@ -1,0 +1,35 @@
+# ==================================================
+# notifications.conf — Event notification providers
+# ==================================================
+# Place at your project root (alongside strut.conf). strut reads this
+# whenever it dispatches a lifecycle event (deploy.success, backup.success,
+# health.fail, drift.detected, etc.).
+#
+# Format is shell env vars — same style as strut.conf. Leave a provider
+# unset to disable it. Events are a comma-separated list, or `*` for all.
+#
+# Test a provider:
+#   strut notify test slack
+#   strut notify test discord
+#   strut notify test webhook
+#
+# Notification failures never fail the underlying action.
+
+# ── Slack ──────────────────────────────────────────
+# SLACK_WEBHOOK=https://hooks.slack.com/services/T000/B000/XXXX
+# SLACK_EVENTS=deploy.success,deploy.fail,health.fail,backup.fail
+
+# ── Discord ────────────────────────────────────────
+# DISCORD_WEBHOOK=https://discord.com/api/webhooks/000/XXXX
+# DISCORD_EVENTS=deploy.fail,health.fail
+
+# ── Generic JSON webhook ───────────────────────────
+# Posts a raw JSON body: {"event": "...", "key": "value", ...}
+# WEBHOOK_URL=https://ops.example.com/strut
+# WEBHOOK_EVENTS=*
+
+# ── Events currently wired ─────────────────────────
+#   deploy.success    — stack, env, services
+#   backup.success    — stack, env, type
+#
+# Coming in a follow-up: deploy.fail, health.fail, backup.fail, drift.detected

--- a/tests/test_cmd_backup.bats
+++ b/tests/test_cmd_backup.bats
@@ -8,6 +8,7 @@ setup() {
   load_utils
 
   source "$CLI_ROOT/lib/hooks.sh"
+  source "$CLI_ROOT/lib/notify.sh"
   source "$CLI_ROOT/lib/backup/cmd.sh"
   source "$CLI_ROOT/lib/cmd_backup.sh"
 

--- a/tests/test_notify.bats
+++ b/tests/test_notify.bats
@@ -1,0 +1,206 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_notify.bats — Tests for notification dispatcher
+# ==================================================
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_utils
+  source "$CLI_ROOT/lib/notify.sh"
+
+  # Stub curl so provider send functions don't hit the network.
+  # Providers redirect stdout to /dev/null, so write to a trace file.
+  export CURL_TRACE="$TEST_TMP/curl.trace"
+  : > "$CURL_TRACE"
+  curl() { echo "curl $*" >> "$CURL_TRACE"; return 0; }
+  export -f curl
+
+  # Reset config-loaded flag and provider envs for each test
+  unset NOTIFY_CONFIG_LOADED
+  unset SLACK_WEBHOOK SLACK_EVENTS
+  unset DISCORD_WEBHOOK DISCORD_EVENTS
+  unset WEBHOOK_URL WEBHOOK_EVENTS
+  NOTIFY_CONFIG_LOADED=false
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------- _notify_provider_subscribed ----------
+
+@test "_notify_provider_subscribed: exact event match returns 0" {
+  run _notify_provider_subscribed "deploy.success,deploy.fail" "deploy.success"
+  [ "$status" -eq 0 ]
+}
+
+@test "_notify_provider_subscribed: non-matching event returns 1" {
+  run _notify_provider_subscribed "deploy.success" "backup.success"
+  [ "$status" -eq 1 ]
+}
+
+@test "_notify_provider_subscribed: wildcard matches any event" {
+  run _notify_provider_subscribed "*" "anything.at.all"
+  [ "$status" -eq 0 ]
+}
+
+@test "_notify_provider_subscribed: wildcard in CSV list matches" {
+  run _notify_provider_subscribed "deploy.fail,*" "random.event"
+  [ "$status" -eq 0 ]
+}
+
+@test "_notify_provider_subscribed: empty list returns 1" {
+  run _notify_provider_subscribed "" "deploy.success"
+  [ "$status" -eq 1 ]
+}
+
+@test "_notify_provider_subscribed: tolerates whitespace around entries" {
+  run _notify_provider_subscribed "deploy.success, deploy.fail , backup.success" "deploy.fail"
+  [ "$status" -eq 0 ]
+}
+
+# ---------- notify_load_config ----------
+
+@test "notify_load_config: loads variables from config file" {
+  cat > "$TEST_TMP/notifications.conf" <<'EOF'
+SLACK_WEBHOOK=https://hooks.example.com/slack
+SLACK_EVENTS=deploy.success
+EOF
+  notify_load_config "$TEST_TMP/notifications.conf"
+  [ "$SLACK_WEBHOOK" = "https://hooks.example.com/slack" ]
+  [ "$SLACK_EVENTS" = "deploy.success" ]
+}
+
+@test "notify_load_config: is idempotent — second call is a no-op" {
+  cat > "$TEST_TMP/notifications.conf" <<'EOF'
+SLACK_WEBHOOK=first-value
+EOF
+  notify_load_config "$TEST_TMP/notifications.conf"
+  [ "$SLACK_WEBHOOK" = "first-value" ]
+
+  # Rewrite the file — should NOT be re-read
+  cat > "$TEST_TMP/notifications.conf" <<'EOF'
+SLACK_WEBHOOK=second-value
+EOF
+  notify_load_config "$TEST_TMP/notifications.conf"
+  [ "$SLACK_WEBHOOK" = "first-value" ]
+}
+
+@test "notify_load_config: missing file is non-fatal" {
+  run notify_load_config "/nonexistent/path/notifications.conf"
+  [ "$status" -eq 0 ]
+}
+
+# ---------- notify_event ----------
+
+@test "notify_event: dry-run echoes event and returns 0" {
+  export DRY_RUN=true
+  run notify_event deploy.success stack=my-stack env=prod
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[notify:dry-run]"* ]]
+  [[ "$output" == *"event=deploy.success"* ]]
+  [[ "$output" == *"stack=my-stack"* ]]
+}
+
+@test "notify_event: no providers configured — returns 0 silently" {
+  export DRY_RUN=false
+  run notify_event deploy.success stack=my-stack
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "notify_event: only dispatches to subscribed providers" {
+  export DRY_RUN=false
+  export SLACK_WEBHOOK=https://hooks.example.com/slack
+  export SLACK_EVENTS=deploy.success
+  export DISCORD_WEBHOOK=https://discord.example.com/hook
+  export DISCORD_EVENTS=backup.success
+  NOTIFY_CONFIG_LOADED=true
+
+  run notify_event deploy.success stack=my-stack
+  [ "$status" -eq 0 ]
+  local trace
+  trace=$(cat "$CURL_TRACE")
+  [[ "$trace" == *"hooks.example.com/slack"* ]]
+  [[ "$trace" != *"discord.example.com"* ]]
+}
+
+@test "notify_event: wildcard provider receives all events" {
+  export DRY_RUN=false
+  export WEBHOOK_URL=https://ops.example.com/strut
+  export WEBHOOK_EVENTS="*"
+  NOTIFY_CONFIG_LOADED=true
+
+  run notify_event custom.event key=value
+  [ "$status" -eq 0 ]
+  grep -q "ops.example.com/strut" "$CURL_TRACE"
+}
+
+@test "notify_event: always returns 0 even when provider send fails" {
+  export DRY_RUN=false
+  export SLACK_WEBHOOK=https://hooks.example.com/slack
+  export SLACK_EVENTS="*"
+  NOTIFY_CONFIG_LOADED=true
+  # Force send function to fail
+  notify_slack_send() { return 1; }
+  export -f notify_slack_send
+
+  run notify_event deploy.success stack=x
+  [ "$status" -eq 0 ]
+}
+
+# ---------- _notify_payload_json ----------
+
+@test "_notify_payload_json: builds JSON with event key" {
+  run _notify_payload_json deploy.success
+  [ "$status" -eq 0 ]
+  [ "$output" = '{"event":"deploy.success"}' ]
+}
+
+@test "_notify_payload_json: appends key=value pairs" {
+  run _notify_payload_json deploy.success stack=my-stack env=prod
+  [ "$status" -eq 0 ]
+  [ "$output" = '{"event":"deploy.success","stack":"my-stack","env":"prod"}' ]
+}
+
+@test "_notify_payload_json: escapes double quotes in values" {
+  run _notify_payload_json some.event msg='hello "world"'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'\"world\"'* ]]
+}
+
+@test "_notify_payload_json: escapes backslashes in values" {
+  run _notify_payload_json some.event path='a\b\c'
+  [ "$status" -eq 0 ]
+  # Each `\` becomes `\\` (JSON-escaped); input has 3 → output has 6 backslashes
+  [[ "$output" == *'a\\b\\c'* ]]
+}
+
+# ---------- notify_test ----------
+
+@test "notify_test: empty provider name fails with usage" {
+  run notify_test ""
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "notify_test: unknown provider fails" {
+  run notify_test bogus
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unknown provider"* ]]
+}
+
+@test "notify_test: slack without SLACK_WEBHOOK configured fails" {
+  NOTIFY_CONFIG_LOADED=true
+  run notify_test slack
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"SLACK_WEBHOOK not configured"* ]]
+}
+
+@test "notify_test: slack with webhook configured sends test ping" {
+  export SLACK_WEBHOOK=https://hooks.example.com/slack
+  NOTIFY_CONFIG_LOADED=true
+  run notify_test slack
+  [ "$status" -eq 0 ]
+  grep -q "hooks.example.com/slack" "$CURL_TRACE"
+}


### PR DESCRIPTION
## Summary

- Event-driven notification dispatcher (`lib/notify.sh`) with Slack, Discord, and generic JSON webhook providers
- Config lives in `notifications.conf` at project root, flat shell-env style (matches `strut.conf` instead of INI — bash sources it natively)
- Wired `deploy.success` + `backup.success` events at the end of deploy and each backup-creation target

## Providers

| File | Format |
|---|---|
| `lib/notify/slack.sh` | Slack incoming webhook (`{"text": "..."}`) |
| `lib/notify/discord.sh` | Discord webhook (`{"content": "..."}`) |
| `lib/notify/webhook.sh` | Raw JSON (`{"event": "...", ...kv}`) |

## Config

```sh
# notifications.conf
SLACK_WEBHOOK=https://hooks.slack.com/services/...
SLACK_EVENTS=deploy.success,deploy.fail,health.fail

DISCORD_WEBHOOK=https://discord.com/api/webhooks/...
DISCORD_EVENTS=deploy.fail

WEBHOOK_URL=https://ops.example.com/strut
WEBHOOK_EVENTS=*
```

`*` subscribes to all events. Providers without a webhook URL are silently skipped.

## CLI

```sh
strut notify test slack
strut notify test discord
strut notify test webhook
```

Sends a `test.ping` event with stub payload.

## Safety

- `notify_event` **always returns 0** — a 5xx from Slack can't fail your deploy
- `_notify_payload_json` only emits explicit `key=value` pairs — never dumps env, addressing the secret-leak concern from #25
- `curl --max-time 5` caps hang risk
- Dry-run mode emits `[notify:dry-run] event=... payload=...` instead of calling providers

## Scope note

Only `deploy.success` and `backup.success` are wired in this PR. `deploy.fail` / `health.fail` / `backup.fail` / `drift.detected` will land when those failure paths get explicit error handling — wiring a fail event into a `fail()` call that unconditionally exits would require more restructuring than fits here.

## Test plan

- [x] 22 new tests in `tests/test_notify.bats` — subscription matching, config loading, dispatch, payload escaping, `notify_test`
- [x] Full suite: **683 passing, 0 failing**
- [ ] Manual end-to-end against a real Slack webhook
- [ ] Manual end-to-end against a real Discord webhook

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)