### PR TITLE
feat: add stack groups for coordinated multi-stack ops (#17)

### DIFF
--- a/lib/cmd_group.sh
+++ b/lib/cmd_group.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# ==================================================
+# lib/cmd_group.sh — `strut group <name> <command>` dispatcher
+# ==================================================
+# Iterates the stacks in a group and runs a strut command against each.
+# The engine is a thin shell-out to `$0 <stack> <cmd> [args]` — re-using
+# the main entrypoint rather than calling cmd_* inline, so one stack's
+# state cannot corrupt the next. Slower, but predictable.
+
+set -euo pipefail
+
+_usage_group() {
+  cat <<'EOF'
+
+Usage:
+  strut group list                              List all groups
+  strut group show <name>                       Show stacks in a group
+  strut group add <name> <stack>                Add a stack to a group
+  strut group remove <name> <stack>             Remove a stack from a group
+  strut group <name> <command> [--env <name>] [--stop-on-error] [options]
+                                                Run command for all stacks in group
+
+Flags (for group execution):
+  --stop-on-error   Halt on the first failing stack (default: continue)
+  --json            Summary as JSON (text summary otherwise)
+  --help, -h        Show this help
+
+Groups are defined in groups.conf at the project root. INI-style:
+
+    [vps-1]
+    knowledge-graph
+    api-service
+
+Exit codes:
+  0   All stacks succeeded
+  1   One or more stacks failed
+
+Examples:
+  strut group vps-1 deploy --env prod
+  strut group postgres-stacks backup postgres
+  strut group list
+  strut group show vps-1
+  strut group add vps-1 new-stack
+
+EOF
+}
+
+_group_stack_exists() {
+  # A stack is "real" if stacks/<name>/ exists under either the project
+  # or the strut home (scaffold fallback). Missing stacks are warned, not
+  # fatal, per acceptance criteria.
+  local stack="$1"
+  [ -d "${PROJECT_ROOT:-}/stacks/$stack" ] || [ -d "$CLI_ROOT/stacks/$stack" ]
+}
+
+_group_list() {
+  local groups
+  groups=$(groups_list)
+  if [ -z "$groups" ]; then
+    warn "No groups defined. Create groups.conf at the project root."
+    return 0
+  fi
+  local g members count
+  while IFS= read -r g; do
+    members=$(groups_members "$g")
+    # awk's count (vs `grep -c`) so an empty group doesn't exit 1 under set -e
+    count=$(printf '%s\n' "$members" | awk 'NF { n++ } END { print n+0 }')
+    printf '  %-30s %d stacks\n' "$g" "$count"
+  done <<< "$groups"
+}
+
+_group_show() {
+  local group="$1"
+  if ! groups_exists "$group"; then
+    fail "Unknown group: $group"
+  fi
+  echo "Group: $group"
+  local members
+  members=$(groups_members "$group")
+  if [ -z "$members" ]; then
+    echo "  (empty)"
+    return 0
+  fi
+  local stack marker
+  while IFS= read -r stack; do
+    if _group_stack_exists "$stack"; then
+      marker="✓"
+    else
+      marker="✗ (missing)"
+    fi
+    printf '  %s %s\n' "$marker" "$stack"
+  done <<< "$members"
+}
+
+_group_add() {
+  local group="$1" stack="$2"
+  [ -z "$group" ] && fail "Missing group name"
+  [ -z "$stack" ] && fail "Missing stack name"
+  groups_add "$group" "$stack"
+  ok "Added '$stack' to group '$group'"
+}
+
+_group_remove() {
+  local group="$1" stack="$2"
+  [ -z "$group" ] && fail "Missing group name"
+  [ -z "$stack" ] && fail "Missing stack name"
+  groups_remove "$group" "$stack"
+  ok "Removed '$stack' from group '$group'"
+}
+
+# _group_dispatch <group> <command> [args...]
+#
+# Iterates stacks in the group and invokes `$0 <stack> <command> [args]`
+# sequentially. Collects per-stack exit codes. Prints a summary at the
+# end and returns 0 only if every stack succeeded.
+_group_dispatch() {
+  local group="$1"; shift
+  local cmd="$1"; shift
+  local stop_on_error=false
+  local json_mode=false
+  local -a passthrough=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --stop-on-error) stop_on_error=true; shift ;;
+      --json) json_mode=true; passthrough+=("$1"); shift ;;
+      *) passthrough+=("$1"); shift ;;
+    esac
+  done
+
+  if ! groups_exists "$group"; then
+    fail "Unknown group: $group"
+  fi
+
+  local members
+  members=$(groups_members "$group")
+  if [ -z "$members" ]; then
+    warn "Group '$group' has no stacks"
+    return 0
+  fi
+
+  local total=0 passed=0 failed=0
+  local -a failed_stacks=()
+  local stack
+
+  if [ "$json_mode" != "true" ]; then
+    echo ""
+    echo "▶ Running '$cmd' for group '$group':"
+    echo ""
+  fi
+
+  while IFS= read -r stack; do
+    [ -z "$stack" ] && continue
+    total=$((total + 1))
+
+    if ! _group_stack_exists "$stack"; then
+      warn "  skip: $stack (no stacks/$stack directory found)"
+      continue
+    fi
+
+    if [ "$json_mode" != "true" ]; then
+      echo "── $stack ───────────────────────────────"
+    fi
+
+    # Shell out to the main strut entrypoint. Using "$0" re-uses the
+    # exact binary the user invoked, including its resolved Strut_Home.
+    if "$0" "$stack" "$cmd" "${passthrough[@]+"${passthrough[@]}"}"; then
+      passed=$((passed + 1))
+    else
+      failed=$((failed + 1))
+      failed_stacks+=("$stack")
+      if [ "$stop_on_error" = "true" ]; then
+        break
+      fi
+    fi
+  done <<< "$members"
+
+  if [ "$json_mode" = "true" ]; then
+    OUTPUT_MODE=json
+    out_json_object
+      out_json_field "group" "$group"
+      out_json_field "command" "$cmd"
+      out_json_field_raw "total" "$total"
+      out_json_field_raw "passed" "$passed"
+      out_json_field_raw "failed" "$failed"
+      out_json_array "failed_stacks"
+      local s
+      for s in "${failed_stacks[@]+"${failed_stacks[@]}"}"; do
+        out_json_string "$s"
+      done
+      out_json_close_array
+    out_json_close_object
+    out_json_newline
+  else
+    echo ""
+    if [ "$failed" -eq 0 ]; then
+      ok "$passed/$total stacks succeeded"
+    else
+      error "$failed/$total stacks failed: ${failed_stacks[*]}"
+    fi
+  fi
+
+  [ "$failed" -eq 0 ]
+}
+
+# cmd_group — entry point invoked from strut entrypoint.
+# Usage patterns:
+#   cmd_group list
+#   cmd_group show <group>
+#   cmd_group add <group> <stack>
+#   cmd_group remove <group> <stack>
+#   cmd_group <group> <command> [args...]
+cmd_group() {
+  local first="${1:-}"
+  shift || true
+
+  case "$first" in
+    ""|--help|-h)  _usage_group ;;
+    list)          _group_list ;;
+    show)          _group_show "${1:-}" ;;
+    add)           _group_add "${1:-}" "${2:-}" ;;
+    remove)        _group_remove "${1:-}" "${2:-}" ;;
+    *)
+      local cmd="${1:-}"
+      shift || true
+      [ -z "$cmd" ] && { _usage_group; fail "Missing command for group '$first'"; }
+      _group_dispatch "$first" "$cmd" "$@"
+      ;;
+  esac
+}

