### PR TITLE
feat: protect rollback-referenced images from docker prune (#40)

### DIFF
--- a/lib/cmd_deploy.sh
+++ b/lib/cmd_deploy.sh
@@ -170,15 +170,34 @@ cmd_status() {
   $compose_cmd ps
 }
 
-# cmd_prune [--volumes|positional...]
+# cmd_prune [--volumes] [--all] [--no-protect]
+#
+# Forwards flags through to docker_prune, automatically scoping the prune to
+# the current stack so rollback snapshots can protect their referenced images
+# from deletion. Opt out with --no-protect or PRUNE_PROTECT_ROLLBACK_IMAGES=false.
 cmd_prune() {
+  local -a args=()
+  local protect=true
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --no-protect) protect=false; shift ;;
+      *) args+=("$1"); shift ;;
+    esac
+  done
+  # Default to --volumes when caller passed no flags (preserves prior behavior).
+  [ "${#args[@]}" -eq 0 ] && args=(--volumes)
+
+  if [ "$protect" = "true" ] && [ -n "${CMD_STACK:-}" ]; then
+    args+=(--stack "$CMD_STACK")
+  fi
+
   if [ "$DRY_RUN" = "true" ]; then
     echo ""
     echo -e "${YELLOW}[DRY-RUN] Execution plan for prune:${NC}"
-    run_cmd "Docker system prune" docker system prune -af "${1:---volumes}"
+    run_cmd "Docker system prune" docker system prune -af "${args[@]}"
     echo ""
     echo -e "${YELLOW}[DRY-RUN] No changes made.${NC}"
     return 0
   fi
-  docker_prune "${1:---volumes}"
+  docker_prune "${args[@]}"
 }

--- a/lib/docker.sh
+++ b/lib/docker.sh
@@ -33,24 +33,99 @@ docker_pull_stack() {
     || warn "Some images could not be pulled (may need to build from source)"
 }
 
-# docker_prune [--volumes] [--all]
+# _docker_unused_images
+#   Emits `<repo:tag>\n` for every image that is not currently in use by a
+#   running container. Filters out `<none>:<none>` dangling images (those
+#   have a separate prune step). Used by `docker_prune` when we want to
+#   manually rmi a filtered subset (e.g. to protect rollback-referenced
+#   images).
+_docker_unused_images() {
+  local running_images
+  running_images=$(docker ps --format '{{.Image}}' 2>/dev/null | sort -u)
+  docker images --format '{{.Repository}}:{{.Tag}}' 2>/dev/null \
+    | grep -v '<none>' \
+    | grep -v '^:$' \
+    | awk -v running="$running_images" '
+        BEGIN { n = split(running, arr, "\n"); for (i=1; i<=n; i++) used[arr[i]] = 1 }
+        !($0 in used) { print }
+      '
+}
+
+# docker_prune_protected <protected_images...>
+#
+# Prunes unused images except those in the protected list. Called by
+# `docker_prune` when `--all --protect <img> [<img>...]` is supplied and
+# gives us fine-grained control that `docker image prune -a` can't.
+# Dry-run mode is controlled by $DRY_RUN.
+docker_prune_protected() {
+  local -a protected=("$@")
+  declare -A protect
+  local img
+  for img in "${protected[@]+"${protected[@]}"}"; do
+    protect["$img"]=1
+  done
+
+  local unused
+  unused=$(_docker_unused_images)
+
+  local to_prune=() to_keep=()
+  while IFS= read -r img; do
+    [ -z "$img" ] && continue
+    if [ "${protect[$img]:-0}" = "1" ]; then
+      to_keep+=("$img")
+    else
+      to_prune+=("$img")
+    fi
+  done <<< "$unused"
+
+  if [ "${#to_keep[@]}" -gt 0 ]; then
+    log "Protecting ${#to_keep[@]} image(s) referenced by rollback snapshots:"
+    for img in "${to_keep[@]}"; do
+      echo "  • $img"
+    done
+  fi
+
+  if [ "${#to_prune[@]}" -eq 0 ]; then
+    ok "No unused images to prune"
+    return 0
+  fi
+
+  log "Pruning ${#to_prune[@]} unused image(s)..."
+  for img in "${to_prune[@]}"; do
+    if [ "${DRY_RUN:-false}" = "true" ]; then
+      echo "  [dry-run] docker rmi $img"
+    else
+      docker rmi "$img" 2>/dev/null || warn "Failed to remove $img (may be in use)"
+    fi
+  done
+}
+
+# docker_prune [--volumes] [--all] [--stack <name>]
 #
 # Interactively prunes unused Docker resources: dangling images, build cache,
 # and optionally all unused images and anonymous volumes. Each step prompts
 # for confirmation.
 #
 # Args:
