### PR TITLE
feat: add strut status-all dashboard command

### DIFF
--- a/lib/cmd_status_all.sh
+++ b/lib/cmd_status_all.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# ==================================================
+# lib/cmd_status_all.sh — Multi-stack dashboard
+# ==================================================
+# `strut status-all [--env <name>] [--json]`
+# Shows a one-screen overview of every stack: health, last deploy, backup
+# age, drift status. Designed to be fast — reads file mtimes and minimal
+# docker output, not full HTTP health probes.
+
+set -euo pipefail
+
+# ── Time helpers ──────────────────────────────────────────────────────────────
+
+# _status_mtime <path> — emit unix epoch mtime, or empty if missing
+_status_mtime() {
+  local p="$1"
+  [ -e "$p" ] || return 0
+  if stat -f %m "$p" 2>/dev/null; then
+    :
+  else
+    stat -c %Y "$p" 2>/dev/null || true
+  fi
+}
+
+# _status_humanize_age <seconds> — "4h ago", "2d ago", etc.
+_status_humanize_age() {
+  local secs="$1"
+  [ -z "$secs" ] && { echo "-"; return; }
+  if [ "$secs" -lt 60 ]; then
+    echo "${secs}s ago"
+  elif [ "$secs" -lt 3600 ]; then
+    echo "$((secs / 60))m ago"
+  elif [ "$secs" -lt 86400 ]; then
+    echo "$((secs / 3600))h ago"
+  else
+    echo "$((secs / 86400))d ago"
+  fi
+}
+
+# _status_newest_mtime <dir> <glob> — newest mtime of files matching the glob
+_status_newest_mtime() {
+  local dir="$1"
+  local pattern="$2"
+  [ -d "$dir" ] || return 0
+  local f newest="" newest_ts=""
+  for f in "$dir"/$pattern; do
+    [ -e "$f" ] || continue
+    local ts
+    ts=$(_status_mtime "$f")
+    [ -z "$ts" ] && continue
+    if [ -z "$newest_ts" ] || [ "$ts" -gt "$newest_ts" ]; then
+      newest_ts="$ts"
+      newest="$f"
+    fi
+  done
+  echo "$newest_ts"
+}
+
+# ── Per-stack collectors ──────────────────────────────────────────────────────
+
+# _status_last_deploy <stack> — epoch of newest rollback snapshot, or empty
+_status_last_deploy() {
+  local stack="$1"
+  _status_newest_mtime "$CLI_ROOT/stacks/$stack/.rollback" "*.json"
+}
+
+# _status_backup_age <stack> — epoch of newest backup file, or empty
+_status_backup_age() {
+  local stack="$1"
+  local stack_dir="$CLI_ROOT/stacks/$stack"
+  local dir="${BACKUP_LOCAL_DIR:-$stack_dir/backups}"
+  _status_newest_mtime "$dir" "*"
+}
+
+# _status_drift_count <stack> — cached drift file count, or "-"
+_status_drift_count() {
+  local stack="$1"
+  local drift_file="$CLI_ROOT/stacks/$stack/metrics/drift.prom"
+  if [ -f "$drift_file" ]; then
+    # Extract ch_deploy_drift_files_count <number>
+    local n
+    n=$(grep -E '^ch_deploy_drift_files_count\{' "$drift_file" 2>/dev/null \
+          | awk '{print $NF}' | head -1)
+    echo "${n:-0}"
+  else
+    echo "-"
+  fi
+}
+
+# _status_health <stack> <env_name> — emits one of: healthy | degraded | down | unknown
+#
+# Fast check — runs `docker compose ps` and aggregates container State.
+# Returns "unknown" if compose isn't available or the stack has no
+# docker-compose.yml.
+_status_health() {
+  local stack="$1"
+  local env_name="${2:-}"
+  local stack_dir="$CLI_ROOT/stacks/$stack"
+
+  [ -f "$stack_dir/docker-compose.yml" ] || { echo "unknown"; return; }
+  command -v docker >/dev/null 2>&1 || { echo "unknown"; return; }
+
+  local env_file
+  if [ -n "$env_name" ]; then
+    env_file="$CLI_ROOT/.$env_name.env"
+  else
+    env_file="$CLI_ROOT/.env"
+  fi
+
+  local compose_cmd
+  if ! compose_cmd=$(resolve_compose_cmd "$stack" "$env_file" "" 2>/dev/null); then
+    echo "unknown"
+    return
+  fi
+
+  local ps_output
+  if ! ps_output=$($compose_cmd ps --format '{{.State}}' 2>/dev/null); then
+    echo "unknown"
+    return
+  fi
+
+  [ -z "$ps_output" ] && { echo "down"; return; }
+
+  local total=0 running=0 other=0
+  while IFS= read -r state; do
+    [ -z "$state" ] && continue
+    total=$((total + 1))
+    case "$state" in
+      running) running=$((running + 1)) ;;
+      *)       other=$((other + 1)) ;;
+    esac
+  done <<<"$ps_output"
+
+  if [ "$total" -eq 0 ]; then
+    echo "down"
+  elif [ "$running" -eq "$total" ]; then
+    echo "healthy"
+  elif [ "$running" -eq 0 ]; then
+    echo "down"
+  else
+    echo "degraded"
+  fi
+}
+
+# _status_health_glyph <health> — colored symbol for text mode
+_status_health_glyph() {
+  local health="$1"
+  case "$health" in
+    healthy)  echo -e "${GREEN}✓${NC} healthy" ;;
+    degraded) echo -e "${YELLOW}⚠${NC} degraded" ;;
+    down)     echo -e "${RED}✗${NC} down" ;;
+    *)        echo "? unknown" ;;
+  esac
+}
+
+# ── Dashboard command ────────────────────────────────────────────────────────
+
+# cmd_status_all [--env <name>] [--json]
+cmd_status_all() {
+  local env_name=""
+  local json_mode="false"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --env=*)     env_name="${1#*=}"; shift ;;
+      --env)       env_name="${2:-}"; shift 2 ;;
+      --json)      json_mode="true"; shift ;;
+      --help|-h)
+        cat <<'EOF'
+Usage: strut status-all [--env <name>] [--json]
+
+Dashboard showing health, last deploy, backup age, and drift status
+across every stack.
+
+Flags:
+  --env <name>     Filter to a specific environment (default: unscoped)
+  --json           Output structured JSON for CI/dashboards
+EOF
+        return 0
+        ;;
+      *) fail "Unknown flag: $1"; return 1 ;;
+    esac
+  done
+
+  if [ ! -d "$CLI_ROOT/stacks" ]; then
+    fail "No stacks/ directory found — run 'strut init' to get started"
+    return 1
+  fi
+
+  local -a stacks=()
+  local stack_dir name
+  for stack_dir in "$CLI_ROOT/stacks"/*/; do
+    [ -d "$stack_dir" ] || continue
+    name=$(basename "$stack_dir")
+    [ "$name" = "shared" ] && continue
+    stacks+=("$name")
+  done
+
+  [ "${#stacks[@]}" -eq 0 ] && {
+    if [ "$json_mode" = "true" ]; then
+      echo '{"timestamp":"'"$(date -u +%FT%TZ)"'","stacks":[],"summary":{"total":0,"healthy":0,"degraded":0,"down":0}}'
+      return 0
+    fi
+    warn "No stacks found — run 'strut scaffold <name>' to create one"
+    return 0
+  }
+
+  # Collect status for each stack
+  local now
+  now=$(date +%s)
+
+  local total=0 healthy=0 degraded=0 down=0 unknown=0
+  local -a rows_stack rows_health rows_deploy rows_backup rows_drift
+
+  for name in "${stacks[@]}"; do
+    total=$((total + 1))
+    local health deploy_ts backup_ts drift_count
+    health=$(_status_health "$name" "$env_name")
+    deploy_ts=$(_status_last_deploy "$name")
+    backup_ts=$(_status_backup_age "$name")
+    drift_count=$(_status_drift_count "$name")
+
+    case "$health" in
+      healthy)  healthy=$((healthy + 1)) ;;
+      degraded) degraded=$((degraded + 1)) ;;
+      down)     down=$((down + 1)) ;;
+      *)        unknown=$((unknown + 1)) ;;
+    esac
+
+    local deploy_age="-" backup_age="-"
+    [ -n "$deploy_ts" ] && deploy_age=$(_status_humanize_age $((now - deploy_ts)))
+    [ -n "$backup_ts" ] && backup_age=$(_status_humanize_age $((now - backup_ts)))
+
+    local drift_label
+    case "$drift_count" in
+      "-") drift_label="-" ;;
+      0)   drift_label="clean" ;;
+      1)   drift_label="1 file" ;;
+      *)   drift_label="$drift_count files" ;;
+    esac
+
+    rows_stack+=("$name")
+    rows_health+=("$health")
+    rows_deploy+=("$deploy_age")
+    rows_backup+=("$backup_age")
+    rows_drift+=("$drift_label")
+  done
+
+  if [ "$json_mode" = "true" ]; then
+    OUTPUT_MODE=json
+    out_json_object
+      out_json_field "timestamp" "$(date -u +%FT%TZ)"
+      [ -n "$env_name" ] && out_json_field "env" "$env_name"
+      out_json_array "stacks"
+        local i
+        for i in "${!rows_stack[@]}"; do
+          out_json_object
+            out_json_field "name" "${rows_stack[$i]}"
+            out_json_field "health" "${rows_health[$i]}"
+            out_json_field "last_deploy" "${rows_deploy[$i]}"
+            out_json_field "backup_age" "${rows_backup[$i]}"
+            out_json_field "drift_status" "${rows_drift[$i]}"
+          out_json_close_object
+        done
+      out_json_close_array
+      out_json_field_raw "summary" "{\"total\":$total,\"healthy\":$healthy,\"degraded\":$degraded,\"down\":$down,\"unknown\":$unknown}"
+    out_json_close_object
+    out_json_newline
+  else
+    echo ""
+    local title="strut Dashboard"
+    [ -n "$env_name" ] && title="$title ($env_name)"
+    echo -e "${BLUE}${title}${NC}"
+    echo ""
+    out_table_header "Stack" "Health" "Last Deploy" "Backup Age" "Drift"
+    local i
+    for i in "${!rows_stack[@]}"; do
+      out_table_row \
+        "${rows_stack[$i]}" \
+        "$(_status_health_glyph "${rows_health[$i]}")" \
+        "${rows_deploy[$i]}" \
+        "${rows_backup[$i]}" \
+        "${rows_drift[$i]}"
+    done
+    out_table_render
+    echo ""
+    echo "$healthy healthy, $degraded degraded, $down down$([ "$unknown" -gt 0 ] && echo ", $unknown unknown")"
+    echo ""
+  fi
+
+  # Exit code: 0 if no down/degraded, 1 otherwise
+  if [ "$down" -gt 0 ] || [ "$degraded" -gt 0 ]; then
+    return 1
+  fi
+  return 0
+}

--- a/strut
+++ b/strut
@@ -164,6 +164,7 @@ usage() {
   echo "  keys     <subcommand> [options]                                Key management (SSH, API, env, GitHub)"
   echo "  domain   <domain> <email> [--skip-ssl]                         Configure domain/SSL"
   echo "  list                                                           List stacks"
+  echo "  status-all [--env <name>] [--json]                             Dashboard across all stacks"
   echo "  scaffold <new-stack-name>                                      New stack"
   echo "  init     [--registry <type>] [--org <name>]                    Initialize new project"
   echo "  upgrade                                                        Upgrade strut to latest version"
@@ -349,6 +350,12 @@ case "${1:-}" in
     shift
     source "$LIB/cmd_doctor.sh"
     cmd_doctor "$@"
+    exit $?
+    ;;
+  status-all)
+    shift
+    source "$LIB/cmd_status_all.sh"
+    cmd_status_all "$@"
     exit $?
     ;;
 

--- a/tests/test_status_all.bats
+++ b/tests/test_status_all.bats
@@ -1,0 +1,251 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_status_all.bats — Tests for strut status-all dashboard
+# ==================================================
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_utils
+  source "$CLI_ROOT/lib/output.sh"
+
+  # Point CLI_ROOT at an isolated tree so tests don't see real stacks
+  export REAL_CLI_ROOT="$CLI_ROOT"
+  export CLI_ROOT="$TEST_TMP"
+  mkdir -p "$CLI_ROOT/stacks"
+
+  source "$REAL_CLI_ROOT/lib/cmd_status_all.sh"
+
+  # Stub resolve_compose_cmd so health probes don't hit real docker
+  resolve_compose_cmd() { echo "echo running"; return 0; }
+  export -f resolve_compose_cmd
+}
+
+teardown() {
+  common_teardown
+}
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+_make_stack() {
+  local name="$1"
+  mkdir -p "$CLI_ROOT/stacks/$name"
+  touch "$CLI_ROOT/stacks/$name/docker-compose.yml"
+}
+
+_add_rollback() {
+  local stack="$1"
+  local age_secs="${2:-3600}"
+  mkdir -p "$CLI_ROOT/stacks/$stack/.rollback"
+  local f="$CLI_ROOT/stacks/$stack/.rollback/$(date +%Y%m%d-%H%M%S).json"
+  echo '{"timestamp":"test"}' > "$f"
+  if [ "$age_secs" -gt 0 ]; then
+    # Set mtime in the past
+    local ts
+    ts=$(($(date +%s) - age_secs))
+    touch -t "$(date -r "$ts" +%Y%m%d%H%M.%S 2>/dev/null || date -d "@$ts" +%Y%m%d%H%M.%S)" "$f"
+  fi
+}
+
+_add_backup() {
+  local stack="$1"
+  local age_secs="${2:-7200}"
+  mkdir -p "$CLI_ROOT/stacks/$stack/backups"
+  local f="$CLI_ROOT/stacks/$stack/backups/postgres-test.sql"
+  echo "backup" > "$f"
+  if [ "$age_secs" -gt 0 ]; then
+    local ts
+    ts=$(($(date +%s) - age_secs))
+    touch -t "$(date -r "$ts" +%Y%m%d%H%M.%S 2>/dev/null || date -d "@$ts" +%Y%m%d%H%M.%S)" "$f"
+  fi
+}
+
+# ── Age humanizer ──────────────────────────────────────────────────────────────
+
+@test "_status_humanize_age: seconds" {
+  run _status_humanize_age 30
+  [ "$output" = "30s ago" ]
+}
+
+@test "_status_humanize_age: minutes" {
+  run _status_humanize_age 600
+  [ "$output" = "10m ago" ]
+}
+
+@test "_status_humanize_age: hours" {
+  run _status_humanize_age 7200
+  [ "$output" = "2h ago" ]
+}
+
+@test "_status_humanize_age: days" {
+  run _status_humanize_age 172800
+  [ "$output" = "2d ago" ]
+}
+
+@test "_status_humanize_age: empty input returns dash" {
+  run _status_humanize_age ""
+  [ "$output" = "-" ]
+}
+
+# ── Health detection ──────────────────────────────────────────────────────────
+
+@test "_status_health: no compose file returns unknown" {
+  mkdir -p "$CLI_ROOT/stacks/empty"
+  run _status_health empty
+  [ "$output" = "unknown" ]
+}
+
+@test "_status_health: no docker on PATH returns unknown" {
+  _make_stack api
+  # Force command -v docker to fail
+  PATH="" run _status_health api
+  [ "$output" = "unknown" ]
+}
+
+# ── Drift count ────────────────────────────────────────────────────────────────
+
+@test "_status_drift_count: no metrics file returns dash" {
+  _make_stack api
+  run _status_drift_count api
+  [ "$output" = "-" ]
+}
+
+@test "_status_drift_count: reads count from drift.prom" {
+  _make_stack api
+  mkdir -p "$CLI_ROOT/stacks/api/metrics"
+  cat > "$CLI_ROOT/stacks/api/metrics/drift.prom" <<'EOF'
+# HELP ch_deploy_drift_files_count drift
+# TYPE ch_deploy_drift_files_count gauge
+ch_deploy_drift_files_count{stack="api",env="prod"} 3
+EOF
+  run _status_drift_count api
+  [ "$output" = "3" ]
+}
+
+@test "_status_drift_count: zero count" {
+  _make_stack api
+  mkdir -p "$CLI_ROOT/stacks/api/metrics"
+  cat > "$CLI_ROOT/stacks/api/metrics/drift.prom" <<'EOF'
+ch_deploy_drift_files_count{stack="api",env="prod"} 0
+EOF
+  run _status_drift_count api
+  [ "$output" = "0" ]
+}
+
+# ── Last deploy / backup age ─────────────────────────────────────────────────
+
+@test "_status_last_deploy: empty when no rollback dir" {
+  _make_stack api
+  run _status_last_deploy api
+  [ -z "$output" ]
+}
+
+@test "_status_last_deploy: returns a timestamp when snapshot exists" {
+  _make_stack api
+  _add_rollback api 120
+  run _status_last_deploy api
+  # Non-empty numeric
+  [[ "$output" =~ ^[0-9]+$ ]]
+}
+
+@test "_status_backup_age: empty when no backups dir" {
+  _make_stack api
+  run _status_backup_age api
+  [ -z "$output" ]
+}
+
+@test "_status_backup_age: returns a timestamp when backup exists" {
+  _make_stack api
+  _add_backup api 3600
+  run _status_backup_age api
+  [[ "$output" =~ ^[0-9]+$ ]]
+}
+
+# ── Dashboard command ─────────────────────────────────────────────────────────
+
+@test "cmd_status_all: no stacks directory fails" {
+  rm -rf "$CLI_ROOT/stacks"
+  run cmd_status_all
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"No stacks"* ]]
+}
+
+@test "cmd_status_all: empty stacks dir — JSON mode returns zero-summary" {
+  run cmd_status_all --json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"total":0'* ]]
+  [[ "$output" == *'"stacks":[]'* ]]
+}
+
+@test "cmd_status_all: empty stacks dir — text mode warns and exits 0" {
+  run cmd_status_all
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No stacks found"* ]]
+}
+
+@test "cmd_status_all: text mode renders header and stack row" {
+  _make_stack api
+  _add_rollback api 7200
+  _add_backup api 14400
+  run cmd_status_all
+  [[ "$output" == *"Dashboard"* ]]
+  [[ "$output" == *"Stack"* ]]
+  [[ "$output" == *"api"* ]]
+  [[ "$output" == *"2h ago"* ]]
+  [[ "$output" == *"4h ago"* ]]
+}
+
+@test "cmd_status_all: json mode produces valid structure" {
+  _make_stack api
+  _make_stack worker
+  run cmd_status_all --json
+  [ "$status" -eq 0 ] || [ "$status" -eq 1 ]  # exit 1 if any down
+  [[ "$output" == *'"timestamp":'* ]]
+  [[ "$output" == *'"stacks":['* ]]
+  [[ "$output" == *'"name":"api"'* ]]
+  [[ "$output" == *'"name":"worker"'* ]]
+  [[ "$output" == *'"summary":'* ]]
+  [[ "$output" == *'"total":2'* ]]
+}
+
+@test "cmd_status_all: --env propagates to json output" {
+  _make_stack api
+  run cmd_status_all --env prod --json
+  [[ "$output" == *'"env":"prod"'* ]]
+}
+
+@test "cmd_status_all: skips 'shared' directory" {
+  _make_stack api
+  mkdir -p "$CLI_ROOT/stacks/shared"
+  run cmd_status_all --json
+  [[ "$output" != *'"name":"shared"'* ]]
+  [[ "$output" == *'"name":"api"'* ]]
+}
+
+@test "cmd_status_all: unknown flag fails" {
+  run cmd_status_all --bogus
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unknown flag"* ]]
+}
+
+@test "cmd_status_all: --help prints usage without failing" {
+  run cmd_status_all --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage"* ]]
+  [[ "$output" == *"status-all"* ]]
+}
+
+@test "cmd_status_all: exit 1 when a stack is down" {
+  _make_stack api
+  # Force health=down via a stub that echoes down
+  _status_health() { echo "down"; }
+  export -f _status_health
+  run cmd_status_all
+  [ "$status" -eq 1 ]
+}
+
+@test "cmd_status_all: exit 0 when all stacks unknown (no docker)" {
+  _make_stack api
+  # Override PATH so docker isn't found
+  PATH="" run cmd_status_all
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- New `strut status-all [--env <name>] [--json]` command — one-screen overview of every stack
- Shows health, last deploy, backup age, drift status per stack plus aggregated summary
- Designed to stay fast — reads mtimes and minimal `docker compose ps` output, no HTTP probes, no SSH

## Example

```
strut Dashboard (prod)

Stack     Health       Last Deploy  Backup Age  Drift
------------------------------------------------------
api       ✓ healthy    2h ago       4h ago      clean
worker    ⚠ degraded   1d ago       6h ago      -
legacy    ? unknown    -            -           -

1 healthy, 1 degraded, 0 down, 1 unknown
```

JSON mode (`--json`) returns structured payload with a per-stack list and a `summary` object — ready for CI consumption or dashboards.

## Data sources

| Column | Source | Notes |
|---|---|---|
| Health | `docker compose ps --format '{{.State}}'` | Aggregates running/total → `healthy \| degraded \| down`. `unknown` when compose missing. |
| Last deploy | `stacks/<stack>/.rollback/*.json` newest mtime | Zero-cost file stat |
| Backup age | `stacks/<stack>/backups/*` newest mtime | Honors `BACKUP_LOCAL_DIR` |
| Drift | `metrics/drift.prom` cached count | `-` if no drift check has run. Full drift check stays out of the hot path (SSH-bound). |

## Exit codes

- `0` — all stacks healthy or unknown (nothing observably failing)
- `1` — any stack `down` or `degraded` (so CI alerts)

## Uses lib/output.sh

Both renderers (table + JSON) come from the helpers landed in #60 — no custom column math here.

## Test plan

- [x] 25 new tests in `tests/test_status_all.bats` — age humanization, health detection (no compose, no docker), drift parsing, deploy/backup collection, dashboard rendering in text+JSON, `--env` filter, shared-dir skip, unknown-flag rejection, `--help`, exit codes
- [x] Full BATS suite: **731 passing, 0 failing**
- [ ] Manual end-to-end against a real multi-stack project

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)