--- a/lib/groups.sh
+++ b/lib/groups.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# ==================================================
+# lib/groups.sh — Stack group configuration (INI format)
+# ==================================================
+# groups.conf lives at project root (next to strut.conf) and looks like:
+#
+#   [vps-1]
+#   knowledge-graph
+#   api-service
+#
+#   [postgres-stacks]
+#   knowledge-graph
+#   twenty
+#
+# Stacks can belong to multiple groups. Groups are label-only — no
+# ordering or dependency semantics (those could come later).
+#
+# Parser is pure awk for portability: no yq, no jq. All functions return
+# via stdout; non-zero exit = not found / invalid.
+
+set -euo pipefail
+
+# groups_config_path
+#   Absolute path to groups.conf for the current project.
+#   Callers can override via $STRUT_GROUPS_CONF for tests.
+groups_config_path() {
+  if [ -n "${STRUT_GROUPS_CONF:-}" ]; then
+    echo "$STRUT_GROUPS_CONF"
+    return 0
+  fi
+  local root="${PROJECT_ROOT:-$(pwd)}"
+  echo "$root/groups.conf"
+}
+
+# groups_ensure_config
+#   Creates an empty groups.conf (with a header) if one doesn't exist.
+groups_ensure_config() {
+  local path
+  path=$(groups_config_path)
+  if [ ! -f "$path" ]; then
+    cat > "$path" <<'EOF'
+# groups.conf — stack groups for `strut group <name> <command>`
+#
+# INI-style. Group names in [brackets]; one stack per line underneath.
+# Comments start with #. A stack may appear in multiple groups.
+
+EOF
+  fi
+}
+
+# groups_list
+#   Emits all group names, one per line, in file order.
+groups_list() {
+  local path
+  path=$(groups_config_path)
+  [ -f "$path" ] || return 0
+  awk '
+    /^[[:space:]]*#/ { next }
+    /^[[:space:]]*\[.*\][[:space:]]*$/ {
+      name = $0
+      sub(/^[[:space:]]*\[/, "", name)
+      sub(/\][[:space:]]*$/, "", name)
+      print name
+    }
+  ' "$path"
+}
+
+# groups_members <group>
+#   Emits stack names in the group, one per line.
+#   Exit 0 even if the group is missing (empty output → caller decides).
+groups_members() {
+  local group="$1"
+  local path
+  path=$(groups_config_path)
+  [ -f "$path" ] || return 0
+  awk -v target="$group" '
+    /^[[:space:]]*#/ { next }
+    /^[[:space:]]*\[.*\][[:space:]]*$/ {
+      name = $0
+      sub(/^[[:space:]]*\[/, "", name)
+      sub(/\][[:space:]]*$/, "", name)
+      in_section = (name == target)
+      next
+    }
+    /^[[:space:]]*$/ { next }
+    in_section {
+      stack = $0
+      sub(/^[[:space:]]+/, "", stack)
+      sub(/[[:space:]]+$/, "", stack)
+      if (stack != "") print stack
+    }
+  ' "$path"
+}
+
+# groups_exists <group>
+#   0 if the group is declared in groups.conf (even if empty), 1 otherwise.
+groups_exists() {
+  local group="$1"
+  groups_list | grep -Fx "$group" >/dev/null 2>&1
+}
+
+# groups_has_member <group> <stack>
+#   0 if the stack appears in the group, 1 otherwise.
+groups_has_member() {
+  local group="$1" stack="$2"
+  groups_members "$group" | grep -Fx "$stack" >/dev/null 2>&1
+}
+
+# groups_add <group> <stack>
+#   Appends a stack to a group. Creates the group section if missing.
+#   Idempotent — a no-op if the stack already belongs.
+groups_add() {
+  local group="$1" stack="$2"
+  groups_ensure_config
+  local path
+  path=$(groups_config_path)
+
+  if groups_has_member "$group" "$stack"; then
+    return 0
+  fi
+
+  if groups_exists "$group"; then
+    # Insert right after the last member line of the section.
+    local tmp
+    tmp=$(mktemp)
+    awk -v target="$group" -v stack="$stack" '
+      BEGIN { added = 0; in_section = 0 }
+      /^[[:space:]]*\[.*\][[:space:]]*$/ {
+        if (in_section && !added) { print stack; added = 1 }
+        name = $0
+        sub(/^[[:space:]]*\[/, "", name)
+        sub(/\][[:space:]]*$/, "", name)
+        in_section = (name == target)
+        print; next
+      }
+      { print }
+      END { if (in_section && !added) print stack }
+    ' "$path" > "$tmp"
+    mv "$tmp" "$path"
+  else
+    {
+      echo ""
+      echo "[$group]"
+      echo "$stack"
+    } >> "$path"
+  fi
+}
+
+# groups_remove <group> <stack>
+#   Removes a stack from a group. Idempotent.
+groups_remove() {
+  local group="$1" stack="$2"
+  local path
+  path=$(groups_config_path)
+  [ -f "$path" ] || return 0
+
+  local tmp
+  tmp=$(mktemp)
+  awk -v target="$group" -v stack="$stack" '
+    /^[[:space:]]*\[.*\][[:space:]]*$/ {
+      name = $0
+      sub(/^[[:space:]]*\[/, "", name)
+      sub(/\][[:space:]]*$/, "", name)
+      in_section = (name == target)
+      print; next
+    }
+    in_section {
+      line = $0
+      trimmed = line
+      sub(/^[[:space:]]+/, "", trimmed)
+      sub(/[[:space:]]+$/, "", trimmed)
+      if (trimmed == stack) next
+    }
+    { print }
+  ' "$path" > "$tmp"
+  mv "$tmp" "$path"
+}

