### PR TITLE
feat: add lib/output.sh table + JSON rendering helpers

### DIFF
--- a/lib/output.sh
+++ b/lib/output.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# ==================================================
+# lib/output.sh — Table + JSON rendering helpers
+# ==================================================
+# Unifies list/status/audit command output. Supports plain tables, JSON,
+# and a shared NO_COLOR / non-tty fallback so CI logs stay readable.
+#
+# Usage — table:
+#   out_table_header "Stack" "Health" "Last Deploy"
+#   out_table_row "api" "✓ healthy" "2h ago"
+#   out_table_row "worker" "⚠ degraded" "1d ago"
+#   out_table_render
+#
+# Usage — JSON (streamed; no buffering):
+#   out_json_object
+#     out_json_field env prod
+#     out_json_array stacks
+#       out_json_object
+#         out_json_field name api
+#         out_json_field health healthy
+#       out_json_close_object
+#     out_json_close_array
+#   out_json_close_object
+#
+# Mode selection:
+#   OUTPUT_MODE=json  → JSON helpers emit real JSON; table helpers are no-ops
+#   OUTPUT_MODE=text  → Table helpers render; JSON helpers are no-ops
+#   (unset)           → defaults to text; callers usually flip via --json
+
+set -euo pipefail
+
+# ── Internal state ────────────────────────────────────────────────────────────
+_OUT_TABLE_COLS=()
+_OUT_TABLE_ROWS=()       # Rows stored TSV-encoded (fields joined by \t)
+_OUT_TABLE_WIDTHS=()
+
+_OUT_JSON_STACK=()        # Stack of "object" | "array"
+_OUT_JSON_FIRST=()        # Parallel stack: 1 = first item in container
+
+# ── Environment helpers ───────────────────────────────────────────────────────
+
+# output_is_tty — returns 0 if stdout is a terminal
+output_is_tty() {
+  [ -t 1 ]
+}
+
+# output_use_color — returns 0 if color output is appropriate
+output_use_color() {
+  [ -z "${NO_COLOR:-}" ] && output_is_tty
+}
+
+# output_mode — resolves the effective mode (text|json)
+output_mode() {
+  case "${OUTPUT_MODE:-text}" in
+    json) echo json ;;
+    *)    echo text ;;
+  esac
+}
+
+# ── Table renderer ────────────────────────────────────────────────────────────
+
+# out_table_reset — clear any buffered table state
+out_table_reset() {
+  _OUT_TABLE_COLS=()
+  _OUT_TABLE_ROWS=()
+  _OUT_TABLE_WIDTHS=()
+}
+
+# out_table_header <col1> [col2...]
+#
+# Set column headers. Must be called before out_table_row.
+out_table_header() {
+  [ "$(output_mode)" = "json" ] && return 0
+  _OUT_TABLE_COLS=("$@")
+  _OUT_TABLE_WIDTHS=()
+  local c
+  for c in "$@"; do
+    _OUT_TABLE_WIDTHS+=("${#c}")
+  done
+}
+
+# out_table_row <val1> [val2...]
+#
+# Append a row. Values may contain ANSI color codes — width accounting
+# strips them so alignment stays correct.
+out_table_row() {
+  [ "$(output_mode)" = "json" ] && return 0
+  local i=0 v plain
+  local -a row=("$@")
+  # Track max width per column (based on visible/plain length)
+  for v in "$@"; do
+    plain=$(_out_strip_ansi "$v")
+    if [ "$i" -lt "${#_OUT_TABLE_WIDTHS[@]}" ]; then
+      [ "${#plain}" -gt "${_OUT_TABLE_WIDTHS[$i]}" ] && _OUT_TABLE_WIDTHS[$i]=${#plain}
+    else
+      _OUT_TABLE_WIDTHS+=("${#plain}")
+    fi
+    i=$((i + 1))
+  done
+  # Join with tab — tab is safe since we don't expect tabs in cell values
+  local IFS=$'\t'
+  _OUT_TABLE_ROWS+=("${row[*]}")
+}
+
+# out_table_render — emit the buffered table to stdout and reset
+out_table_render() {
+  [ "$(output_mode)" = "json" ] && { out_table_reset; return 0; }
+
+  # Header
+  if [ "${#_OUT_TABLE_COLS[@]}" -gt 0 ]; then
+    _out_print_row "$(output_use_color && echo 1 || echo 0)" "header" "${_OUT_TABLE_COLS[@]}"
+    _out_print_separator
+  fi
+
+  # Rows
+  local row
+  local IFS=$'\t'
+  for row in "${_OUT_TABLE_ROWS[@]+"${_OUT_TABLE_ROWS[@]}"}"; do
+    local -a fields
+    read -r -a fields <<<"$row"
+    _out_print_row "$(output_use_color && echo 1 || echo 0)" "cell" "${fields[@]}"
+  done
+
+  out_table_reset
+}
+
+# out_table_empty <message>
+#
+# Render a consistent "no results" line when the table would be empty.
+out_table_empty() {
+  [ "$(output_mode)" = "json" ] && return 0
+  local msg="${1:-(no results)}"
+  if output_use_color; then
+    printf '%b%s%b\n' "\033[2m" "$msg" "\033[0m"
+  else
+    printf '%s\n' "$msg"
+  fi
+}
+
+# ── Internal table helpers ────────────────────────────────────────────────────
+
+# _out_strip_ansi <text> — strip ESC[... codes for width accounting
+_out_strip_ansi() {
+  # Portable sed without GNU extensions: use perl-style escape
+  printf '%s' "$1" | sed $'s/\033\\[[0-9;]*m//g'
+}
+
+_out_print_row() {
+  local color="$1"; shift
+  local kind="$1"; shift
+  local i=0 val pad plain width out=""
+  for val in "$@"; do
+    width="${_OUT_TABLE_WIDTHS[$i]}"
+    plain=$(_out_strip_ansi "$val")
+    pad=$((width - ${#plain}))
+    if [ "$color" = "1" ] && [ "$kind" = "header" ]; then
+      out+=$(printf '\033[1m%s\033[0m' "$val")
+    else
+      out+="$val"
+    fi
+    if [ "$pad" -gt 0 ]; then
+      out+=$(printf '%*s' "$pad" '')
+    fi
+    i=$((i + 1))
+    [ "$i" -lt "$#" ] && out+="  "
+  done
+  printf '%s\n' "$out"
+}
+
+_out_print_separator() {
+  local total=0 w
+  for w in "${_OUT_TABLE_WIDTHS[@]}"; do
+    total=$((total + w))
+  done
+  # Account for 2-char gutters between columns
+  local gutters=$((${#_OUT_TABLE_WIDTHS[@]} > 0 ? (${#_OUT_TABLE_WIDTHS[@]} - 1) * 2 : 0))
+  total=$((total + gutters))
+  printf '%*s\n' "$total" '' | tr ' ' '-'
+}
+
+# ── JSON renderer ─────────────────────────────────────────────────────────────
+# Streaming helpers — emit JSON tokens directly to stdout. Callers maintain
+# structure by calling open/close in matching pairs. No buffering means
+# large result sets don't blow up memory.
+
+# _out_json_enabled — returns 0 if we should emit JSON
+_out_json_enabled() {
+  [ "$(output_mode)" = "json" ]
+}
+
+# _out_json_escape <string> — escape for JSON string literal (stdin passthrough)
+_out_json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  printf '%s' "$s"
+}
+
+_out_json_comma_if_needed() {
+  if [ "${#_OUT_JSON_STACK[@]}" -gt 0 ]; then
+    local depth=$((${#_OUT_JSON_STACK[@]} - 1))
+    if [ "${_OUT_JSON_FIRST[$depth]}" = "1" ]; then
+      _OUT_JSON_FIRST[$depth]=0
+    else
+      printf ','
+    fi
+  fi
+}
+
+# out_json_object — open an object. Use inside an array or at top level.
+out_json_object() {
+  _out_json_enabled || return 0
+  _out_json_comma_if_needed
+  printf '{'
+  _OUT_JSON_STACK+=("object")
+  _OUT_JSON_FIRST+=("1")
+}
+
+# out_json_close_object — close the current object
+out_json_close_object() {
+  _out_json_enabled || return 0
+  printf '}'
+  unset '_OUT_JSON_STACK[-1]'
+  unset '_OUT_JSON_FIRST[-1]'
+}
+
+# out_json_array <key> — open a keyed array inside an object
+out_json_array() {
+  _out_json_enabled || return 0
+  local key="$1"
+  _out_json_comma_if_needed
+  printf '"%s":[' "$(_out_json_escape "$key")"
+  _OUT_JSON_STACK+=("array")
+  _OUT_JSON_FIRST+=("1")
+}
+
+# out_json_close_array — close the current array
+out_json_close_array() {
+  _out_json_enabled || return 0
+  printf ']'
+  unset '_OUT_JSON_STACK[-1]'
+  unset '_OUT_JSON_FIRST[-1]'
+}
+
+# out_json_field <key> <value>
+#
+# Emit a string-valued key. Value is JSON-escaped. Use out_json_field_raw
+# for booleans or numbers (caller responsible for validity).
+out_json_field() {
+  _out_json_enabled || return 0
+  local key="$1" val="$2"
+  _out_json_comma_if_needed
+  printf '"%s":"%s"' "$(_out_json_escape "$key")" "$(_out_json_escape "$val")"
+}
+
+# out_json_field_raw <key> <raw_value>
+#
+# Emit key with unquoted raw value — used for booleans, numbers, nested JSON.
+out_json_field_raw() {
+  _out_json_enabled || return 0
+  local key="$1" val="$2"
+  _out_json_comma_if_needed
+  printf '"%s":%s' "$(_out_json_escape "$key")" "$val"
+}
+
+# out_json_string <value>
+#
+# Emit a bare string inside an array (no key).
+out_json_string() {
+  _out_json_enabled || return 0
+  local val="$1"
+  _out_json_comma_if_needed
+  printf '"%s"' "$(_out_json_escape "$val")"
+}
+
+# out_json_newline — emit a trailing newline after the root value closes
+out_json_newline() {
+  _out_json_enabled || return 0
+  printf '\n'
+}
+
+# out_json_reset — clear any partial JSON state (for error recovery)
+out_json_reset() {
+  _OUT_JSON_STACK=()
+  _OUT_JSON_FIRST=()
+}

--- a/strut
+++ b/strut
@@ -71,6 +71,7 @@ find_project_root || true  # OK if not in a project (init, --version, etc.)
 load_strut_config
 
 source "$LIB/utils.sh"
+source "$LIB/output.sh"
 source "$LIB/flags.sh"
 source "$LIB/hooks.sh"
 source "$LIB/notify.sh"
@@ -219,28 +220,64 @@ usage() {
 
 # ── list command ──────────────────────────────────────────────────────────────
 cmd_list() {
+  if [ ! -d "$CLI_ROOT/stacks" ]; then
+    if [ "$(output_mode)" = "json" ]; then
+      out_json_object
+        out_json_array "stacks"
+        out_json_close_array
+      out_json_close_object
+      out_json_newline
+    else
+      warn "No stacks/ directory found — run 'strut init' to get started"
+    fi
+    return 0
+  fi
+
+  if [ "$(output_mode)" = "json" ]; then
+    out_json_object
+      out_json_array "stacks"
+      local stack_dir
+      for stack_dir in "$CLI_ROOT/stacks"/*/; do
+        [ -d "$stack_dir" ] || continue
+        local name
+        name=$(basename "$stack_dir")
+        [ "$name" = "shared" ] && continue
+        local has_compose="false"
+        [ -f "$stack_dir/docker-compose.yml" ] && has_compose="true"
+        out_json_object
+          out_json_field "name" "$name"
+          out_json_field "path" "$stack_dir"
+          out_json_field_raw "has_compose" "$has_compose"
+        out_json_close_object
+      done
+      out_json_close_array
+    out_json_close_object
+    out_json_newline
+    return 0
+  fi
+
   echo ""
   echo -e "${BLUE}Available stacks:${NC}"
   echo ""
-  if [ -d "$CLI_ROOT/stacks" ]; then
-    local found=false
-    for stack_dir in "$CLI_ROOT/stacks"/*/; do
-      [ -d "$stack_dir" ] || continue
-      local name
-      name=$(basename "$stack_dir")
-      [ "$name" = "shared" ] && continue
-      found=true
-      if [ -f "$stack_dir/docker-compose.yml" ]; then
-        echo -e "  ${GREEN}✓${NC} $name   ($stack_dir)"
-      else
-        echo -e "  ${YELLOW}?${NC} $name   (no docker-compose.yml)"
-      fi
-    done
-    if ! $found; then
-      echo "  (none — run 'strut scaffold <name>' to create one)"
+  out_table_header "Stack" "Compose" "Path"
+  local found=false
+  for stack_dir in "$CLI_ROOT/stacks"/*/; do
+    [ -d "$stack_dir" ] || continue
+    local name
+    name=$(basename "$stack_dir")
+    [ "$name" = "shared" ] && continue
+    found=true
+    if [ -f "$stack_dir/docker-compose.yml" ]; then
+      out_table_row "$name" "✓" "$stack_dir"
+    else
+      out_table_row "$name" "?" "$stack_dir"
     fi
+  done
+  if $found; then
+    out_table_render
   else
-    warn "No stacks/ directory found — run 'strut init' to get started"
+    out_table_reset
+    echo "  (none — run 'strut scaffold <name>' to create one)"
   fi
   echo ""
 }
@@ -298,7 +335,15 @@ case "${1:-}" in
     fi
     exit 0
     ;;
-  list|--list|-l) cmd_list; exit 0 ;;
+  list|--list|-l)
+    shift
+    # Honor --json for CI consumption
+    for _arg in "$@"; do
+      if [ "$_arg" = "--json" ]; then OUTPUT_MODE=json; break; fi
+    done
+    cmd_list
+    exit 0
+    ;;
   scaffold)       cmd_scaffold "${2:-}"; exit 0 ;;
   doctor)
     shift

--- a/tests/test_output.bats
+++ b/tests/test_output.bats
@@ -1,0 +1,246 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_output.bats — Tests for lib/output.sh
+# ==================================================
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_utils
+  source "$CLI_ROOT/lib/output.sh"
+
+  unset OUTPUT_MODE
+  unset NO_COLOR
+  out_table_reset
+  out_json_reset
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------- output_mode ----------
+
+@test "output_mode: defaults to text" {
+  run output_mode
+  [ "$output" = "text" ]
+}
+
+@test "output_mode: json when OUTPUT_MODE=json" {
+  OUTPUT_MODE=json run output_mode
+  [ "$output" = "json" ]
+}
+
+@test "output_mode: unknown value falls back to text" {
+  OUTPUT_MODE=xml run output_mode
+  [ "$output" = "text" ]
+}
+
+# ---------- output_use_color ----------
+
+@test "output_use_color: false when NO_COLOR set" {
+  NO_COLOR=1 run output_use_color
+  [ "$status" -ne 0 ]
+}
+
+@test "output_use_color: false when not a tty (run always pipes)" {
+  unset NO_COLOR
+  run output_use_color
+  [ "$status" -ne 0 ]
+}
+
+# ---------- Table renderer ----------
+
+@test "out_table_header + render: empty table prints header + separator" {
+  out_table_header "Name" "Status"
+  run out_table_render
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Name"* ]]
+  [[ "$output" == *"Status"* ]]
+  [[ "$output" == *"---"* ]]
+}
+
+@test "out_table_row: values appear in rendered output" {
+  out_table_header "Name" "Status"
+  out_table_row "api" "healthy"
+  out_table_row "worker" "degraded"
+  run out_table_render
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"api"* ]]
+  [[ "$output" == *"healthy"* ]]
+  [[ "$output" == *"worker"* ]]
+  [[ "$output" == *"degraded"* ]]
+}
+
+@test "out_table_row: widens column when value longer than header" {
+  out_table_header "N" "S"
+  out_table_row "longer-name" "x"
+  run out_table_render
+  [ "$status" -eq 0 ]
+  # The separator line width should reflect the expanded column
+  [[ "$output" == *"longer-name"* ]]
+}
+
+@test "out_table: json mode is a no-op" {
+  OUTPUT_MODE=json
+  out_table_header "Name" "Status"
+  out_table_row "api" "healthy"
+  run out_table_render
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "out_table_empty: renders fallback message" {
+  run out_table_empty "no backups found"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no backups found"* ]]
+}
+
+@test "out_table_empty: default message when none given" {
+  run out_table_empty
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"(no results)"* ]]
+}
+
+@test "out_table_empty: silent in json mode" {
+  OUTPUT_MODE=json run out_table_empty "nothing"
+  [ -z "$output" ]
+}
+
+@test "_out_strip_ansi: removes color codes for width calc" {
+  run _out_strip_ansi $'\033[31mRED\033[0m'
+  [ "$output" = "RED" ]
+}
+
+# ---------- JSON renderer ----------
+
+@test "out_json_object: bare object with single field" {
+  export OUTPUT_MODE=json
+  run bash -c '
+    source "'"$CLI_ROOT"'/lib/output.sh"
+    out_json_object
+      out_json_field "name" "api"
+    out_json_close_object
+    out_json_newline
+  '
+  [ "$status" -eq 0 ]
+  [ "$output" = '{"name":"api"}' ]
+}
+
+@test "out_json_object: multiple fields separated by commas" {
+  export OUTPUT_MODE=json
+  run bash -c '
+    source "'"$CLI_ROOT"'/lib/output.sh"
+    out_json_object
+      out_json_field "name" "api"
+      out_json_field "env" "prod"
+    out_json_close_object
+  '
+  [ "$status" -eq 0 ]
+  [ "$output" = '{"name":"api","env":"prod"}' ]
+}
+
+@test "out_json_array: keyed array with string elements" {
+  export OUTPUT_MODE=json
+  run bash -c '
+    source "'"$CLI_ROOT"'/lib/output.sh"
+    out_json_object
+      out_json_array "stacks"
+        out_json_string "api"
+        out_json_string "worker"
+      out_json_close_array
+    out_json_close_object
+  '
+  [ "$status" -eq 0 ]
+  [ "$output" = '{"stacks":["api","worker"]}' ]
+}
+
+@test "out_json: nested objects inside array" {
+  export OUTPUT_MODE=json
+  run bash -c '
+    source "'"$CLI_ROOT"'/lib/output.sh"
+    out_json_object
+      out_json_array "stacks"
+        out_json_object
+          out_json_field "name" "api"
+          out_json_field "health" "ok"
+        out_json_close_object
+        out_json_object
+          out_json_field "name" "worker"
+          out_json_field "health" "down"
+        out_json_close_object
+      out_json_close_array
+    out_json_close_object
+  '
+  [ "$status" -eq 0 ]
+  [ "$output" = '{"stacks":[{"name":"api","health":"ok"},{"name":"worker","health":"down"}]}' ]
+}
+
+@test "out_json_field_raw: emits unquoted numeric values" {
+  export OUTPUT_MODE=json
+  run bash -c '
+    source "'"$CLI_ROOT"'/lib/output.sh"
+    out_json_object
+      out_json_field_raw "count" "42"
+      out_json_field_raw "enabled" "true"
+    out_json_close_object
+  '
+  [ "$status" -eq 0 ]
+  [ "$output" = '{"count":42,"enabled":true}' ]
+}
+
+@test "out_json_field: escapes double quotes" {
+  export OUTPUT_MODE=json
+  run bash -c '
+    source "'"$CLI_ROOT"'/lib/output.sh"
+    out_json_object
+      out_json_field "msg" "he said \"hi\""
+    out_json_close_object
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'\"hi\"'* ]]
+}
+
+@test "out_json_field: escapes backslashes" {
+  export OUTPUT_MODE=json
+  run bash -c '
+    source "'"$CLI_ROOT"'/lib/output.sh"
+    out_json_object
+      out_json_field "path" "a\\b"
+    out_json_close_object
+  '
+  [ "$status" -eq 0 ]
+  # The value `a\b` → JSON `a\\b`
+  [[ "$output" == *'"path":"a\\b"'* ]]
+}
+
+@test "out_json_field: escapes newlines to \\n" {
+  export OUTPUT_MODE=json
+  run bash -c "
+    source \"$CLI_ROOT/lib/output.sh\"
+    out_json_object
+      out_json_field 'msg' \$'line1\\nline2'
+    out_json_close_object
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'line1\nline2'* ]]
+}
+
+@test "out_json: helpers are no-ops in text mode" {
+  OUTPUT_MODE=text
+  run bash -c '
+    source "'"$CLI_ROOT"'/lib/output.sh"
+    out_json_object
+      out_json_field "name" "api"
+    out_json_close_object
+  '
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "out_json_reset: clears partial state" {
+  OUTPUT_MODE=json
+  out_json_object
+  [ "${#_OUT_JSON_STACK[@]}" -gt 0 ]
+  out_json_reset
+  [ "${#_OUT_JSON_STACK[@]}" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- New `lib/output.sh` with table and streaming JSON helpers
- Shared `OUTPUT_MODE` switch — same producer code renders text or JSON depending on caller preference
- Retrofits `strut list` as the first consumer and gains a `--json` flag for it

## API quick tour

```bash
# Tables — columns auto-size; ANSI stripped for width accounting
out_table_header "Stack" "Health" "Last Deploy"
out_table_row    "api"   "✓ healthy" "2h ago"
out_table_render

# Streaming JSON — no buffering
out_json_object
  out_json_array "stacks"
    out_json_object
      out_json_field "name" "api"
      out_json_field_raw "healthy" "true"
    out_json_close_object
  out_json_close_array
out_json_close_object
```

- `output_mode` → `text` (default) / `json` (via `OUTPUT_MODE=json`)
- Text mode: table helpers render; JSON helpers are no-ops
- JSON mode: JSON helpers emit; table helpers are no-ops
- `output_use_color` honors `NO_COLOR` and non-tty

## Scope decisions

- **Only `strut list` retrofitted here.** `keys status` and `backup list` already have their own JSON formats — switching them without a redesign would break downstream CI scripts. Those move over in follow-ups once #22 and #41 establish the canonical fields.
- **Streaming, not buffered.** JSON helpers write tokens directly to stdout so listing 100+ backups doesn't blow up memory. The trade-off: callers must open/close containers in matching pairs.

## Test plan

- [x] 23 new tests in `tests/test_output.bats` covering mode resolution, color gating, table widths, JSON nesting, escape handling
- [x] Full BATS suite green (706 passing, 0 failing)
- [x] Manual smoke: `strut list` renders aligned table, `strut list --json` produces valid JSON

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)