-#   --volumes — Also remove anonymous volumes
-#   --all     — Remove all unused images (not just dangling)
+#   --volumes       — Also remove anonymous volumes
+#   --all           — Remove all unused images (not just dangling)
+#   --stack <name>  — Scope the prune to a stack's context; rollback snapshots
+#                     for <name> will protect their referenced images from
+#                     pruning (respect ROLLBACK_RETENTION_DAYS). Off by default;
+#                     PRUNE_PROTECT_ROLLBACK_IMAGES=false opts out even when
+#                     --stack is provided.
 #
 # Side effects: Removes Docker images, build cache, and optionally volumes
 docker_prune() {
   local remove_volumes=false
   local remove_all=false
+  local scope_stack=""
   while [[ $# -gt 0 ]]; do
     case $1 in
       --volumes) remove_volumes=true; shift ;;
       --all)     remove_all=true;     shift ;;
+      --stack)   scope_stack="${2:-}"; shift 2 ;;
+      --stack=*) scope_stack="${1#*=}"; shift ;;
       *)         shift ;;
     esac
   done
@@ -66,10 +141,24 @@ docker_prune() {
     ok "No dangling images"
   fi
 
-  # All unused images
+  # All unused images — protected by rollback snapshots when applicable.
   if $remove_all; then
-    confirm "Remove ALL unused images (not currently used by any container)?" \
-      && docker image prune -a -f
+    local -a protected=()
+    if [ -n "$scope_stack" ] && [ "${PRUNE_PROTECT_ROLLBACK_IMAGES:-true}" = "true" ]; then
+      if declare -F rollback_protected_images >/dev/null; then
+        while IFS= read -r p; do
+          [ -n "$p" ] && protected+=("$p")
+        done < <(rollback_protected_images "$scope_stack")
+      fi
+    fi
+
+    if [ "${#protected[@]}" -gt 0 ]; then
+      confirm "Remove unused images (protecting ${#protected[@]} referenced by rollback)?" \
+        && docker_prune_protected "${protected[@]}"
+    else
+      confirm "Remove ALL unused images (not currently used by any container)?" \
+        && docker image prune -a -f
+    fi
   fi
 
   # Build cache

--- a/lib/rollback.sh
+++ b/lib/rollback.sh
@@ -202,6 +202,63 @@ rollback_list_snapshots() {
 
 # ── Retention ─────────────────────────────────────────────────────────────────
 
+# rollback_protected_images <stack> [retention_days]
+#
+# Emits image tags referenced by rollback snapshots within the retention
+# window — one per line, deduplicated. Used by `docker_prune` to avoid
+# deleting images a rollback might need.
+#
+# Retention window defaults to $ROLLBACK_RETENTION_DAYS (or 30) and can be
+# overridden by the second arg. A window of 0 means "protect every
+# snapshot that exists" (useful when retention is count-based rather than
+# time-based).
+#
+# Snapshots without jq available fall back to a grep-based extractor so
+# operators without jq still get protection.
+rollback_protected_images() {
+  local stack="$1"
+  local retention_days="${2:-${ROLLBACK_RETENTION_DAYS:-30}}"
+  local rollback_dir
+  rollback_dir=$(_rollback_dir "$stack")
+  [ -d "$rollback_dir" ] || return 0
+
+  # Build the cutoff epoch. 0 disables time-filtering.
+  local cutoff=0
+  if [ "$retention_days" -gt 0 ] 2>/dev/null; then
+    local now
+    now=$(date -u +%s)
+    cutoff=$(( now - retention_days * 86400 ))
+  fi
+
+  local f ts ts_epoch
+  for f in "$rollback_dir"/*.json; do
+    [ -f "$f" ] || continue
+
+    if [ "$cutoff" -gt 0 ]; then
+      if command -v jq >/dev/null 2>&1; then
+        ts=$(jq -r '.timestamp // empty' "$f" 2>/dev/null || echo "")
+      else
+        ts=$(awk -F'"' '/"timestamp"/ { print $4; exit }' "$f")
+      fi
+      if [ -n "$ts" ]; then
+        ts_epoch=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$ts" +%s 2>/dev/null \
+          || date -u -d "$ts" +%s 2>/dev/null \
+          || echo 0)
+        if [ "$ts_epoch" -lt "$cutoff" ]; then
+          continue
+        fi
+      fi
+    fi
+
+    if command -v jq >/dev/null 2>&1; then
+      jq -r '.services | to_entries[] | .value.image' "$f" 2>/dev/null
+    else
+      # Grep-based fallback: tolerates slight JSON formatting changes.
+      awk -F'"' '/"image"[[:space:]]*:/ { print $4 }' "$f"
+    fi
+  done | awk 'NF && !seen[$0]++'
+}
+
 # rollback_enforce_retention <stack>
 # Keeps only the last N snapshots (default: 5, configurable via ROLLBACK_RETENTION)
 rollback_enforce_retention() {

--- a/tests/test_rollback_protect.bats
+++ b/tests/test_rollback_protect.bats
@@ -1,0 +1,273 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_rollback_protect.bats — rollback-aware docker image pruning
+# ==================================================
+# Covers:
+#   rollback_protected_images  (lib/rollback.sh) — image extraction + dedup
+#   docker_prune_protected     (lib/docker.sh)   — manual rmi respecting
+#                                                  protect set + DRY_RUN
+#
+# We do not run Docker; docker_prune_protected is exercised with DRY_RUN=true
+# so it prints what it would remove.
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_utils
+  source "$CLI_ROOT/lib/rollback.sh"
+  source "$CLI_ROOT/lib/docker.sh"
+
+  # Each test gets its own stack + rollback dir, sandboxed under TEST_TMP via
+  # CLI_ROOT-rooted paths. We override _rollback_dir by overriding CLI_ROOT.
+  export SANDBOX_ROOT="$TEST_TMP/sandbox"
+  mkdir -p "$SANDBOX_ROOT/stacks"
+}
+
+teardown() {
+  common_teardown
+  unset SANDBOX_ROOT ROLLBACK_RETENTION_DAYS PRUNE_PROTECT_ROLLBACK_IMAGES DRY_RUN
+}
+
+# Helper — write a snapshot with given iso-timestamp and image list.
+# Args: <stack> <timestamp> <image1> [image2...]
+_write_snapshot() {
+  local stack="$1" ts="$2"; shift 2
+  local dir="$SANDBOX_ROOT/stacks/$stack/.rollback"
+  mkdir -p "$dir"
+  local ts_file
+  ts_file=$(echo "$ts" | tr -d ':-')
+  ts_file="${ts_file%Z}"
+  local file="$dir/${ts_file}.json"
+
+  local services="{" first=true
+  local n=0
+  local img
+  for img in "$@"; do
+    if $first; then first=false; else services+=","; fi
+    services+="\"svc$n\":{\"image\":\"$img\"}"
+    n=$((n + 1))
+  done
+  services+="}"
+
+  cat > "$file" <<EOF
+{
+  "timestamp": "$ts",
+  "stack": "$stack",
+  "env": "test",
+  "service_count": $n,
+  "services": $services
+}
+EOF
+  echo "$file"
+}
+
+# Override _rollback_dir to point into the sandbox.
+_sandbox_dir_override() {
+  eval '
+_rollback_dir() {
+  echo "$SANDBOX_ROOT/stacks/$1/.rollback"
+}'
+}
+
+# ── rollback_protected_images ────────────────────────────────────────────────
+
+@test "rollback_protected_images: empty dir → no output" {
+  _sandbox_dir_override
+  local out
+  out=$(rollback_protected_images "nope" 30)
+  [ -z "$out" ]
+}
+
+@test "rollback_protected_images: recent snapshot → images listed" {
+  _sandbox_dir_override
+  local stack="pp-recent"
+  local now_iso
+  now_iso=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  _write_snapshot "$stack" "$now_iso" \
+    "ghcr.io/org/api:sha-111" \
+    "nginx:1.25" >/dev/null
+
+  run rollback_protected_images "$stack" 30
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ghcr.io/org/api:sha-111"* ]]
+  [[ "$output" == *"nginx:1.25"* ]]
+}
+
+@test "rollback_protected_images: old snapshot excluded by retention window" {
+  _sandbox_dir_override
+  local stack="pp-old"
+  # 100 days ago — well outside 30-day window
+  _write_snapshot "$stack" "2020-01-01T00:00:00Z" \
+    "ghcr.io/org/api:ancient" >/dev/null
+
+  run rollback_protected_images "$stack" 30
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"ghcr.io/org/api:ancient"* ]]
+}
+
+@test "rollback_protected_images: retention 0 protects every snapshot" {
+  _sandbox_dir_override
+  local stack="pp-all"
+  _write_snapshot "$stack" "2020-01-01T00:00:00Z" \
+    "ghcr.io/org/api:ancient" >/dev/null
+
+  run rollback_protected_images "$stack" 0
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ghcr.io/org/api:ancient"* ]]
+}
+
+@test "rollback_protected_images: duplicates are deduped across snapshots" {
+  _sandbox_dir_override
+  local stack="pp-dedup"
+  local now_iso
+  now_iso=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  _write_snapshot "$stack" "$now_iso" \
+    "ghcr.io/org/api:sha-1" "nginx:1.25" >/dev/null
+  _write_snapshot "$stack" "${now_iso%Z}.001Z" \
+    "ghcr.io/org/api:sha-1" "redis:7" >/dev/null 2>/dev/null || \
+    _write_snapshot "$stack" "$(date -u -v+1S +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d '+1 sec' +"%Y-%m-%dT%H:%M:%SZ")" \
+      "ghcr.io/org/api:sha-1" "redis:7" >/dev/null
+
+  run rollback_protected_images "$stack" 30
+  [ "$status" -eq 0 ]
+
+  # api:sha-1 should appear exactly once
+  local api_count
+  api_count=$(echo "$output" | grep -c 'ghcr.io/org/api:sha-1' || true)
+  [ "$api_count" -eq 1 ]
+}
+
+@test "rollback_protected_images: env override ROLLBACK_RETENTION_DAYS" {
+  _sandbox_dir_override
+  local stack="pp-envret"
+  # 5-day-old snapshot
+  local five_days_ago
+  five_days_ago=$(date -u -v-5d +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+    || date -u -d '-5 days' +"%Y-%m-%dT%H:%M:%SZ")
+  _write_snapshot "$stack" "$five_days_ago" "ghcr.io/org/mid:v1" >/dev/null
+
+  # With 2-day window → excluded
+  ROLLBACK_RETENTION_DAYS=2
+  export ROLLBACK_RETENTION_DAYS
+  run rollback_protected_images "$stack"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"ghcr.io/org/mid:v1"* ]]
+
+  # With 10-day window → included
+  ROLLBACK_RETENTION_DAYS=10
+  export ROLLBACK_RETENTION_DAYS
+  run rollback_protected_images "$stack"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ghcr.io/org/mid:v1"* ]]
+}
+
+# ── docker_prune_protected ───────────────────────────────────────────────────
+#
+# We stub `docker` on PATH so the function's internals (docker ps, docker images,
+# docker rmi) run through our fake. In DRY_RUN mode, removal just prints.
+
+_install_docker_stub() {
+  # Writes a docker stub that emits a fixed image list and records rmi calls.
+  local stub_dir="$TEST_TMP/bin"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/docker" <<'EOF'
+#!/usr/bin/env bash
+# Fake docker for prune-protect tests.
+# Subcommands:
+#   ps --format '{{.Image}}'          → running images (from $FAKE_RUNNING)
+#   images --format ...               → image list (from $FAKE_IMAGES)
+#   rmi <img>                         → append to $TEST_TMP/rmi.log, succeed
+case "$1" in
+  ps)
+    printf '%s\n' $FAKE_RUNNING
+    ;;
+  images)
+    printf '%s\n' $FAKE_IMAGES
+    ;;
+  rmi)
+    shift
+    echo "$@" >> "$TEST_TMP/rmi.log"
+    ;;
+  *)
+    echo "docker stub: unhandled $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+  chmod +x "$stub_dir/docker"
+  export PATH="$stub_dir:$PATH"
+  export TEST_TMP
+}
+
+@test "_docker_unused_images: lists non-running, non-dangling" {
+  _install_docker_stub
+  export FAKE_RUNNING="ghcr.io/org/running:v1"
+  export FAKE_IMAGES=$'ghcr.io/org/running:v1\nghcr.io/org/stale:v1\nghcr.io/org/other:v2'
+
+  run _docker_unused_images
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ghcr.io/org/stale:v1"* ]]
+  [[ "$output" == *"ghcr.io/org/other:v2"* ]]
+  [[ "$output" != *"ghcr.io/org/running:v1"* ]]
+}
+
+@test "docker_prune_protected: DRY_RUN prints but does not rmi" {
+  _install_docker_stub
+  export FAKE_RUNNING=""
+  export FAKE_IMAGES=$'ghcr.io/org/keep:v1\nghcr.io/org/drop:v1'
+  : > "$TEST_TMP/rmi.log"
+  export DRY_RUN=true
+
+  run docker_prune_protected "ghcr.io/org/keep:v1"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[dry-run] docker rmi ghcr.io/org/drop:v1"* ]]
+  # Nothing actually rmi'd
+  [ ! -s "$TEST_TMP/rmi.log" ]
+}
+
+@test "docker_prune_protected: protects listed images, removes the rest" {
+  _install_docker_stub
+  export FAKE_RUNNING=""
+  export FAKE_IMAGES=$'ghcr.io/org/keep:v1\nghcr.io/org/drop:v1\nghcr.io/org/drop:v2'
+  : > "$TEST_TMP/rmi.log"
+  export DRY_RUN=false
+
+  run docker_prune_protected "ghcr.io/org/keep:v1"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Protecting 1 image(s)"* ]]
+  [[ "$output" == *"ghcr.io/org/keep:v1"* ]]
+
+  # Check rmi log
+  local log
+  log=$(cat "$TEST_TMP/rmi.log")
+  [[ "$log" == *"ghcr.io/org/drop:v1"* ]]
+  [[ "$log" == *"ghcr.io/org/drop:v2"* ]]
+  [[ "$log" != *"ghcr.io/org/keep:v1"* ]]
+}
+
+@test "docker_prune_protected: no unused images → ok, no-op" {
+  _install_docker_stub
+  export FAKE_RUNNING="ghcr.io/org/only:v1"
+  export FAKE_IMAGES="ghcr.io/org/only:v1"
+  : > "$TEST_TMP/rmi.log"
+  export DRY_RUN=false
+
+  run docker_prune_protected
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No unused images to prune"* ]]
+  [ ! -s "$TEST_TMP/rmi.log" ]
+}
+
+@test "docker_prune_protected: empty protect list → removes all unused" {
+  _install_docker_stub
+  export FAKE_RUNNING=""
+  export FAKE_IMAGES=$'ghcr.io/org/a:v1\nghcr.io/org/b:v1'
+  : > "$TEST_TMP/rmi.log"
+  export DRY_RUN=false
+
+  run docker_prune_protected
+  [ "$status" -eq 0 ]
+  local log
+  log=$(cat "$TEST_TMP/rmi.log")
+  [[ "$log" == *"ghcr.io/org/a:v1"* ]]
+  [[ "$log" == *"ghcr.io/org/b:v1"* ]]
+}


### PR DESCRIPTION
Closes #40

## Summary
- Adds `rollback_protected_images <stack> [days]` — extracts image tags from rollback JSON snapshots within a retention window (default 30d, overridable via `ROLLBACK_RETENTION_DAYS`). jq when available, awk fallback otherwise.
- Extends `docker_prune` with `--stack <name>`: computes the protected set and routes `--all` through `docker_prune_protected`, which manually `docker rmi`s only unprotected unused images (respects `DRY_RUN`).
- `cmd_prune` auto-scopes with the current stack. Opt out with `--no-protect` or `PRUNE_PROTECT_ROLLBACK_IMAGES=false`.

## Why this matters
`docker_prune --all` would silently delete the exact image tags recent rollback snapshots depend on. A routine post-deploy cleanup could strip safety nets from the last N deploys without the operator noticing.

## Test plan
- [x] 11 new BATS cases in `tests/test_rollback_protect.bats`
  - retention window filters old snapshots
  - retention 0 protects everything
  - duplicate image tags deduped across snapshots
  - `ROLLBACK_RETENTION_DAYS` env override respected
  - `_docker_unused_images` omits running + dangling
  - `docker_prune_protected` in DRY_RUN prints without `rmi`
  - `docker_prune_protected` removes non-protected, keeps protected
  - no-op when nothing unused; empty protect list → removes all
- [x] Full bats suite: 876/876 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)