--- a/strut
+++ b/strut
@@ -129,6 +129,8 @@ source "$LIB/diff.sh"
 source "$LIB/cmd_diff.sh"
 source "$LIB/lock.sh"
 source "$LIB/cmd_lock.sh"
+source "$LIB/groups.sh"
+source "$LIB/cmd_group.sh"
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
@@ -190,6 +192,7 @@ usage() {
   echo "  list                                                           List stacks"
   echo "  status-all [--env <name>] [--json]                             Dashboard across all stacks"
   echo "  posture    [--stack <name>] [--category <c>] [--fail-on <l>]   Security/ops posture check"
+  echo "  group      list|show|add|remove | <name> <command>             Stack groups (coordinated multi-stack ops)"
   echo "  scaffold <new-stack-name>                                      New stack"
   echo "  init     [--registry <type>] [--org <name>]                    Initialize new project"
   echo "  upgrade                                                        Upgrade strut to latest version"
@@ -387,6 +390,11 @@ case "${1:-}" in
     shift
     source "$LIB/cmd_posture.sh"
     cmd_posture "$@"
+    exit $?
+    ;;
+  group)
+    shift
+    cmd_group "$@"
     exit $?
     ;;
 

--- a/tests/test_groups.bats
+++ b/tests/test_groups.bats
@@ -1,0 +1,260 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_groups.bats — Tests for lib/groups.sh (INI parser + mutations)
+# ==================================================
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_utils
+  source "$CLI_ROOT/lib/groups.sh"
+
+  export STRUT_GROUPS_CONF="$TEST_TMP/groups.conf"
+}
+
+teardown() {
+  common_teardown
+  unset STRUT_GROUPS_CONF
+}
+
+_write_groups() {
+  cat > "$STRUT_GROUPS_CONF"
+}
+
+# ── groups_list ───────────────────────────────────────────────────────────────
+
+@test "groups_list: empty when file missing" {
+  result=$(groups_list)
+  [ -z "$result" ]
+}
+
+@test "groups_list: returns all group names in file order" {
+  _write_groups <<'EOF'
+[alpha]
+a
+
+[beta]
+b
+
+[gamma]
+c
+EOF
+  result=$(groups_list)
+  [ "$result" = $'alpha\nbeta\ngamma' ]
+}
+
+@test "groups_list: ignores comments and whitespace" {
+  _write_groups <<'EOF'
+# header comment
+
+[only-group]
+a
+# inline comment
+EOF
+  result=$(groups_list)
+  [ "$result" = "only-group" ]
+}
+
+# ── groups_members ────────────────────────────────────────────────────────────
+
+@test "groups_members: returns stacks under a group" {
+  _write_groups <<'EOF'
+[vps-1]
+stack-a
+stack-b
+EOF
+  result=$(groups_members "vps-1")
+  [ "$result" = $'stack-a\nstack-b' ]
+}
+
+@test "groups_members: empty for missing group" {
+  _write_groups <<'EOF'
+[other]
+stack-a
+EOF
+  result=$(groups_members "missing")
+  [ -z "$result" ]
+}
+
+@test "groups_members: scoped to the right section (doesn't leak)" {
+  _write_groups <<'EOF'
+[first]
+a
+b
+
+[second]
+c
+d
+EOF
+  result=$(groups_members "first")
+  [ "$result" = $'a\nb' ]
+}
+
+@test "groups_members: handles leading whitespace on stack lines" {
+  _write_groups <<'EOF'
+[g]
+   indented-stack
+tab-indented
+EOF
+  result=$(groups_members "g")
+  [[ "$result" == *"indented-stack"* ]]
+  [[ "$result" == *"tab-indented"* ]]
+}
+
+# ── groups_exists / has_member ────────────────────────────────────────────────
+
+@test "groups_exists: true for declared group" {
+  _write_groups <<'EOF'
+[my-group]
+x
+EOF
+  run groups_exists "my-group"
+  [ "$status" -eq 0 ]
+}
+
+@test "groups_exists: false for undeclared group" {
+  _write_groups <<'EOF'
+[other]
+x
+EOF
+  run groups_exists "my-group"
+  [ "$status" -ne 0 ]
+}
+
+@test "groups_has_member: true when stack is in group" {
+  _write_groups <<'EOF'
+[g]
+alpha
+beta
+EOF
+  run groups_has_member "g" "beta"
+  [ "$status" -eq 0 ]
+}
+
+@test "groups_has_member: false when stack absent" {
+  _write_groups <<'EOF'
+[g]
+alpha
+EOF
+  run groups_has_member "g" "missing"
+  [ "$status" -ne 0 ]
+}
+
+# ── groups_add ────────────────────────────────────────────────────────────────
+
+@test "groups_add: creates file + section when neither exists" {
+  rm -f "$STRUT_GROUPS_CONF"
+  groups_add "new-group" "stack-a"
+  [ -f "$STRUT_GROUPS_CONF" ]
+  run groups_has_member "new-group" "stack-a"
+  [ "$status" -eq 0 ]
+}
+
+@test "groups_add: appends to existing section" {
+  _write_groups <<'EOF'
+[g]
+existing
+EOF
+  groups_add "g" "added"
+  result=$(groups_members "g")
+  [[ "$result" == *"existing"* ]]
+  [[ "$result" == *"added"* ]]
+}
+
+@test "groups_add: idempotent — doesn't duplicate members" {
+  _write_groups <<'EOF'
+[g]
+alpha
+EOF
+  groups_add "g" "alpha"
+  count=$(groups_members "g" | grep -c "^alpha$")
+  [ "$count" -eq 1 ]
+}
+
+@test "groups_add: creates a new section when the group is new" {
+  _write_groups <<'EOF'
+[existing]
+a
+EOF
+  groups_add "fresh" "x"
+  run groups_exists "fresh"
+  [ "$status" -eq 0 ]
+  run groups_exists "existing"
+  [ "$status" -eq 0 ]
+}
+
+# ── groups_remove ─────────────────────────────────────────────────────────────
+
+@test "groups_remove: removes exact match" {
+  _write_groups <<'EOF'
+[g]
+alpha
+beta
+gamma
+EOF
+  groups_remove "g" "beta"
+  result=$(groups_members "g")
+  [ "$result" = $'alpha\ngamma' ]
+}
+
+@test "groups_remove: idempotent when stack missing" {
+  _write_groups <<'EOF'
+[g]
+alpha
+EOF
+  groups_remove "g" "not-there"
+  result=$(groups_members "g")
+  [ "$result" = "alpha" ]
+}
+
+@test "groups_remove: only affects the named group" {
+  _write_groups <<'EOF'
+[a]
+shared
+
+[b]
+shared
+EOF
+  groups_remove "a" "shared"
+  run groups_has_member "a" "shared"
+  [ "$status" -ne 0 ]
+  run groups_has_member "b" "shared"
+  [ "$status" -eq 0 ]
+}
+
+# ── Round-trip add/remove preserves other content ─────────────────────────────
+
+@test "groups: add+remove roundtrip leaves untouched content intact" {
+  _write_groups <<'EOF'
+# comment
+
+[g1]
+a
+b
+
+[g2]
+c
+EOF
+  groups_add "g2" "d"
+  groups_remove "g2" "c"
+  g1=$(groups_members "g1")
+  g2=$(groups_members "g2")
+  [ "$g1" = $'a\nb' ]
+  [ "$g2" = "d" ]
+}
+
+# ── Property: many add/remove operations leave consistent state ──────────────
+
+@test "Property: 50 add/remove cycles never duplicate or lose members" {
+  for i in $(seq 1 50); do
+    groups_add "churn" "stack-$((i % 5))"
+    if [ $((i % 3)) -eq 0 ]; then
+      groups_remove "churn" "stack-$((i % 5))"
+    fi
+  done
+  # After the dust settles, no duplicates.
+  local members
+  members=$(groups_members "churn")
+  local unique
+  unique=$(printf '%s\n' "$members" | sort -u)
+  [ "$(printf '%s\n' "$members" | sort)" = "$unique" ]
+}


