### PR TITLE
feat: add rollback diff for snapshot-to-snapshot forensics (#42)

### DIFF
--- a/lib/cmd_rollback.sh
+++ b/lib/cmd_rollback.sh
@@ -10,12 +10,16 @@ set -euo pipefail
 _usage_rollback() {
   echo ""
   echo "Usage: strut <stack> rollback [--env <name>] [--list] [--dry-run]"
+  echo "       strut <stack> rollback diff <a> <b> [--json]"
   echo ""
-  echo "Roll back to the previous deploy snapshot."
+  echo "Roll back to the previous deploy snapshot, list snapshots, or diff"
+  echo "two historical snapshots for post-incident forensics."
   echo ""
   echo "Flags:"
   echo "  --list               List available rollback points"
   echo "  --dry-run            Show what would be restored without making changes"
+  echo ""
+  echo "Diff refs accept: snapshot basename, HEAD (latest), or HEAD~N (Nth older)."
   echo ""
   echo "Snapshots are automatically saved before each deploy."
   echo "Retention: last ${ROLLBACK_RETENTION:-5} snapshots (configurable via ROLLBACK_RETENTION in strut.conf)."
@@ -24,7 +28,92 @@ _usage_rollback() {
   echo "  strut my-stack rollback --env prod"
   echo "  strut my-stack rollback --env prod --list"
   echo "  strut my-stack rollback --env prod --dry-run"
+  echo "  strut my-stack rollback diff HEAD~1 HEAD"
+  echo "  strut my-stack rollback diff 20260420-091500 HEAD --json"
   echo ""
+}
+
+# _rollback_diff <stack> <ref-a> <ref-b> [--json]
+#
+# Renders a structured diff of the images each snapshot captured.
+# Exit codes match `strut diff`:
+#   0 — snapshots are equivalent (no image changes)
+#   1 — snapshots differ
+#   2 — error resolving a ref
+_rollback_diff() {
+  local stack="$1"; shift
+  local ref_a="" ref_b=""
+  local json_mode=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --json)    json_mode=true; shift ;;
+      --help|-h) _usage_rollback; return 0 ;;
+      *)
+        if [ -z "$ref_a" ]; then ref_a="$1"
+        elif [ -z "$ref_b" ]; then ref_b="$1"
+        else
+          fail "Unexpected arg: $1 (usage: rollback diff <a> <b>)"
+          return 2
+        fi
+        shift ;;
+    esac
+  done
+
+  if [ -z "$ref_a" ] || [ -z "$ref_b" ]; then
+    _usage_rollback
+    fail "rollback diff requires two snapshot refs"
+    return 2
+  fi
+
+  # Ensure diff helpers are available when cmd_rollback is sourced standalone.
+  # Guarded so tests can override _rollback_dir after sourcing without us
+  # clobbering it on re-entry.
+  declare -F rollback_get_latest_snapshot >/dev/null || source "$LIB/rollback.sh"
+  declare -F diff_image_pairs            >/dev/null || source "$LIB/diff.sh"
+
+  local file_a file_b
+  file_a=$(rollback_resolve_ref "$stack" "$ref_a") || return 2
+  file_b=$(rollback_resolve_ref "$stack" "$ref_b") || return 2
+
+  local pairs_a pairs_b
+  pairs_a=$(rollback_snapshot_image_pairs "$file_a")
+  pairs_b=$(rollback_snapshot_image_pairs "$file_b")
+
+  # Treat <b> as "new" — operators read "HEAD~1 → HEAD" as "from old to new".
+  local image_diff
+  image_diff=$(diff_image_pairs "$pairs_b" "$pairs_a")
+
+  local has_changes=0
+  [ -n "$image_diff" ] && has_changes=1
+
+  local base_a base_b
+  base_a=$(basename "$file_a" .json)
+  base_b=$(basename "$file_b" .json)
+
+  if [ "$json_mode" = "true" ]; then
+    OUTPUT_MODE=json
+    out_json_object
+      out_json_field "stack" "$stack"
+      out_json_field "from" "$base_a"
+      out_json_field "to" "$base_b"
+      out_json_field_raw "has_changes" "$([ "$has_changes" -eq 1 ] && echo true || echo false)"
+      _diff_render_section_json "images" "$image_diff"
+    out_json_close_object
+    out_json_newline
+  else
+    if [ "$has_changes" -eq 0 ]; then
+      ok "Snapshots are identical: $base_a == $base_b"
+    else
+      echo ""
+      echo "Rollback diff for $stack: $base_a → $base_b"
+      _diff_render_section_text "Images" "$image_diff"
+      echo ""
+    fi
+  fi
+
+  [ "$has_changes" -eq 1 ] && return 1
+  return 0
 }
 
 cmd_rollback() {
@@ -33,6 +122,14 @@ cmd_rollback() {
   local env_file="$CMD_ENV_FILE"
   local env_name="$CMD_ENV_NAME"
   local services="$CMD_SERVICES"
+
+  # Subcommand dispatch — `rollback diff …` runs independently of the
+  # restore path (no env file or compose required).
+  if [ "${1:-}" = "diff" ]; then
+    shift
+    _rollback_diff "$stack" "$@"
+    return $?
+  fi
 
   # Parse rollback-specific flags
   local list_mode=false
@@ -43,7 +140,7 @@ cmd_rollback() {
     esac
   done
 
-  source "$LIB/rollback.sh"
+  declare -F rollback_get_latest_snapshot >/dev/null || source "$LIB/rollback.sh"
 
   if $list_mode; then
     rollback_list_snapshots "$stack"

--- a/lib/diff.sh
+++ b/lib/diff.sh
@@ -142,12 +142,60 @@ diff_extract_images() {
   '
 }
 
+# diff_image_pairs <new_pairs> <old_pairs>
+#
+# Both args are streams of `service<US>image\n` rows (US = 0x1f). Emits
+# the same op stream as diff_env_content — ADD/REMOVE/CHANGE — so callers
+# can treat env and image diffs uniformly.
+#
+# Semantics match the two-argument convention used elsewhere: the first
+# argument is the *newer* / *incoming* side (what's on the left of "→")
+# when rendered, the second is the *older* / *baseline* side.
+#
+#   ADD    → present in new only
+#   REMOVE → present in old only
+#   CHANGE → present in both but differs
+diff_image_pairs() {
+  local new_pairs="$1"
+  local old_pairs="$2"
+
+  declare -A new_map old_map
+  local svc img
+  while IFS=$'\x1f' read -r svc img; do
+    [ -z "$svc" ] && continue
+    new_map[$svc]="$img"
+  done <<< "$new_pairs"
+
+  while IFS=$'\x1f' read -r svc img; do
+    [ -z "$svc" ] && continue
+    old_map[$svc]="$img"
+  done <<< "$old_pairs"
+
+  local -a all_svcs=()
+  for svc in "${!new_map[@]}" "${!old_map[@]}"; do
+    all_svcs+=("$svc")
+  done
+  local sorted
+  sorted=$(printf '%s\n' "${all_svcs[@]+"${all_svcs[@]}"}" | sort -u)
+
+  while IFS= read -r svc; do
+    [ -z "$svc" ] && continue
+    local nv="${new_map[$svc]-__STRUT_ABSENT__}"
+    local ov="${old_map[$svc]-__STRUT_ABSENT__}"
+    if [ "$nv" = "__STRUT_ABSENT__" ] && [ "$ov" != "__STRUT_ABSENT__" ]; then
+      printf 'REMOVE\x1f%s\x1f%s\x1f\n' "$svc" "$ov"
+    elif [ "$nv" != "__STRUT_ABSENT__" ] && [ "$ov" = "__STRUT_ABSENT__" ]; then
+      printf 'ADD\x1f%s\x1f\x1f%s\n' "$svc" "$nv"
+    elif [ "$nv" != "$ov" ]; then
+      printf 'CHANGE\x1f%s\x1f%s\x1f%s\n' "$svc" "$ov" "$nv"
+    fi
+  done <<< "$sorted"
+}
+
 # diff_images_content <local_content> <remote_content>
 #
-# Compares extracted service→image maps. Emits TSV:
-#   ADD\t<service>\t\t<new_image>
-#   REMOVE\t<service>\t<old_image>\t
-#   CHANGE\t<service>\t<old_image>\t<new_image>
+# Compares extracted service→image maps from two compose files. Thin
+# wrapper over diff_image_pairs.
 diff_images_content() {
   local local_content="$1"
   local remote_content="$2"
@@ -156,37 +204,7 @@ diff_images_content() {
   loc_img=$(diff_extract_images "$local_content")
   rem_img=$(diff_extract_images "$remote_content")
 
-  declare -A loc_map rem_map
-  local svc img
-  while IFS=$'\x1f' read -r svc img; do
-    [ -z "$svc" ] && continue
-    loc_map[$svc]="$img"
-  done <<< "$loc_img"
-
-  while IFS=$'\x1f' read -r svc img; do
-    [ -z "$svc" ] && continue
-    rem_map[$svc]="$img"
-  done <<< "$rem_img"
-
-  local -a all_svcs=()
-  for svc in "${!loc_map[@]}" "${!rem_map[@]}"; do
-    all_svcs+=("$svc")
-  done
-  local sorted
-  sorted=$(printf '%s\n' "${all_svcs[@]}" | sort -u)
-
-  while IFS= read -r svc; do
-    [ -z "$svc" ] && continue
-    local lv="${loc_map[$svc]-__STRUT_ABSENT__}"
-    local rv="${rem_map[$svc]-__STRUT_ABSENT__}"
-    if [ "$lv" = "__STRUT_ABSENT__" ] && [ "$rv" != "__STRUT_ABSENT__" ]; then
-      printf 'REMOVE\x1f%s\x1f%s\x1f\n' "$svc" "$rv"
-    elif [ "$lv" != "__STRUT_ABSENT__" ] && [ "$rv" = "__STRUT_ABSENT__" ]; then
-      printf 'ADD\x1f%s\x1f\x1f%s\n' "$svc" "$lv"
-    elif [ "$lv" != "$rv" ]; then
-      printf 'CHANGE\x1f%s\x1f%s\x1f%s\n' "$svc" "$rv" "$lv"
-    fi
-  done <<< "$sorted"
+  diff_image_pairs "$loc_img" "$rem_img"
 }
 
 # ── Remote fetchers (thin SSH wrappers) ───────────────────────────────────────

--- a/lib/rollback.sh
+++ b/lib/rollback.sh
@@ -259,6 +259,94 @@ rollback_protected_images() {
   done | awk 'NF && !seen[$0]++'
 }
 
+# ── Reference resolution ──────────────────────────────────────────────────────
+#
+# rollback_list_snapshot_files <stack>
+#
+# Emits snapshot file paths in descending timestamp order (newest first),
+# one per line. Empty output when the rollback dir is missing or empty.
+rollback_list_snapshot_files() {
+  local stack="$1"
+  local rollback_dir
+  rollback_dir=$(_rollback_dir "$stack")
+  [ -d "$rollback_dir" ] || return 0
+  ls -t "$rollback_dir"/*.json 2>/dev/null || true
+}
+
+# rollback_resolve_ref <stack> <ref>
+#
+# Resolves a human-supplied snapshot reference to an absolute file path.
+# Supported forms:
+#   HEAD         → newest snapshot
+#   HEAD~N       → Nth-older snapshot (HEAD~0 == HEAD, HEAD~1 == previous, …)
+#   <basename>   → file at <rollback_dir>/<basename>.json (with or without .json)
+#   <path>       → verbatim path when absolute or existing
+#
+# Returns 0 with the path on stdout, 1 with an error message on stderr when
+# the ref cannot be resolved.
+rollback_resolve_ref() {
+  local stack="$1"
+  local ref="$2"
+
+  [ -z "$ref" ] && { echo "empty snapshot ref" >&2; return 1; }
+
+  # Literal path that exists.
+  if [ -f "$ref" ]; then
+    echo "$ref"
+    return 0
+  fi
+
+  # HEAD[~N] form
+  if [[ "$ref" =~ ^HEAD(~([0-9]+))?$ ]]; then
+    local offset="${BASH_REMATCH[2]:-0}"
+    local -a snapshots=()
+    while IFS= read -r f; do
+      [ -n "$f" ] && snapshots+=("$f")
+    done < <(rollback_list_snapshot_files "$stack")
+    local count="${#snapshots[@]}"
+    if [ "$count" -eq 0 ]; then
+      echo "no snapshots for stack '$stack'" >&2
+      return 1
+    fi
+    if [ "$offset" -ge "$count" ]; then
+      echo "HEAD~$offset out of range (only $count snapshot(s) exist)" >&2
+      return 1
+    fi
+    echo "${snapshots[$offset]}"
+    return 0
+  fi
+
+  # Basename lookup inside the stack's rollback dir.
+  local rollback_dir
+  rollback_dir=$(_rollback_dir "$stack")
+  local base="${ref%.json}"
+  local candidate="$rollback_dir/${base}.json"
+  if [ -f "$candidate" ]; then
+    echo "$candidate"
+    return 0
+  fi
+
+  echo "snapshot not found: $ref" >&2
+  return 1
+}
+
+# rollback_snapshot_image_pairs <snapshot_file>
+#
+# Emits `<service><US><image>\n` rows for every service in the snapshot.
+# US = 0x1f, matching the delimiter used by lib/diff.sh. Requires jq —
+# rollback_restore_snapshot already makes jq a hard requirement, so the
+# rest of the rollback family follows the same policy.
+rollback_snapshot_image_pairs() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+
+  if ! command -v jq >/dev/null 2>&1; then
+    fail "jq is required for rollback diff (install with: brew install jq)"
+  fi
+
+  jq -r '.services | to_entries[] | "\(.key)\u001f\(.value.image)"' "$file" 2>/dev/null
+}
+
 # rollback_enforce_retention <stack>
 # Keeps only the last N snapshots (default: 5, configurable via ROLLBACK_RETENTION)
 rollback_enforce_retention() {

--- a/tests/test_rollback_diff.bats
+++ b/tests/test_rollback_diff.bats
@@ -1,0 +1,321 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_rollback_diff.bats — `strut <stack> rollback diff` coverage
+# ==================================================
+# Covers:
+#   rollback_list_snapshot_files    (ordering)
+#   rollback_resolve_ref            (HEAD / HEAD~N / basename / missing)
+#   rollback_snapshot_image_pairs   (jq-backed extraction)
+#   _rollback_diff                  (end-to-end text + json)
+#
+# jq is required for rollback diff — tests skip gracefully when it's
+# missing so CI on minimal images doesn't explode.
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_utils
+  source "$CLI_ROOT/lib/output.sh"
+  source "$CLI_ROOT/lib/diff.sh"
+  source "$CLI_ROOT/lib/rollback.sh"
+  source "$CLI_ROOT/lib/cmd_rollback.sh"
+
+  # _rollback_diff re-sources via $LIB — point it at our lib/ dir.
+  export LIB="$CLI_ROOT/lib"
+
+  # Sandbox snapshot dirs under TEST_TMP by overriding _rollback_dir.
+  export SANDBOX_ROOT="$TEST_TMP/sandbox"
+  mkdir -p "$SANDBOX_ROOT"
+  eval '
+_rollback_dir() {
+  echo "$SANDBOX_ROOT/stacks/$1/.rollback"
+}'
+}
+
+teardown() {
+  common_teardown
+  unset SANDBOX_ROOT LIB
+}
+
+_require_jq() {
+  command -v jq >/dev/null 2>&1 || skip "jq not installed"
+}
+
+# Helper: write a snapshot at a specific timestamp with a list of svc=img pairs.
+#   _write_snap <stack> <file-basename> <iso-ts> <svc1=img1> [<svc2=img2> …]
+_write_snap() {
+  local stack="$1" base="$2" ts="$3"; shift 3
+  local dir="$SANDBOX_ROOT/stacks/$stack/.rollback"
+  mkdir -p "$dir"
+  local file="$dir/$base.json"
+
+  local services="{" first=true
+  local pair key val
+  for pair in "$@"; do
+    key="${pair%%=*}"
+    val="${pair#*=}"
+    if $first; then first=false; else services+=","; fi
+    services+="\"$key\":{\"image\":\"$val\"}"
+  done
+  services+="}"
+
+  cat > "$file" <<EOF
+{
+  "timestamp": "$ts",
+  "stack": "$stack",
+  "env": "test",
+  "service_count": $#,
+  "services": $services
+}
+EOF
+  echo "$file"
+}
+
+# ── rollback_list_snapshot_files ─────────────────────────────────────────────
+
+@test "list_snapshot_files: empty dir → no output" {
+  run rollback_list_snapshot_files "empty-stack"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "list_snapshot_files: returns newest first" {
+  local stack="lst-$$"
+  # Create in timestamp-order; ls -t uses mtime so sleep between creates.
+  _write_snap "$stack" "old"   "2026-04-19T12:00:00Z" "api=v1" >/dev/null
+  sleep 1
+  _write_snap "$stack" "mid"   "2026-04-20T09:00:00Z" "api=v2" >/dev/null
+  sleep 1
+  _write_snap "$stack" "new"   "2026-04-20T14:00:00Z" "api=v3" >/dev/null
+
+  run rollback_list_snapshot_files "$stack"
+  [ "$status" -eq 0 ]
+
+  # First line should be the newest.
+  local first
+  first=$(echo "$output" | head -1)
+  [[ "$first" == *"new.json" ]]
+  local last
+  last=$(echo "$output" | tail -1)
+  [[ "$last" == *"old.json" ]]
+}
+
+# ── rollback_resolve_ref ─────────────────────────────────────────────────────
+
+@test "resolve_ref: HEAD returns newest" {
+  local stack="hd-$$"
+  _write_snap "$stack" "a" "2026-04-19T00:00:00Z" "api=v1" >/dev/null
+  sleep 1
+  _write_snap "$stack" "b" "2026-04-20T00:00:00Z" "api=v2" >/dev/null
+
+  run rollback_resolve_ref "$stack" "HEAD"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"b.json" ]]
+}
+
+@test "resolve_ref: HEAD~1 returns previous" {
+  local stack="hd1-$$"
+  _write_snap "$stack" "a" "2026-04-19T00:00:00Z" "api=v1" >/dev/null
+  sleep 1
+  _write_snap "$stack" "b" "2026-04-20T00:00:00Z" "api=v2" >/dev/null
+
+  run rollback_resolve_ref "$stack" "HEAD~1"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"a.json" ]]
+}
+
+@test "resolve_ref: basename with or without .json suffix" {
+  local stack="bn-$$"
+  _write_snap "$stack" "my-snap" "2026-04-20T00:00:00Z" "api=v1" >/dev/null
+
+  run rollback_resolve_ref "$stack" "my-snap"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"my-snap.json" ]]
+
+  run rollback_resolve_ref "$stack" "my-snap.json"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"my-snap.json" ]]
+}
+
+@test "resolve_ref: unknown basename errors" {
+  local stack="un-$$"
+  _write_snap "$stack" "exists" "2026-04-20T00:00:00Z" "api=v1" >/dev/null
+
+  run rollback_resolve_ref "$stack" "does-not-exist"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"snapshot not found"* ]]
+}
+
+@test "resolve_ref: HEAD with no snapshots errors" {
+  run rollback_resolve_ref "ghost-stack" "HEAD"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no snapshots"* ]]
+}
+
+@test "resolve_ref: HEAD~N out of range errors" {
+  local stack="or-$$"
+  _write_snap "$stack" "only" "2026-04-20T00:00:00Z" "api=v1" >/dev/null
+
+  run rollback_resolve_ref "$stack" "HEAD~5"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"out of range"* ]]
+}
+
+# ── rollback_snapshot_image_pairs ────────────────────────────────────────────
+
+@test "snapshot_image_pairs: extracts service/image via jq" {
+  _require_jq
+  local stack="ip-$$"
+  local file
+  file=$(_write_snap "$stack" "s" "2026-04-20T00:00:00Z" \
+    "api=ghcr.io/org/api:v1" "worker=ghcr.io/org/worker:v2")
+
+  run rollback_snapshot_image_pairs "$file"
+  [ "$status" -eq 0 ]
+  # Fields separated by US (0x1f). Use printf to build the expected rows.
+  local us_api
+  us_api=$(printf 'api\x1fghcr.io/org/api:v1')
+  local us_worker
+  us_worker=$(printf 'worker\x1fghcr.io/org/worker:v2')
+  [[ "$output" == *"$us_api"* ]]
+  [[ "$output" == *"$us_worker"* ]]
+}
+
+# ── _rollback_diff (end-to-end) ──────────────────────────────────────────────
+
+@test "rollback diff: identical snapshots → exit 0, no change" {
+  _require_jq
+  local stack="id-$$"
+  _write_snap "$stack" "a" "2026-04-19T00:00:00Z" "api=v1" >/dev/null
+  sleep 1
+  _write_snap "$stack" "b" "2026-04-20T00:00:00Z" "api=v1" >/dev/null
+
+  run _rollback_diff "$stack" "a" "b"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"identical"* ]]
+}
+
+@test "rollback diff: image bump → CHANGE row, exit 1" {
+  _require_jq
+  local stack="ch-$$"
+  _write_snap "$stack" "a" "2026-04-19T00:00:00Z" "api=v1" >/dev/null
+  sleep 1
+  _write_snap "$stack" "b" "2026-04-20T00:00:00Z" "api=v2" >/dev/null
+
+  run _rollback_diff "$stack" "a" "b"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"api"* ]]
+  [[ "$output" == *"v1"* ]]
+  [[ "$output" == *"v2"* ]]
+  [[ "$output" == *"→"* ]] || [[ "$output" == *"->"* ]]
+}
+
+@test "rollback diff: service added in newer snapshot → ADD" {
+  _require_jq
+  local stack="ad-$$"
+  _write_snap "$stack" "a" "2026-04-19T00:00:00Z" "api=v1" >/dev/null
+  sleep 1
+  _write_snap "$stack" "b" "2026-04-20T00:00:00Z" "api=v1" "new-svc=ghcr.io/org/new:v1" >/dev/null
+
+  run _rollback_diff "$stack" "a" "b"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"new-svc"* ]]
+  [[ "$output" == *"+"* ]]
+}
+
+@test "rollback diff: service removed in newer snapshot → REMOVE" {
+  _require_jq
+  local stack="rm-$$"
+  _write_snap "$stack" "a" "2026-04-19T00:00:00Z" "api=v1" "gone=v1" >/dev/null
+  sleep 1
+  _write_snap "$stack" "b" "2026-04-20T00:00:00Z" "api=v1" >/dev/null
+
+  run _rollback_diff "$stack" "a" "b"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"gone"* ]]
+  [[ "$output" == *"-"* ]]
+}
+
+@test "rollback diff: HEAD~1 HEAD shortcut resolves correctly" {
+  _require_jq
+  local stack="sh-$$"
+  _write_snap "$stack" "old" "2026-04-19T00:00:00Z" "api=v1" >/dev/null
+  sleep 1
+  _write_snap "$stack" "new" "2026-04-20T00:00:00Z" "api=v2" >/dev/null
+
+  run _rollback_diff "$stack" "HEAD~1" "HEAD"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"old → new"* ]]
+  [[ "$output" == *"api"* ]]
+}
+
+@test "rollback diff: --json output is structured" {
+  _require_jq
+  local stack="js-$$"
+  _write_snap "$stack" "a" "2026-04-19T00:00:00Z" "api=v1" >/dev/null
+  sleep 1
+  _write_snap "$stack" "b" "2026-04-20T00:00:00Z" "api=v2" >/dev/null
+
+  run _rollback_diff "$stack" "a" "b" --json
+  [ "$status" -eq 1 ]
+  # Validate structure with jq
+  run bash -c "
+    source '$CLI_ROOT/lib/utils.sh'
+    fail() { echo \"\$1\" >&2; return 1; }
+    source '$CLI_ROOT/lib/output.sh'
+    source '$CLI_ROOT/lib/diff.sh'
+    source '$CLI_ROOT/lib/rollback.sh'
+    source '$CLI_ROOT/lib/cmd_rollback.sh'
+    eval '
+_rollback_dir() {
+  echo \"$SANDBOX_ROOT/stacks/\$1/.rollback\"
+}'
+    LIB='$CLI_ROOT/lib' _rollback_diff '$stack' a b --json
+  "
+  [[ "$output" == *'"stack"'* ]]
+  [[ "$output" == *'"from"'* ]]
+  [[ "$output" == *'"to"'* ]]
+  [[ "$output" == *'"images"'* ]]
+  [[ "$output" == *'"has_changes"'* ]]
+  [[ "$output" == *'"CHANGE"'* ]]
+
+  # Validate it parses as JSON
+  echo "$output" | jq . >/dev/null
+}
+
+@test "rollback diff: missing ref returns exit 2" {
+  _require_jq
+  local stack="ms-$$"
+  _write_snap "$stack" "only" "2026-04-20T00:00:00Z" "api=v1" >/dev/null
+
+  run _rollback_diff "$stack" "only" "does-not-exist"
+  [ "$status" -eq 2 ]
+}
+
+@test "rollback diff: fewer than two refs errors with usage" {
+  run _rollback_diff "some-stack"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"requires two snapshot refs"* ]]
+}
+
+# ── dispatch: cmd_rollback routes `diff` subcommand ──────────────────────────
+
+@test "cmd_rollback: dispatches 'diff' before --list" {
+  _require_jq
+  local stack="dp-$$"
+  export CMD_STACK="$stack"
+  export CMD_STACK_DIR="$SANDBOX_ROOT/stacks/$stack"
+  export CMD_ENV_FILE=""
+  export CMD_ENV_NAME=""
+  export CMD_SERVICES=""
+  mkdir -p "$CMD_STACK_DIR"
+
+  _write_snap "$stack" "a" "2026-04-19T00:00:00Z" "api=v1" >/dev/null
+  sleep 1
+  _write_snap "$stack" "b" "2026-04-20T00:00:00Z" "api=v2" >/dev/null
+
+  run cmd_rollback diff "a" "b"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"api"* ]]
+
+  unset CMD_STACK CMD_STACK_DIR CMD_ENV_FILE CMD_ENV_NAME CMD_SERVICES
+}


### PR DESCRIPTION
Closes #42

## Summary
- `strut <stack> rollback diff <a> <b> [--json]` — compare two rollback snapshots
- Refs accept snapshot basename, `HEAD` (latest), or `HEAD~N` (Nth older)
- Reuses the engine in `lib/diff.sh` — factored out `diff_image_pairs` so the same ADD/REMOVE/CHANGE op stream powers both `strut diff` (local vs VPS) and `rollback diff` (historical)

## Why
Operators need to answer: *what did the last deploy change?* or *what differs between the last known-good release and the broken one?* — without this, snapshots capture state but are opaque.

## Exit codes
Match `strut diff` semantics for CI/scripting:
- `0` — snapshots identical
- `1` — snapshots differ
- `2` — bad ref / usage error

## Example
```
$ strut api rollback diff HEAD~1 HEAD

Rollback diff for api: 20260419-184500 → 20260420-143000

Images (2 changes)
  ~ api: ghcr.io/org/api:v1.2.3 → ghcr.io/org/api:v1.2.5
  ~ worker: ghcr.io/org/worker:v0.8.1 → ghcr.io/org/worker:v0.8.2
```

## Test plan
- [x] 18 new BATS cases in `tests/test_rollback_diff.bats`
  - ref resolution: HEAD, HEAD~1, basename, `.json` suffix, missing, out-of-range
  - image-pair extraction via jq
  - diff ops: identical, CHANGE (bump), ADD (new service), REMOVE (dropped service)
  - HEAD~1 HEAD shortcut
  - `--json` structural shape validates as JSON
  - `cmd_rollback` dispatches `diff` subcommand
- [x] Full bats suite: 894/894 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)