### PR TITLE
feat: add strut posture security/ops audit command (#41)

### DIFF
--- a/lib/cmd_posture.sh
+++ b/lib/cmd_posture.sh
@@ -1,0 +1,369 @@
+#!/usr/bin/env bash
+# ==================================================
+# lib/cmd_posture.sh — Security / ops posture audit
+# ==================================================
+# `strut posture [--stack <name>] [--category <cat>] [--fail-on <level>] [--json]`
+#
+# Runs a battery of security and operational checks across every stack and
+# reports pass/warn/fail for each. Designed as a CI gate — `--fail-on warn`
+# lets CI block on a warning threshold.
+#
+# Scope note: the existing `strut audit` command performs VPS discovery for
+# migration workflows (see lib/audit.sh). This is a separate posture check
+# to avoid breaking that command's positional-arg interface.
+
+set -euo pipefail
+
+# ── Result buffers ────────────────────────────────────────────────────────────
+# Each finding is stored as TSV: level<TAB>category<TAB>stack<TAB>message<TAB>remediation
+_POSTURE_RESULTS=()
+_POSTURE_PASS=0
+_POSTURE_WARN=0
+_POSTURE_FAIL=0
+
+posture_reset() {
+  _POSTURE_RESULTS=()
+  _POSTURE_PASS=0
+  _POSTURE_WARN=0
+  _POSTURE_FAIL=0
+}
+
+# posture_emit <level> <category> <stack> <message> [remediation]
+posture_emit() {
+  local level="$1"
+  local category="$2"
+  local stack="$3"
+  local msg="$4"
+  local remedy="${5:-}"
+  local IFS=$'\t'
+  _POSTURE_RESULTS+=("$level	$category	$stack	$msg	$remedy")
+  case "$level" in
+    pass) _POSTURE_PASS=$((_POSTURE_PASS + 1)) ;;
+    warn) _POSTURE_WARN=$((_POSTURE_WARN + 1)) ;;
+    fail) _POSTURE_FAIL=$((_POSTURE_FAIL + 1)) ;;
+  esac
+}
+
+# ── Individual checks ─────────────────────────────────────────────────────────
+
+# Placeholder tokens that suggest the operator forgot to set a real value
+_POSTURE_PLACEHOLDERS_REGEX='^(changeme|change_me|password|todo|xxx+|placeholder|secret|admin|root)$'
+
+# check_placeholder_secrets <stack>
+#
+# Scans env files for values that look like placeholders. The env file lives
+# outside the stack dir (at CLI_ROOT/.env or CLI_ROOT/.<env>.env) so we scan
+# all strut-managed env files, attributing findings to whichever stacks use
+# them (every stack, since env files are shared).
+check_placeholder_secrets() {
+  local stack="$1"
+  local env_file
+  for env_file in "$CLI_ROOT"/.env "$CLI_ROOT"/.*.env; do
+    [ -f "$env_file" ] || continue
+    local line key val
+    while IFS= read -r line; do
+      # Skip blanks and comments
+      [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+      [[ "$line" == *"="* ]] || continue
+      key="${line%%=*}"
+      val="${line#*=}"
+      # Strip surrounding quotes
+      val="${val#\"}"; val="${val%\"}"
+      val="${val#\'}"; val="${val%\'}"
+      # Lowercase for comparison
+      local lower
+      lower=$(printf '%s' "$val" | tr '[:upper:]' '[:lower:]')
+      if [[ "$lower" =~ $_POSTURE_PLACEHOLDERS_REGEX ]]; then
+        posture_emit "fail" "secrets" "$stack" \
+          "$(basename "$env_file"): $key appears to be a placeholder ('$val')" \
+          "Set a real value for $key in $env_file"
+        return 0
+      fi
+    done < "$env_file"
+  done
+  posture_emit "pass" "secrets" "$stack" "no placeholder values in env files"
+}
+
+# check_env_in_git <stack>
+#
+# Warns if any .env* file is tracked by git — env files routinely contain
+# secrets and should be gitignored.
+check_env_in_git() {
+  local stack="$1"
+  command -v git >/dev/null 2>&1 || { posture_emit "pass" "filesystem" "$stack" "git not available; skipping env-in-git check"; return; }
+  [ -d "$CLI_ROOT/.git" ] || { posture_emit "pass" "filesystem" "$stack" "not a git repo; skipping env-in-git check"; return; }
+
+  local tracked
+  tracked=$(cd "$CLI_ROOT" && git ls-files '.env' '.*.env' '*.env' 2>/dev/null || true)
+  if [ -n "$tracked" ]; then
+    local first
+    first=$(echo "$tracked" | head -1)
+    posture_emit "fail" "filesystem" "$stack" \
+      ".env file tracked by git: $first" \
+      "Add env files to .gitignore and run 'git rm --cached' on them"
+  else
+    posture_emit "pass" "filesystem" "$stack" "no env files tracked by git"
+  fi
+}
+
+# check_compose_ports <stack>
+#
+# Warns about services publishing to 0.0.0.0 when they could be internal.
+# The check is heuristic — we flag unprefixed `<port>:<port>` or explicit
+# `0.0.0.0:<port>:<port>` mappings. We pass if ports are bound to 127.0.0.1
+# or only `expose:` is used.
+check_compose_ports() {
+  local stack="$1"
+  local compose="$CLI_ROOT/stacks/$stack/docker-compose.yml"
+  [ -f "$compose" ] || { posture_emit "pass" "network" "$stack" "no docker-compose.yml"; return; }
+
+  local exposed
+  exposed=$(grep -En '^\s*-\s*"?(0\.0\.0\.0:)?[0-9]+:[0-9]+' "$compose" 2>/dev/null | \
+            grep -vE '127\.0\.0\.1:' || true)
+
+  if [ -n "$exposed" ]; then
+    local count
+    count=$(echo "$exposed" | wc -l | tr -d ' ')
+    local first_line
+    first_line=$(echo "$exposed" | head -1 | sed 's/^[[:space:]]*//')
+    posture_emit "warn" "network" "$stack" \
+      "$count port mapping(s) publish to 0.0.0.0 (first: $first_line)" \
+      "Prefix with 127.0.0.1: to restrict to localhost or move behind the reverse proxy"
+  else
+    posture_emit "pass" "network" "$stack" "no unrestricted port mappings"
+  fi
+}
+
+# check_resource_limits <stack>
+#
+# Warns if docker-compose services define no memory limit. Unbounded
+# services can starve the host on runaway growth.
+check_resource_limits() {
+  local stack="$1"
+  local compose="$CLI_ROOT/stacks/$stack/docker-compose.yml"
+  [ -f "$compose" ] || { posture_emit "pass" "runtime" "$stack" "no docker-compose.yml"; return; }
+
+  # Count services (crude but good enough for a warning signal)
+  local service_count
+  service_count=$(awk '/^services:/{in_services=1;next} /^[a-zA-Z]/{in_services=0} in_services && /^  [a-zA-Z][a-zA-Z0-9_-]*:/{n++} END{print n+0}' "$compose")
+
+  local limit_count
+  limit_count=$(grep -cE '^\s*(mem_limit|limits:)' "$compose" 2>/dev/null || echo 0)
+  # Strip any trailing whitespace/newlines from grep output
+  limit_count=$(printf '%s' "$limit_count" | tr -d '[:space:]')
+
+  if [ "$service_count" -eq 0 ]; then
+    posture_emit "pass" "runtime" "$stack" "no services in docker-compose.yml"
+  elif [ "$limit_count" -eq 0 ]; then
+    posture_emit "warn" "runtime" "$stack" \
+      "$service_count service(s) with no memory limits" \
+      "Set mem_limit or deploy.resources.limits in docker-compose.yml"
+  else
+    posture_emit "pass" "runtime" "$stack" "resource limits defined"
+  fi
+}
+
+# check_required_vars <stack>
+#
+# Reads stacks/<stack>/required_vars and verifies each listed variable is
+# defined and non-empty in the env file.
+check_required_vars() {
+  local stack="$1"
+  local req_file="$CLI_ROOT/stacks/$stack/required_vars"
+  [ -f "$req_file" ] || { posture_emit "pass" "secrets" "$stack" "no required_vars declared"; return; }
+
+  # Use whichever env file is most likely to be loaded
+  local env_file="$CLI_ROOT/.env"
+  [ -f "$env_file" ] || env_file=""
+
+  if [ -z "$env_file" ]; then
+    posture_emit "warn" "secrets" "$stack" \
+      "required_vars declared but no .env file to validate against" \
+      "Create $CLI_ROOT/.env or run 'strut init'"
+    return
+  fi
+
+  local missing=()
+  local var
+  while IFS= read -r var; do
+    # Skip blanks/comments
+    [[ -z "$var" || "$var" =~ ^# ]] && continue
+    var="${var#"${var%%[![:space:]]*}"}"
+    var="${var%"${var##*[![:space:]]}"}"
+    [ -z "$var" ] && continue
+    if ! grep -qE "^${var}=.+" "$env_file" 2>/dev/null; then
+      missing+=("$var")
+    fi
+  done < "$req_file"
+
+  if [ "${#missing[@]}" -gt 0 ]; then
+    local first="${missing[0]}"
+    local count="${#missing[@]}"
+    posture_emit "fail" "secrets" "$stack" \
+      "$count required var(s) missing or empty (first: $first)" \
+      "Set missing vars in $env_file"
+  else
+    posture_emit "pass" "secrets" "$stack" "all required vars present"
+  fi
+}
+
+# ── Category dispatch ─────────────────────────────────────────────────────────
+
+# run_category <stack> <category>
+#
+# Runs checks in the given category. `all` runs everything.
+run_category() {
+  local stack="$1"
+  local category="$2"
+
+  case "$category" in
+    secrets|all)
+      check_placeholder_secrets "$stack"
+      check_required_vars "$stack"
+      ;;
+  esac
+  case "$category" in
+    filesystem|all)
+      check_env_in_git "$stack"
+      ;;
+  esac
+  case "$category" in
+    network|all)
+      check_compose_ports "$stack"
+      ;;
+  esac
+  case "$category" in
+    runtime|all)
+      check_resource_limits "$stack"
+      ;;
+  esac
+
+  case "$category" in
+    secrets|filesystem|network|runtime|all) ;;
+    *) fail "Unknown category: $category (secrets|filesystem|network|runtime|all)"; return 1 ;;
+  esac
+}
+
+# ── Output ────────────────────────────────────────────────────────────────────
+
+_posture_level_glyph() {
+  case "$1" in
+    pass) echo -e "${GREEN}✓${NC}" ;;
+    warn) echo -e "${YELLOW}⚠${NC}" ;;
+    fail) echo -e "${RED}✗${NC}" ;;
+    *)    echo "?" ;;
+  esac
+}
+
+# _posture_render_text — print findings in human-readable format
+_posture_render_text() {
+  echo ""
+  echo -e "${BLUE}Posture check${NC}"
+  echo ""
+  local line level category stack msg remedy
+  for line in "${_POSTURE_RESULTS[@]+"${_POSTURE_RESULTS[@]}"}"; do
+    IFS=$'\t' read -r level category stack msg remedy <<<"$line"
+    # Skip passes in text mode to keep the report focused on actionable items
+    [ "$level" = "pass" ] && continue
+    local glyph
+    glyph=$(_posture_level_glyph "$level")
+    echo -e "  $glyph [$category] $stack: $msg"
+    [ -n "$remedy" ] && echo -e "      ${BLUE}→${NC} $remedy"
+  done
+  echo ""
+  echo "$_POSTURE_PASS passed, $_POSTURE_WARN warnings, $_POSTURE_FAIL failures"
+  echo ""
+}
+
+_posture_render_json() {
+  OUTPUT_MODE=json
+  out_json_object
+    out_json_field "timestamp" "$(date -u +%FT%TZ)"
+    out_json_array "findings"
+      local line level category stack msg remedy
+      for line in "${_POSTURE_RESULTS[@]+"${_POSTURE_RESULTS[@]}"}"; do
+        IFS=$'\t' read -r level category stack msg remedy <<<"$line"
+        out_json_object
+          out_json_field "level" "$level"
+          out_json_field "category" "$category"
+          out_json_field "stack" "$stack"
+          out_json_field "message" "$msg"
+          out_json_field "remediation" "$remedy"
+        out_json_close_object
+      done
+    out_json_close_array
+    out_json_field_raw "summary" "{\"pass\":$_POSTURE_PASS,\"warn\":$_POSTURE_WARN,\"fail\":$_POSTURE_FAIL}"
+  out_json_close_object
+  out_json_newline
+}
+
+# ── Entrypoint ────────────────────────────────────────────────────────────────
+
+cmd_posture() {
+  local stack_filter=""
+  local category="all"
+  local fail_on="fail"
+  local json_mode="false"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --stack=*)    stack_filter="${1#*=}"; shift ;;
+      --stack)      stack_filter="${2:-}"; shift 2 ;;
+      --category=*) category="${1#*=}"; shift ;;
+      --category)   category="${2:-}"; shift 2 ;;
+      --fail-on=*)  fail_on="${1#*=}"; shift ;;
+      --fail-on)    fail_on="${2:-}"; shift 2 ;;
+      --json)       json_mode="true"; shift ;;
+      --help|-h)
+        cat <<'EOF'
+Usage: strut posture [options]
+
+Security and ops posture check. Scans every stack (or one, with --stack)
+for placeholder secrets, exposed ports, missing resource limits, env
+files tracked in git, and missing required_vars.
+
+Options:
+  --stack <name>        Limit to a single stack
+  --category <cat>      secrets | filesystem | network | runtime | all  (default: all)
+  --fail-on <level>     fail | warn    Exit 1 threshold (default: fail)
+  --json                Structured JSON output for CI
+EOF
+        return 0
+        ;;
+      *) fail "Unknown flag: $1"; return 1 ;;
+    esac
+  done
+
+  case "$fail_on" in
+    fail|warn) ;;
+    *) fail "Invalid --fail-on level: $fail_on (fail|warn)"; return 1 ;;
+  esac
+
+  [ -d "$CLI_ROOT/stacks" ] || { fail "No stacks/ directory found — run 'strut init' to get started"; return 1; }
+
+  posture_reset
+
+  local stack_dir name
+  for stack_dir in "$CLI_ROOT/stacks"/*/; do
+    [ -d "$stack_dir" ] || continue
+    name=$(basename "$stack_dir")
+    [ "$name" = "shared" ] && continue
+    [ -n "$stack_filter" ] && [ "$name" != "$stack_filter" ] && continue
+    run_category "$name" "$category" || return 1
+  done
+
+  if [ "$json_mode" = "true" ]; then
+    _posture_render_json
+  else
+    _posture_render_text
+  fi
+
+  # Exit code based on --fail-on
+  if [ "$_POSTURE_FAIL" -gt 0 ]; then
+    return 1
+  fi
+  if [ "$fail_on" = "warn" ] && [ "$_POSTURE_WARN" -gt 0 ]; then
+    return 1
+  fi
+  return 0
+}

--- a/strut
+++ b/strut
@@ -165,6 +165,7 @@ usage() {
   echo "  domain   <domain> <email> [--skip-ssl]                         Configure domain/SSL"
   echo "  list                                                           List stacks"
   echo "  status-all [--env <name>] [--json]                             Dashboard across all stacks"
+  echo "  posture    [--stack <name>] [--category <c>] [--fail-on <l>]   Security/ops posture check"
   echo "  scaffold <new-stack-name>                                      New stack"
   echo "  init     [--registry <type>] [--org <name>]                    Initialize new project"
   echo "  upgrade                                                        Upgrade strut to latest version"
@@ -356,6 +357,12 @@ case "${1:-}" in
     shift
     source "$LIB/cmd_status_all.sh"
     cmd_status_all "$@"
+    exit $?
+    ;;
+  posture)
+    shift
+    source "$LIB/cmd_posture.sh"
+    cmd_posture "$@"
     exit $?
     ;;
 

--- a/tests/test_posture.bats
+++ b/tests/test_posture.bats
@@ -1,0 +1,350 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_posture.bats — Tests for strut posture
+# ==================================================
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_utils
+  source "$CLI_ROOT/lib/output.sh"
+
+  export REAL_CLI_ROOT="$CLI_ROOT"
+  export CLI_ROOT="$TEST_TMP"
+  mkdir -p "$CLI_ROOT/stacks"
+
+  source "$REAL_CLI_ROOT/lib/cmd_posture.sh"
+  posture_reset
+}
+
+teardown() {
+  common_teardown
+}
+
+_make_stack() {
+  local name="$1"
+  mkdir -p "$CLI_ROOT/stacks/$name"
+  cat > "$CLI_ROOT/stacks/$name/docker-compose.yml" <<'EOF'
+services:
+  app:
+    image: example
+EOF
+}
+
+_clean_env() {
+  rm -f "$CLI_ROOT"/.env "$CLI_ROOT"/.*.env
+}
+
+# ── posture_emit + counters ───────────────────────────────────────────────────
+
+@test "posture_emit: increments the right counter" {
+  posture_emit pass secrets api "looks fine"
+  posture_emit warn network api "port exposed"
+  posture_emit fail runtime api "no mem limit"
+  [ "$_POSTURE_PASS" -eq 1 ]
+  [ "$_POSTURE_WARN" -eq 1 ]
+  [ "$_POSTURE_FAIL" -eq 1 ]
+  [ "${#_POSTURE_RESULTS[@]}" -eq 3 ]
+}
+
+@test "posture_reset: clears all buffers" {
+  posture_emit fail secrets api "x"
+  posture_reset
+  [ "$_POSTURE_FAIL" -eq 0 ]
+  [ "${#_POSTURE_RESULTS[@]}" -eq 0 ]
+}
+
+# ── check_placeholder_secrets ─────────────────────────────────────────────────
+
+@test "check_placeholder_secrets: pass when no placeholders" {
+  _clean_env
+  cat > "$CLI_ROOT/.env" <<'EOF'
+POSTGRES_PASSWORD=s3cret-real-value
+API_KEY=sk_live_abc123xyz
+EOF
+  check_placeholder_secrets mystack
+  [ "$_POSTURE_PASS" -eq 1 ]
+  [ "$_POSTURE_FAIL" -eq 0 ]
+}
+
+@test "check_placeholder_secrets: fail when value is 'changeme'" {
+  _clean_env
+  cat > "$CLI_ROOT/.env" <<'EOF'
+POSTGRES_PASSWORD=changeme
+EOF
+  check_placeholder_secrets mystack
+  [ "$_POSTURE_FAIL" -eq 1 ]
+}
+
+@test "check_placeholder_secrets: fail when value is 'password'" {
+  _clean_env
+  cat > "$CLI_ROOT/.env" <<'EOF'
+DB_PASS=password
+EOF
+  check_placeholder_secrets mystack
+  [ "$_POSTURE_FAIL" -eq 1 ]
+}
+
+@test "check_placeholder_secrets: case-insensitive match" {
+  _clean_env
+  cat > "$CLI_ROOT/.env" <<'EOF'
+FOO=CHANGEME
+EOF
+  check_placeholder_secrets mystack
+  [ "$_POSTURE_FAIL" -eq 1 ]
+}
+
+@test "check_placeholder_secrets: strips quotes before comparing" {
+  _clean_env
+  cat > "$CLI_ROOT/.env" <<'EOF'
+FOO="changeme"
+EOF
+  check_placeholder_secrets mystack
+  [ "$_POSTURE_FAIL" -eq 1 ]
+}
+
+@test "check_placeholder_secrets: ignores comments and blank lines" {
+  _clean_env
+  cat > "$CLI_ROOT/.env" <<'EOF'
+# This is a comment
+
+VALID_KEY=real-value
+EOF
+  check_placeholder_secrets mystack
+  [ "$_POSTURE_PASS" -eq 1 ]
+}
+
+# ── check_env_in_git ──────────────────────────────────────────────────────────
+
+@test "check_env_in_git: passes when not a git repo" {
+  check_env_in_git mystack
+  [ "$_POSTURE_PASS" -eq 1 ]
+}
+
+@test "check_env_in_git: fails when .env is tracked" {
+  ( cd "$CLI_ROOT" && git init -q && git config user.email t@t && git config user.name t )
+  echo "SECRET=value" > "$CLI_ROOT/.env"
+  ( cd "$CLI_ROOT" && git add .env && git commit -q -m "bad" )
+  check_env_in_git mystack
+  [ "$_POSTURE_FAIL" -eq 1 ]
+}
+
+@test "check_env_in_git: passes when .env is gitignored" {
+  ( cd "$CLI_ROOT" && git init -q && git config user.email t@t && git config user.name t )
+  echo ".env" > "$CLI_ROOT/.gitignore"
+  echo "SECRET=value" > "$CLI_ROOT/.env"
+  ( cd "$CLI_ROOT" && git add .gitignore && git commit -q -m "gitignore" )
+  check_env_in_git mystack
+  [ "$_POSTURE_PASS" -eq 1 ]
+}
+
+# ── check_compose_ports ───────────────────────────────────────────────────────
+
+@test "check_compose_ports: warns when port published to 0.0.0.0" {
+  mkdir -p "$CLI_ROOT/stacks/api"
+  cat > "$CLI_ROOT/stacks/api/docker-compose.yml" <<'EOF'
+services:
+  app:
+    ports:
+      - "8080:8080"
+EOF
+  check_compose_ports api
+  [ "$_POSTURE_WARN" -eq 1 ]
+}
+
+@test "check_compose_ports: passes when bound to 127.0.0.1" {
+  mkdir -p "$CLI_ROOT/stacks/api"
+  cat > "$CLI_ROOT/stacks/api/docker-compose.yml" <<'EOF'
+services:
+  app:
+    ports:
+      - "127.0.0.1:8080:8080"
+EOF
+  check_compose_ports api
+  [ "$_POSTURE_PASS" -eq 1 ]
+}
+
+@test "check_compose_ports: passes when no ports declared" {
+  mkdir -p "$CLI_ROOT/stacks/api"
+  cat > "$CLI_ROOT/stacks/api/docker-compose.yml" <<'EOF'
+services:
+  app:
+    image: x
+EOF
+  check_compose_ports api
+  [ "$_POSTURE_PASS" -eq 1 ]
+}
+
+@test "check_compose_ports: passes when compose file missing" {
+  mkdir -p "$CLI_ROOT/stacks/nocompose"
+  check_compose_ports nocompose
+  [ "$_POSTURE_PASS" -eq 1 ]
+}
+
+# ── check_resource_limits ─────────────────────────────────────────────────────
+
+@test "check_resource_limits: warns when no mem_limit defined" {
+  mkdir -p "$CLI_ROOT/stacks/api"
+  cat > "$CLI_ROOT/stacks/api/docker-compose.yml" <<'EOF'
+services:
+  app:
+    image: x
+EOF
+  check_resource_limits api
+  [ "$_POSTURE_WARN" -eq 1 ]
+}
+
+@test "check_resource_limits: passes when mem_limit set" {
+  mkdir -p "$CLI_ROOT/stacks/api"
+  cat > "$CLI_ROOT/stacks/api/docker-compose.yml" <<'EOF'
+services:
+  app:
+    image: x
+    mem_limit: 512m
+EOF
+  check_resource_limits api
+  [ "$_POSTURE_PASS" -eq 1 ]
+}
+
+# ── check_required_vars ───────────────────────────────────────────────────────
+
+@test "check_required_vars: passes when no required_vars file" {
+  mkdir -p "$CLI_ROOT/stacks/api"
+  check_required_vars api
+  [ "$_POSTURE_PASS" -eq 1 ]
+}
+
+@test "check_required_vars: fails when required var missing from env" {
+  mkdir -p "$CLI_ROOT/stacks/api"
+  echo "POSTGRES_PASSWORD" > "$CLI_ROOT/stacks/api/required_vars"
+  _clean_env
+  echo "OTHER=value" > "$CLI_ROOT/.env"
+  check_required_vars api
+  [ "$_POSTURE_FAIL" -eq 1 ]
+}
+
+@test "check_required_vars: passes when all required vars present" {
+  mkdir -p "$CLI_ROOT/stacks/api"
+  printf 'POSTGRES_PASSWORD\nAPI_KEY\n' > "$CLI_ROOT/stacks/api/required_vars"
+  _clean_env
+  cat > "$CLI_ROOT/.env" <<'EOF'
+POSTGRES_PASSWORD=real
+API_KEY=sk_live
+EOF
+  check_required_vars api
+  [ "$_POSTURE_PASS" -eq 1 ]
+}
+
+# ── cmd_posture entrypoint ────────────────────────────────────────────────────
+
+@test "cmd_posture: no stacks directory fails" {
+  rm -rf "$CLI_ROOT/stacks"
+  run cmd_posture
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"No stacks"* ]]
+}
+
+@test "cmd_posture: unknown flag fails" {
+  _make_stack api
+  run cmd_posture --bogus
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unknown flag"* ]]
+}
+
+@test "cmd_posture: --help prints usage" {
+  run cmd_posture --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage"* ]]
+  [[ "$output" == *"posture"* ]]
+}
+
+@test "cmd_posture: invalid --fail-on level fails" {
+  _make_stack api
+  run cmd_posture --fail-on bogus
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid --fail-on"* ]]
+}
+
+@test "cmd_posture: unknown category fails" {
+  _make_stack api
+  run cmd_posture --category xyz
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unknown category"* ]]
+}
+
+@test "cmd_posture: text output runs across all stacks" {
+  _make_stack api
+  _make_stack worker
+  _clean_env
+  run cmd_posture
+  # Text mode: may exit 0 or 1 depending on default policies
+  [[ "$output" == *"Posture check"* ]]
+  [[ "$output" == *"passed"* ]]
+}
+
+@test "cmd_posture: json mode produces structured output" {
+  _make_stack api
+  _clean_env
+  run cmd_posture --json
+  [[ "$output" == *'"timestamp":'* ]]
+  [[ "$output" == *'"findings":'* ]]
+  [[ "$output" == *'"summary":'* ]]
+  [[ "$output" == *'"pass":'* ]]
+}
+
+@test "cmd_posture: --stack filter limits to one stack" {
+  _make_stack api
+  _make_stack worker
+  _clean_env
+  run cmd_posture --stack api --json
+  [[ "$output" == *'"stack":"api"'* ]]
+  [[ "$output" != *'"stack":"worker"'* ]]
+}
+
+@test "cmd_posture: --category secrets only runs secrets checks" {
+  _make_stack api
+  _clean_env
+  run cmd_posture --category secrets --json
+  [[ "$output" == *'"category":"secrets"'* ]]
+  [[ "$output" != *'"category":"network"'* ]]
+}
+
+@test "cmd_posture: exit 1 when a placeholder secret is found" {
+  _make_stack api
+  _clean_env
+  echo "POSTGRES_PASSWORD=changeme" > "$CLI_ROOT/.env"
+  run cmd_posture
+  [ "$status" -eq 1 ]
+}
+
+@test "cmd_posture: --fail-on warn exits 1 on warnings" {
+  _make_stack api
+  # Compose with 0.0.0.0 port → warn; no failing conditions
+  cat > "$CLI_ROOT/stacks/api/docker-compose.yml" <<'EOF'
+services:
+  app:
+    image: x
+    ports:
+      - "8080:8080"
+    mem_limit: 128m
+EOF
+  _clean_env
+  echo "REAL=value" > "$CLI_ROOT/.env"
+  run cmd_posture --fail-on warn
+  [ "$status" -eq 1 ]
+}
+
+@test "cmd_posture: default fail-on level ignores warnings" {
+  _make_stack api
+  cat > "$CLI_ROOT/stacks/api/docker-compose.yml" <<'EOF'
+services:
+  app:
+    image: x
+    ports:
+      - "8080:8080"
+    mem_limit: 128m
+EOF
+  _clean_env
+  echo "REAL=value" > "$CLI_ROOT/.env"
+  run cmd_posture
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Adds a new top-level `strut posture` command that scans all stacks for security and operational misconfigurations. Part of the audit expansion tracked by issue #41.

## Checks

| Category | Check | Severity |
|----------|-------|----------|
| secrets | placeholder values in `.env` (`changeme`, `password`, etc., case-insensitive, quote-stripped) | fail |
| secrets | `.env` files committed to git | fail |
| network | docker-compose ports published to `0.0.0.0` | warn |
| runtime | services without `mem_limit` / `deploy.resources.limits` | warn |
| filesystem | vars in `stacks/<s>/required_vars` missing from `.env` | fail |

## Flags

- `--stack <name>` — scope to a single stack
- `--category <secrets\|filesystem\|network\|runtime\|all>` — run a subset
- `--fail-on fail\|warn` — exit-code policy (default `fail`)
- `--json` — structured output for CI
- `--help` / `-h`

## Why a new command instead of overloading `strut audit`?

`strut audit <vps-host>` is already a positional-arg VPS discovery command — layering flag-based local posture checks there would muddy both interfaces. `strut posture` is a clean, testable entry point that can grow more checks without conflating with remote audit.

## Test plan

- [x] 32 unit tests in `tests/test_posture.bats` cover each check's pass/warn/fail branches, flag parsing, exit codes, and JSON structure
- [x] Full suite: 763 passing, 0 failing
- [x] Manual: `strut posture --help`, `strut posture --json`, `strut posture --category secrets`

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)