### PR DESCRIPTION
## Summary

Adds `strut group <name> <command>` for coordinated multi-stack operations. Closes #17.

Operators can now define named collections of stacks (e.g. "stacks on vps-1", "all postgres stacks") in `groups.conf` and run a single strut command against every member.

- `lib/groups.sh` — pure INI parser (awk-only, no yq/jq) with list/members/exists/has_member/add/remove
- `lib/cmd_group.sh` — dispatcher for `list|show|add|remove` subcommands plus generic `<group> <command>` pass-through
- Entrypoint — new top-level `group` command routed before the stack/command parser

## Format

```ini
[vps-1]
knowledge-graph
api-service

[postgres-stacks]
knowledge-graph
twenty
```

Stacks can belong to multiple groups. INI-style so it's easy to diff and edit by hand.

## Dispatch strategy

Per-stack execution shells out to `$0 <stack> <cmd> [args]` rather than calling `cmd_*` inline. Slightly slower (re-sources per stack) but isolates state so one stack's env-file leakage can't corrupt the next. Sequential by default; `--stop-on-error` halts on first failure. Text summary at the end; `--json` for CI.

## Commands

```bash
strut group list                        # list groups + member counts
strut group show vps-1                  # show members (✓ present, ✗ missing)
strut group add vps-1 new-stack         # append member (idempotent)
strut group remove vps-1 old-stack      # remove member (idempotent)
strut group vps-1 deploy --env prod     # dispatch to every member
strut group postgres-stacks backup postgres
```

## Notes

- Missing stacks are warned, not fatal, per the acceptance criteria
- Commented one subtle bash-ism in the source: `grep -c .` returns exit 1 on 0 matches, which trips `set -e` for empty groups — swapped for `awk 'NF {n++}'`

## Test plan

- [x] 20 tests in `tests/test_groups.bats` — parser correctness, idempotency, section scoping, round-trip, 50-iteration property test
- [x] Full suite passing (856 tests, 0 failures)
- [x] Manual: `group list` and `group show` on a fixture with vps-1, empty-group, vps-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)