### PR TITLE
fix: portable timeout wrapper for BATS (#27)

### DIFF
--- a/tests/test_helper/common.bash
+++ b/tests/test_helper/common.bash
@@ -22,6 +22,21 @@ load_docker() {
   source "$CLI_ROOT/lib/docker.sh"
 }
 
+# Portable timeout wrapper — uses `timeout` on Linux, `gtimeout` on macOS
+# (install via `brew install coreutils`), otherwise runs without a timeout.
+#
+# Usage: _timeout <seconds> <command> [args...]
+_timeout() {
+  if command -v timeout &>/dev/null; then
+    timeout "$@"
+  elif command -v gtimeout &>/dev/null; then
+    gtimeout "$@"
+  else
+    shift  # drop the duration
+    "$@"
+  fi
+}
+
 # Cleanup helper — call in teardown()
 common_teardown() {
   [ -n "${TEST_TMP:-}" ] && rm -rf "$TEST_TMP"

--- a/tests/test_migrate.bats
+++ b/tests/test_migrate.bats
@@ -7,8 +7,7 @@
 #         migrate_status, phase validation
 
 setup() {
-  export CLI_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
-  TEST_TMP="$(mktemp -d)"
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
 
   source "$CLI_ROOT/lib/utils.sh"
   fail() { echo "$1" >&2; return 1; }
@@ -51,8 +50,10 @@ teardown() {
 # ── migrate_wizard argument validation ────────────────────────────────────────
 
 @test "migrate_wizard: fails without vps_host" {
-  # Test in a subshell with timeout to avoid hanging
-  run timeout 5 bash -c '
+  # Run in a subshell under timeout to avoid hanging; source utils.sh
+  # first so fail/warn/log are defined in the child shell.
+  run _timeout 5 bash -c '
+    source "$CLI_ROOT/lib/utils.sh"
     source "$CLI_ROOT/lib/migrate.sh"
     MIGRATE_AUTO_YES=true
     migrate_wizard "" 2>&1
@@ -61,7 +62,8 @@ teardown() {
 }
 
 @test "migrate_wizard: rejects invalid start phase 0" {
-  run timeout 5 bash -c '
+  run _timeout 5 bash -c '
+    source "$CLI_ROOT/lib/utils.sh"
     source "$CLI_ROOT/lib/migrate.sh"
     MIGRATE_AUTO_YES=true
     migrate_wizard "test-host" "ubuntu" "" "" "--start-phase=0" 2>&1
@@ -70,7 +72,8 @@ teardown() {
 }
 
 @test "migrate_wizard: rejects invalid start phase 9" {
-  run timeout 5 bash -c '
+  run _timeout 5 bash -c '
+    source "$CLI_ROOT/lib/utils.sh"
     source "$CLI_ROOT/lib/migrate.sh"
     MIGRATE_AUTO_YES=true
     migrate_wizard "test-host" "ubuntu" "" "" "--start-phase=9" 2>&1


### PR DESCRIPTION
## Summary

Eliminates the `BW01: timeout ... exited with code 127` warnings that appeared on every CI run. Closes #27.

Two orthogonal sources were both producing exit 127:
1. GNU `timeout` missing on macOS runners.
2. The inner `bash -c` subshell sourced `migrate.sh` but not `utils.sh`, so `migrate_wizard`'s call to `fail` was itself "command not found".

## Fix

- New `_timeout` helper in `tests/test_helper/common.bash` — uses `timeout` (Linux), `gtimeout` (macOS + coreutils), or falls back to running without a timeout.
- Inner `bash -c` subshells now source `utils.sh` before `migrate.sh`.
- `test_migrate.bats` sources the common test helper.

## Test plan
- [x] `bats tests/test_migrate.bats` — 10/10 pass, no BW01
- [x] Full suite: 776 pass, 0 fail, **0 BW01 warnings**

🤖 Generated with [Claude Code](https://claude.com/claude-code)