### PR TITLE
feat: add offsite backup sync for S3/R2/B2 (#21)

### DIFF
--- a/lib/backup.sh
+++ b/lib/backup.sh
@@ -18,6 +18,7 @@ BACKUP_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/backup"
 [ -f "$BACKUP_LIB_DIR/compare.sh" ] && source "$BACKUP_LIB_DIR/compare.sh"
 [ -f "$BACKUP_LIB_DIR/mysql.sh" ] && source "$BACKUP_LIB_DIR/mysql.sh"
 [ -f "$BACKUP_LIB_DIR/sqlite.sh" ] && source "$BACKUP_LIB_DIR/sqlite.sh"
+[ -f "$BACKUP_LIB_DIR/offsite.sh" ] && source "$BACKUP_LIB_DIR/offsite.sh"
 [ -f "$BACKUP_LIB_DIR/cmd.sh" ] && source "$BACKUP_LIB_DIR/cmd.sh"
 
 # _backup_dir <stack>

--- a/lib/backup/cmd.sh
+++ b/lib/backup/cmd.sh
@@ -33,7 +33,7 @@ backup_command() {
   local arg5="${positional[4]:-}"
 
   local compose_cmd=""
-  if [[ "$target" != "compare" && "$target" != "compare-labels" ]]; then
+  if [[ "$target" != "compare" && "$target" != "compare-labels" && "$target" != "offsite" ]]; then
     validate_env_file "$env_file"
     export_volume_paths "$stack_dir"
     compose_cmd=$(resolve_compose_cmd "$stack" "$env_file" "$services")
@@ -106,6 +106,24 @@ backup_command() {
     storage)
       backup_storage_stats_cmd "$stack"
       ;;
+    offsite)
+      # Load backup.conf so offsite_* helpers see BACKUP_OFFSITE* vars.
+      local _bk_conf="$stack_dir/backup.conf"
+      [ -f "$_bk_conf" ] && { set -a; source "$_bk_conf"; set +a; }
+
+      case "$arg2" in
+        ""|status)  offsite_status ;;
+        sync)       offsite_sync_all "$stack" ;;
+        list)       offsite_list "$stack" ;;
+        restore)
+          [ -z "$arg3" ] && fail "Usage: strut $stack backup offsite restore <filename>"
+          offsite_restore "$stack" "$arg3"
+          ;;
+        *)
+          fail "Unknown offsite subcommand: $arg2 (status|sync|list|restore)"
+          ;;
+      esac
+      ;;
     check-missed)
       backup_check_missed_cmd "$stack"
       ;;
@@ -129,11 +147,14 @@ backup_command() {
         run_cmd "Create backup directory" mkdir -p "$(_backup_dir "$stack")"
         run_cmd "Run pg_dump inside postgres container" echo "pg_dump → postgres-$(date +%Y%m%d-%H%M%S).sql"
         run_cmd "Create backup metadata" echo "metadata → backups/metadata/"
+        offsite_enabled 2>/dev/null && \
+          run_cmd "Offsite sync (${BACKUP_OFFSITE})" echo "$(_offsite_remote_url "$stack" "postgres-*.sql")"
         echo ""
         echo -e "${YELLOW}[DRY-RUN] No changes made.${NC}"
         return 0
       fi
       backup_postgres "$stack" "$compose_cmd"
+      offsite_sync_latest "$stack" "postgres-*.sql"
       BACKUP_TARGET="postgres" fire_hook_or_warn post_backup "$stack_dir"
       notify_event backup.success stack="$stack" env="$env_name" type=postgres
       ;;
@@ -150,6 +171,7 @@ backup_command() {
         return 0
       fi
       backup_neo4j "$stack" "$compose_cmd"
+      offsite_sync_latest "$stack" "neo4j-*.dump"
       BACKUP_TARGET="neo4j" fire_hook_or_warn post_backup "$stack_dir"
       notify_event backup.success stack="$stack" env="$env_name" type=neo4j
       ;;
@@ -165,6 +187,7 @@ backup_command() {
         return 0
       fi
       backup_mysql "$stack" "$compose_cmd"
+      offsite_sync_latest "$stack" "mysql-*.sql"
       BACKUP_TARGET="mysql" fire_hook_or_warn post_backup "$stack_dir"
       notify_event backup.success stack="$stack" env="$env_name" type=mysql
       ;;
@@ -180,6 +203,7 @@ backup_command() {
         return 0
       fi
       backup_sqlite "$stack" "$compose_cmd"
+      offsite_sync_latest "$stack" "sqlite-*.db"
       BACKUP_TARGET="sqlite" fire_hook_or_warn post_backup "$stack_dir"
       notify_event backup.success stack="$stack" env="$env_name" type=sqlite
       ;;
@@ -247,7 +271,8 @@ Available commands:
   storage                               Show storage statistics
   check-missed                          Check for missed backups
   compare <env1> <env2> [--service X]   Compare databases between environments
-  compare-labels <env1> <env2>          Compare Neo4j label distribution"
+  compare-labels <env1> <env2>          Compare Neo4j label distribution
+  offsite status|sync|list|restore ...  Offsite backup sync (S3/R2/B2)"
       ;;
   esac
 }

--- a/lib/backup/offsite.sh
+++ b/lib/backup/offsite.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+# ==================================================
+# lib/backup/offsite.sh — Offsite backup sync (S3 / R2 / B2)
+# ==================================================
+# Pushes backup artefacts to cloud storage after each local backup so the
+# VPS disk is no longer a single point of failure. Opt-in via backup.conf:
+#
+#   BACKUP_OFFSITE=s3              # s3 | r2 | b2 | none (default: none)
+#   BACKUP_OFFSITE_BUCKET=my-bkps
+#   BACKUP_OFFSITE_PREFIX=my-stack # default: the stack name
+#   BACKUP_OFFSITE_RETENTION_DAYS=90
+#
+# Providers:
+#   s3  → AWS CLI, credentials via env/IAM/~/.aws
+#   r2  → AWS CLI against a Cloudflare R2 endpoint (R2_* env vars)
+#   b2  → Backblaze b2 CLI with B2_APPLICATION_KEY* env vars
+#
+# Design notes:
+# - Sync failures warn() but never abort the local backup — the whole point
+#   is defense in depth, not a hard dependency.
+# - `offsite_enabled` is the single source of truth for whether to sync.
+# - The remote key layout is `<prefix>/<basename>`. No directory traversal
+#   inside the bucket; operators use separate buckets for separate stacks
+#   if they want isolation.
+
+set -euo pipefail
+
+# ── Config helpers ────────────────────────────────────────────────────────────
+
+# offsite_provider
+#   Emits the configured provider (s3|r2|b2|none). Lower-cased.
+offsite_provider() {
+  local p="${BACKUP_OFFSITE:-none}"
+  printf '%s' "$p" | tr '[:upper:]' '[:lower:]'
+}
+
+# offsite_enabled
+#   Returns 0 if offsite sync is configured and its CLI is available, else 1.
+#   Why the CLI check here: if BACKUP_OFFSITE=s3 but aws isn't installed,
+#   we treat it as disabled rather than failing every backup. The missing
+#   CLI is warned about once so operators notice.
+offsite_enabled() {
+  local provider
+  provider=$(offsite_provider)
+  case "$provider" in
+    none|"") return 1 ;;
+    s3|r2)
+      command -v aws >/dev/null 2>&1 || {
+        warn "BACKUP_OFFSITE=$provider but 'aws' CLI not found; offsite sync disabled"
+        return 1
+      }
+      ;;
+    b2)
+      command -v b2 >/dev/null 2>&1 || {
+        warn "BACKUP_OFFSITE=b2 but 'b2' CLI not found; offsite sync disabled"
+        return 1
+      }
+      ;;
+    *)
+      warn "Unknown BACKUP_OFFSITE value: $provider (expected s3|r2|b2|none)"
+      return 1
+      ;;
+  esac
+  if [ -z "${BACKUP_OFFSITE_BUCKET:-}" ]; then
+    warn "BACKUP_OFFSITE=$provider set but BACKUP_OFFSITE_BUCKET is empty; offsite sync disabled"
+    return 1
+  fi
+  return 0
+}
+
+# _offsite_prefix <stack>
+_offsite_prefix() {
+  local stack="$1"
+  echo "${BACKUP_OFFSITE_PREFIX:-$stack}"
+}
+
+# _offsite_remote_url <stack> <filename>
+#   Builds the remote URL for a given local backup basename. S3/R2 use
+#   s3://bucket/prefix/filename; B2 uses b2://bucket/prefix/filename
+#   (surface form — the b2 CLI takes a separate bucket arg).
+_offsite_remote_url() {
+  local stack="$1" filename="$2"
+  local prefix provider
+  prefix=$(_offsite_prefix "$stack")
+  provider=$(offsite_provider)
+  case "$provider" in
+    s3|r2) echo "s3://${BACKUP_OFFSITE_BUCKET}/${prefix}/${filename}" ;;
+    b2)    echo "b2://${BACKUP_OFFSITE_BUCKET}/${prefix}/${filename}" ;;
+    *)     echo "" ;;
+  esac
+}
+
+# _offsite_aws_opts
+#   Adds --endpoint-url for R2 so `aws s3 cp` can talk to Cloudflare's
+#   S3-compatible API. For vanilla S3 we return an empty string.
+_offsite_aws_opts() {
+  local provider
+  provider=$(offsite_provider)
+  if [ "$provider" = "r2" ]; then
+    # R2 endpoint requires R2_ACCOUNT_ID. We don't inject credentials —
+    # operators set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY (or R2_*) in
+    # their env and let the aws CLI pick them up.
+    local acct="${R2_ACCOUNT_ID:-}"
+    if [ -n "$acct" ]; then
+      echo "--endpoint-url=https://${acct}.r2.cloudflarestorage.com"
+    fi
+  fi
+}
+
+# ── Sync ──────────────────────────────────────────────────────────────────────
+
+# offsite_sync_file <stack> <local_path>
+#
+# Uploads one backup artefact. Non-fatal: any failure warns and returns 1
+# so the surrounding backup flow continues.
+offsite_sync_file() {
+  local stack="$1" local_path="$2"
+  offsite_enabled || return 1
+  [ -f "$local_path" ] || { warn "offsite sync: $local_path does not exist"; return 1; }
+
+  local filename provider remote_url
+  filename=$(basename "$local_path")
+  provider=$(offsite_provider)
+  remote_url=$(_offsite_remote_url "$stack" "$filename")
+
+  if [ "${DRY_RUN:-false}" = "true" ]; then
+    echo "  [dry-run] offsite sync → $remote_url"
+    return 0
+  fi
+
+  log "Offsite sync → $remote_url"
+  case "$provider" in
+    s3|r2)
+      local opts
+      opts=$(_offsite_aws_opts)
+      # shellcheck disable=SC2086
+      if aws $opts s3 cp "$local_path" "$remote_url" >/dev/null 2>&1; then
+        ok "Offsite sync complete: $filename"
+        return 0
+      fi
+      warn "Offsite sync failed for $filename (aws s3 cp exit non-zero)"
+      return 1
+      ;;
+    b2)
+      local prefix
+      prefix=$(_offsite_prefix "$stack")
+      if b2 upload-file "${BACKUP_OFFSITE_BUCKET}" "$local_path" "${prefix}/${filename}" >/dev/null 2>&1; then
+        ok "Offsite sync complete: $filename"
+        return 0
+      fi
+      warn "Offsite sync failed for $filename (b2 upload-file exit non-zero)"
+      return 1
+      ;;
+  esac
+  return 1
+}
+
+# offsite_sync_latest <stack> <pattern>
+#
+# Finds the newest file in the stack's backup dir matching <pattern>
+# (glob, e.g. `postgres-*.sql`) and syncs it. Called from cmd.sh after
+# each successful backup_<type> so we don't need to plumb the exact
+# output filename through every backup function.
+#
+# No-op when offsite is disabled or no match is found.
+offsite_sync_latest() {
+  local stack="$1" pattern="$2"
+  offsite_enabled || return 0
+
+  local dir latest
+  dir=$(_backup_dir "$stack")
+  [ -d "$dir" ] || return 0
+
+  # Newest match wins. Null-glob via conditional guard.
+  latest=$(ls -t "$dir"/$pattern 2>/dev/null | head -1)
+  [ -z "$latest" ] && return 0
+
+  # Non-fatal — never abort the enclosing backup if sync fails.
+  offsite_sync_file "$stack" "$latest" || true
+}
+
+# offsite_sync_all <stack>
+#
+# Walks the local backup directory and uploads every file. Intended for
+# initial backfill or after a provider was newly configured. Emits a
+# per-file result; aggregate exit is 0 if at least one file succeeded,
+# 1 if all failed.
+offsite_sync_all() {
+  local stack="$1"
+  offsite_enabled || { warn "Offsite not configured; nothing to sync"; return 1; }
+
+  local dir
+  dir=$(_backup_dir "$stack")
+  if [ ! -d "$dir" ]; then
+    warn "Backup dir not found: $dir"
+    return 1
+  fi
+
+  local total=0 ok_count=0 fail_count=0
+  local f
+  for f in "$dir"/*; do
+    [ -f "$f" ] || continue
+    # Skip metadata/sidecar files — those travel with a restore operation,
+    # not as independent artefacts.
+    case "$f" in
+      *.meta|*.json) continue ;;
+    esac
+    total=$((total + 1))
+    if offsite_sync_file "$stack" "$f"; then
+      ok_count=$((ok_count + 1))
+    else
+      fail_count=$((fail_count + 1))
+    fi
+  done
+
+  if [ "$total" -eq 0 ]; then
+    warn "No backup files found in $dir"
+    return 1
+  fi
+  log "Offsite sync: $ok_count/$total succeeded ($fail_count failed)"
+  [ "$ok_count" -gt 0 ]
+}
+
+# ── List / Restore ────────────────────────────────────────────────────────────
+
+# offsite_list <stack>
+#
+# Lists objects under the stack's prefix. Output format is provider-native;
+# operators read this for ad-hoc inspection — we don't try to reshape it.
+offsite_list() {
+  local stack="$1"
+  offsite_enabled || { warn "Offsite not configured"; return 1; }
+
+  local provider prefix
+  provider=$(offsite_provider)
+  prefix=$(_offsite_prefix "$stack")
+
+  case "$provider" in
+    s3|r2)
+      local opts
+      opts=$(_offsite_aws_opts)
+      # shellcheck disable=SC2086
+      aws $opts s3 ls "s3://${BACKUP_OFFSITE_BUCKET}/${prefix}/" 2>/dev/null
+      ;;
+    b2)
+      b2 ls "${BACKUP_OFFSITE_BUCKET}" "${prefix}" 2>/dev/null
+      ;;
+  esac
+}
+
+# offsite_restore <stack> <filename> [local_dest_dir]
+#
+# Downloads a single object from offsite back into the local backup dir
+# (or a caller-supplied directory). `<filename>` is the basename (e.g.
+# `postgres-20260420-143000.sql`) — the prefix is resolved automatically.
+offsite_restore() {
+  local stack="$1" filename="$2" dest_dir="${3:-}"
+  offsite_enabled || { warn "Offsite not configured"; return 1; }
+
+  [ -z "$filename" ] && { fail "Usage: offsite_restore <stack> <filename>"; return 1; }
+
+  local target_dir
+  if [ -n "$dest_dir" ]; then
+    target_dir="$dest_dir"
+  else
+    target_dir=$(_backup_dir "$stack")
+  fi
+  mkdir -p "$target_dir"
+
+  local provider prefix remote_url target
+  provider=$(offsite_provider)
+  prefix=$(_offsite_prefix "$stack")
+  remote_url=$(_offsite_remote_url "$stack" "$filename")
+  target="$target_dir/$filename"
+
+  if [ "${DRY_RUN:-false}" = "true" ]; then
+    echo "  [dry-run] offsite restore $remote_url → $target"
+    return 0
+  fi
+
+  log "Offsite restore $remote_url → $target"
+  case "$provider" in
+    s3|r2)
+      local opts
+      opts=$(_offsite_aws_opts)
+      # shellcheck disable=SC2086
+      aws $opts s3 cp "$remote_url" "$target" >/dev/null 2>&1 || {
+        fail "Offsite restore failed (aws s3 cp)"
+        return 1
+      }
+      ;;
+    b2)
+      b2 download-file-by-name "${BACKUP_OFFSITE_BUCKET}" "${prefix}/${filename}" "$target" >/dev/null 2>&1 || {
+        fail "Offsite restore failed (b2 download-file-by-name)"
+        return 1
+      }
+      ;;
+  esac
+  ok "Restored: $target"
+}
+
+# ── Status ────────────────────────────────────────────────────────────────────
+
+# offsite_status
+#   Prints a short config summary. Purely informational; exit is 0 whether
+#   or not sync is enabled (caller uses offsite_enabled for the decision).
+offsite_status() {
+  local provider bucket prefix
+  provider=$(offsite_provider)
+  bucket="${BACKUP_OFFSITE_BUCKET:-<unset>}"
+  prefix="${BACKUP_OFFSITE_PREFIX:-<stack-name>}"
+
+  echo ""
+  echo "Offsite backup configuration:"
+  echo "  Provider:  $provider"
+  echo "  Bucket:    $bucket"
+  echo "  Prefix:    $prefix"
+  echo "  Retention: ${BACKUP_OFFSITE_RETENTION_DAYS:-90} days"
+  echo ""
+  if offsite_enabled 2>/dev/null; then
+    ok "Offsite sync is ENABLED"
+  else
+    warn "Offsite sync is DISABLED (check BACKUP_OFFSITE/BACKUP_OFFSITE_BUCKET and CLI availability)"
+  fi
+}

--- a/lib/cmd_backup.sh
+++ b/lib/cmd_backup.sh
@@ -22,6 +22,7 @@ _usage_backup() {
   echo "  retention check|enforce           Manage retention policy"
   echo "  compare <env1> <env2> [service]   Compare backups across environments"
   echo "  compare-labels <env1> <env2>      Compare backup labels"
+  echo "  offsite status|sync|list|restore  Offsite backup sync (S3/R2/B2)"
   echo ""
   echo "Examples:"
   echo "  strut my-stack backup postgres --env prod"

--- a/tests/test_backup_offsite.bats
+++ b/tests/test_backup_offsite.bats
@@ -1,0 +1,365 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_backup_offsite.bats — Offsite sync (S3 / R2 / B2)
+# ==================================================
+# Exercises config parsing, provider dispatch, and the sync/list/restore
+# flows. CLI calls are captured via a stub aws/b2 on PATH — we assert the
+# command shape rather than hitting any real backend.
+
+setup() {
+  export CLI_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  TEST_TMP="$(mktemp -d)"
+
+  source "$CLI_ROOT/lib/utils.sh"
+  fail() { echo "$1" >&2; return 1; }
+  error() { echo "$1" >&2; }
+  warn() { echo "$1" >&2; }
+
+  source "$CLI_ROOT/lib/backup.sh"
+
+  # Sandbox BACKUP_LOCAL_DIR so _backup_dir returns a known path.
+  export BACKUP_LOCAL_DIR="$TEST_TMP/backups"
+  mkdir -p "$BACKUP_LOCAL_DIR"
+
+  # CLI-stub directory — tests insert into PATH as needed.
+  export STUB_BIN="$TEST_TMP/bin"
+  mkdir -p "$STUB_BIN"
+  export CALL_LOG="$TEST_TMP/calls.log"
+  : > "$CALL_LOG"
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+  unset BACKUP_LOCAL_DIR STUB_BIN CALL_LOG DRY_RUN
+  unset BACKUP_OFFSITE BACKUP_OFFSITE_BUCKET BACKUP_OFFSITE_PREFIX R2_ACCOUNT_ID
+}
+
+_install_aws_stub() {
+  cat > "$STUB_BIN/aws" <<'EOF'
+#!/usr/bin/env bash
+echo "aws $*" >> "$CALL_LOG"
+# Simulate success unless the magic env var says to fail.
+[ "${STUB_AWS_FAIL:-0}" = "1" ] && exit 1
+# For `ls`, emit a fake listing.
+for arg in "$@"; do
+  if [ "$arg" = "ls" ]; then
+    echo "2026-04-20 10:00:00       1024 postgres-20260420-100000.sql"
+    echo "2026-04-19 10:00:00       2048 postgres-20260419-100000.sql"
+  fi
+done
+exit 0
+EOF
+  chmod +x "$STUB_BIN/aws"
+  export PATH="$STUB_BIN:$PATH"
+}
+
+_install_b2_stub() {
+  cat > "$STUB_BIN/b2" <<'EOF'
+#!/usr/bin/env bash
+echo "b2 $*" >> "$CALL_LOG"
+[ "${STUB_B2_FAIL:-0}" = "1" ] && exit 1
+for arg in "$@"; do
+  if [ "$arg" = "ls" ]; then
+    echo "postgres-20260420-100000.sql 1024"
+  fi
+done
+exit 0
+EOF
+  chmod +x "$STUB_BIN/b2"
+  export PATH="$STUB_BIN:$PATH"
+}
+
+# ── offsite_provider / offsite_enabled ───────────────────────────────────────
+
+@test "offsite_provider: lowercases and returns configured provider" {
+  BACKUP_OFFSITE=S3 run offsite_provider
+  [ "$output" = "s3" ]
+
+  BACKUP_OFFSITE=r2 run offsite_provider
+  [ "$output" = "r2" ]
+}
+
+@test "offsite_enabled: none → disabled" {
+  BACKUP_OFFSITE=none run offsite_enabled
+  [ "$status" -ne 0 ]
+}
+
+@test "offsite_enabled: unset → disabled" {
+  unset BACKUP_OFFSITE
+  run offsite_enabled
+  [ "$status" -ne 0 ]
+}
+
+@test "offsite_enabled: s3 without aws CLI → disabled with warning" {
+  # Clear PATH so aws is unavailable.
+  PATH="/usr/bin" BACKUP_OFFSITE=s3 BACKUP_OFFSITE_BUCKET=x \
+    run offsite_enabled
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"aws"* ]]
+}
+
+@test "offsite_enabled: s3 without bucket → disabled" {
+  _install_aws_stub
+  BACKUP_OFFSITE=s3 run offsite_enabled
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"BACKUP_OFFSITE_BUCKET"* ]]
+}
+
+@test "offsite_enabled: s3 + bucket + aws installed → enabled" {
+  _install_aws_stub
+  BACKUP_OFFSITE=s3 BACKUP_OFFSITE_BUCKET=my-bucket run offsite_enabled
+  [ "$status" -eq 0 ]
+}
+
+@test "offsite_enabled: unknown provider → disabled" {
+  BACKUP_OFFSITE=gopher BACKUP_OFFSITE_BUCKET=x run offsite_enabled
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unknown"* ]]
+}
+
+# ── URL construction ─────────────────────────────────────────────────────────
+
+@test "_offsite_remote_url: s3 uses s3:// scheme + prefix" {
+  BACKUP_OFFSITE=s3 BACKUP_OFFSITE_BUCKET=bk BACKUP_OFFSITE_PREFIX=pfx \
+    run _offsite_remote_url "mystack" "pg-1.sql"
+  [ "$output" = "s3://bk/pfx/pg-1.sql" ]
+}
+
+@test "_offsite_remote_url: r2 also uses s3:// scheme" {
+  BACKUP_OFFSITE=r2 BACKUP_OFFSITE_BUCKET=bk BACKUP_OFFSITE_PREFIX=pfx \
+    run _offsite_remote_url "mystack" "pg-1.sql"
+  [ "$output" = "s3://bk/pfx/pg-1.sql" ]
+}
+
+@test "_offsite_remote_url: b2 uses b2:// scheme" {
+  BACKUP_OFFSITE=b2 BACKUP_OFFSITE_BUCKET=bk BACKUP_OFFSITE_PREFIX=pfx \
+    run _offsite_remote_url "mystack" "pg-1.sql"
+  [ "$output" = "b2://bk/pfx/pg-1.sql" ]
+}
+
+@test "_offsite_remote_url: prefix defaults to stack name" {
+  BACKUP_OFFSITE=s3 BACKUP_OFFSITE_BUCKET=bk \
+    run _offsite_remote_url "mystack" "pg-1.sql"
+  [ "$output" = "s3://bk/mystack/pg-1.sql" ]
+}
+
+@test "_offsite_aws_opts: r2 with R2_ACCOUNT_ID → endpoint-url" {
+  BACKUP_OFFSITE=r2 R2_ACCOUNT_ID=abc123 run _offsite_aws_opts
+  [[ "$output" == *"endpoint-url"* ]]
+  [[ "$output" == *"abc123.r2.cloudflarestorage.com"* ]]
+}
+
+@test "_offsite_aws_opts: s3 returns empty" {
+  BACKUP_OFFSITE=s3 run _offsite_aws_opts
+  [ -z "$output" ]
+}
+
+# ── offsite_sync_file ────────────────────────────────────────────────────────
+
+@test "offsite_sync_file: s3 issues aws s3 cp" {
+  _install_aws_stub
+  export BACKUP_OFFSITE=s3 BACKUP_OFFSITE_BUCKET=mybk BACKUP_OFFSITE_PREFIX=s
+  echo "fake" > "$BACKUP_LOCAL_DIR/postgres-1.sql"
+
+  run offsite_sync_file "mystack" "$BACKUP_LOCAL_DIR/postgres-1.sql"
+  [ "$status" -eq 0 ]
+
+  local log
+  log=$(cat "$CALL_LOG")
+  [[ "$log" == *"aws"* ]]
+  [[ "$log" == *"s3 cp"* ]]
+  [[ "$log" == *"$BACKUP_LOCAL_DIR/postgres-1.sql"* ]]
+  [[ "$log" == *"s3://mybk/s/postgres-1.sql"* ]]
+}
+
+@test "offsite_sync_file: r2 injects endpoint-url" {
+  _install_aws_stub
+  export BACKUP_OFFSITE=r2 BACKUP_OFFSITE_BUCKET=mybk R2_ACCOUNT_ID=acct
+  echo "fake" > "$BACKUP_LOCAL_DIR/postgres-1.sql"
+
+  run offsite_sync_file "mystack" "$BACKUP_LOCAL_DIR/postgres-1.sql"
+  [ "$status" -eq 0 ]
+
+  local log
+  log=$(cat "$CALL_LOG")
+  [[ "$log" == *"endpoint-url"* ]]
+  [[ "$log" == *"acct.r2.cloudflarestorage.com"* ]]
+}
+
+@test "offsite_sync_file: b2 issues b2 upload-file" {
+  _install_b2_stub
+  export BACKUP_OFFSITE=b2 BACKUP_OFFSITE_BUCKET=mybk BACKUP_OFFSITE_PREFIX=s
+  echo "fake" > "$BACKUP_LOCAL_DIR/postgres-1.sql"
+
+  run offsite_sync_file "mystack" "$BACKUP_LOCAL_DIR/postgres-1.sql"
+  [ "$status" -eq 0 ]
+
+  local log
+  log=$(cat "$CALL_LOG")
+  [[ "$log" == *"b2 upload-file mybk"* ]]
+  [[ "$log" == *"s/postgres-1.sql"* ]]
+}
+
+@test "offsite_sync_file: DRY_RUN prints and skips CLI" {
+  _install_aws_stub
+  export BACKUP_OFFSITE=s3 BACKUP_OFFSITE_BUCKET=mybk
+  export DRY_RUN=true
+  echo "fake" > "$BACKUP_LOCAL_DIR/postgres-1.sql"
+
+  run offsite_sync_file "mystack" "$BACKUP_LOCAL_DIR/postgres-1.sql"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[dry-run]"* ]]
+  [[ "$output" == *"s3://mybk/mystack/postgres-1.sql"* ]]
+  [ ! -s "$CALL_LOG" ]
+}
+
+@test "offsite_sync_file: missing local file → fail non-fatal" {
+  _install_aws_stub
+  export BACKUP_OFFSITE=s3 BACKUP_OFFSITE_BUCKET=mybk
+  run offsite_sync_file "mystack" "$BACKUP_LOCAL_DIR/does-not-exist.sql"
+  [ "$status" -ne 0 ]
+}
+
+@test "offsite_sync_file: aws failure warns but returns 1" {
+  _install_aws_stub
+  export BACKUP_OFFSITE=s3 BACKUP_OFFSITE_BUCKET=mybk STUB_AWS_FAIL=1
+  echo "fake" > "$BACKUP_LOCAL_DIR/postgres-1.sql"
+
+  run offsite_sync_file "mystack" "$BACKUP_LOCAL_DIR/postgres-1.sql"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"failed"* ]]
+}
+
+# ── offsite_sync_latest ──────────────────────────────────────────────────────
+
+@test "offsite_sync_latest: picks newest matching file" {
+  _install_aws_stub
+  export BACKUP_OFFSITE=s3 BACKUP_OFFSITE_BUCKET=mybk
+
+  echo "old" > "$BACKUP_LOCAL_DIR/postgres-20260418-100000.sql"
+  sleep 1
+  echo "new" > "$BACKUP_LOCAL_DIR/postgres-20260420-100000.sql"
+  echo "other" > "$BACKUP_LOCAL_DIR/neo4j-1.dump"
+
+  run offsite_sync_latest "mystack" "postgres-*.sql"
+  [ "$status" -eq 0 ]
+
+  local log
+  log=$(cat "$CALL_LOG")
+  [[ "$log" == *"postgres-20260420-100000.sql"* ]]
+  [[ "$log" != *"postgres-20260418-100000.sql"* ]]
+  [[ "$log" != *"neo4j"* ]]
+}
+
+@test "offsite_sync_latest: no-op when offsite disabled" {
+  unset BACKUP_OFFSITE
+  echo "x" > "$BACKUP_LOCAL_DIR/postgres-1.sql"
+  run offsite_sync_latest "mystack" "postgres-*.sql"
+  [ "$status" -eq 0 ]
+  [ ! -s "$CALL_LOG" ]
+}
+
+@test "offsite_sync_latest: no-op when no matching file" {
+  _install_aws_stub
+  export BACKUP_OFFSITE=s3 BACKUP_OFFSITE_BUCKET=mybk
+  run offsite_sync_latest "mystack" "postgres-*.sql"
+  [ "$status" -eq 0 ]
+  [ ! -s "$CALL_LOG" ]
+}
+
+# ── offsite_sync_all ─────────────────────────────────────────────────────────
+
+@test "offsite_sync_all: syncs every backup file, skips metadata" {
+  _install_aws_stub
+  export BACKUP_OFFSITE=s3 BACKUP_OFFSITE_BUCKET=mybk
+
+  echo "a" > "$BACKUP_LOCAL_DIR/postgres-1.sql"
+  echo "b" > "$BACKUP_LOCAL_DIR/neo4j-1.dump"
+  echo '{}' > "$BACKUP_LOCAL_DIR/postgres-1.sql.meta"
+  echo '{}' > "$BACKUP_LOCAL_DIR/ignored.json"
+
+  run offsite_sync_all "mystack"
+  [ "$status" -eq 0 ]
+
+  local log
+  log=$(cat "$CALL_LOG")
+  [[ "$log" == *"postgres-1.sql"* ]]
+  [[ "$log" == *"neo4j-1.dump"* ]]
+  # .meta / .json should be skipped
+  [[ "$log" != *"postgres-1.sql.meta"* ]]
+  [[ "$log" != *"ignored.json"* ]]
+}
+
+@test "offsite_sync_all: disabled provider → returns 1 with warning" {
+  unset BACKUP_OFFSITE
+  run offsite_sync_all "mystack"
+  [ "$status" -ne 0 ]
+}
+
+# ── offsite_list ─────────────────────────────────────────────────────────────
+
+@test "offsite_list: s3 emits aws s3 ls with prefix" {
+  _install_aws_stub
+  export BACKUP_OFFSITE=s3 BACKUP_OFFSITE_BUCKET=mybk BACKUP_OFFSITE_PREFIX=pfx
+  run offsite_list "mystack"
+  [ "$status" -eq 0 ]
+
+  local log
+  log=$(cat "$CALL_LOG")
+  [[ "$log" == *"s3 ls"* ]]
+  [[ "$log" == *"s3://mybk/pfx/"* ]]
+
+  # Listing output from stub is passed through.
+  [[ "$output" == *"postgres-20260420-100000.sql"* ]]
+}
+
+# ── offsite_restore ──────────────────────────────────────────────────────────
+
+@test "offsite_restore: s3 downloads into backup dir" {
+  _install_aws_stub
+  export BACKUP_OFFSITE=s3 BACKUP_OFFSITE_BUCKET=mybk
+  run offsite_restore "mystack" "postgres-1.sql"
+  [ "$status" -eq 0 ]
+
+  local log
+  log=$(cat "$CALL_LOG")
+  [[ "$log" == *"s3 cp"* ]]
+  [[ "$log" == *"s3://mybk/mystack/postgres-1.sql"* ]]
+  [[ "$log" == *"$BACKUP_LOCAL_DIR/postgres-1.sql"* ]]
+}
+
+@test "offsite_restore: DRY_RUN prints and skips CLI" {
+  _install_aws_stub
+  export BACKUP_OFFSITE=s3 BACKUP_OFFSITE_BUCKET=mybk DRY_RUN=true
+  run offsite_restore "mystack" "postgres-1.sql"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[dry-run]"* ]]
+  [ ! -s "$CALL_LOG" ]
+}
+
+@test "offsite_restore: missing filename arg fails" {
+  _install_aws_stub
+  export BACKUP_OFFSITE=s3 BACKUP_OFFSITE_BUCKET=mybk
+  run offsite_restore "mystack" ""
+  [ "$status" -ne 0 ]
+}
+
+# ── offsite_status ───────────────────────────────────────────────────────────
+
+@test "offsite_status: prints provider and bucket" {
+  _install_aws_stub
+  export BACKUP_OFFSITE=s3 BACKUP_OFFSITE_BUCKET=mybk BACKUP_OFFSITE_PREFIX=pfx
+  run offsite_status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"s3"* ]]
+  [[ "$output" == *"mybk"* ]]
+  [[ "$output" == *"pfx"* ]]
+  [[ "$output" == *"ENABLED"* ]]
+}
+
+@test "offsite_status: reports DISABLED when unconfigured" {
+  unset BACKUP_OFFSITE
+  run offsite_status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DISABLED"* ]]
+}


### PR DESCRIPTION
Closes #21

## Summary
Adds opt-in offsite backup sync so the VPS disk is no longer a single point of failure.
- `BACKUP_OFFSITE={s3|r2|b2|none}` in `backup.conf` enables automatic sync after each local backup.
- New subcommand: `strut <stack> backup offsite {status|sync|list|restore}`.
- Providers: S3 via `aws s3`, R2 via `aws s3` + `--endpoint-url`, B2 via `b2` CLI. Credentials come from each CLI's own env/config — no secrets in `backup.conf`.

## Design choices
- **Non-fatal sync.** A failed upload warns but doesn't abort the local backup. Offsite is defense in depth, not a hard dependency.
- **Post-hook plumbing.** Rather than threading output paths through every `backup_<type>` function, `cmd.sh` calls `offsite_sync_latest <stack> <glob>` after each successful backup.
- **`offsite_enabled` is the gate.** Missing CLI, empty bucket, or unknown provider all resolve to disabled-with-warning rather than hard failure — so flipping one knob in config can't break cron'd backups.

## Usage
```bash
# Automatic — after any backup when BACKUP_OFFSITE is set
strut my-stack backup postgres --env prod
# ✓ PostgreSQL backup saved: backups/postgres-20260420-100000.sql
# [strut] Offsite sync → s3://my-bkps/my-stack/postgres-20260420-100000.sql
# ✓ Offsite sync complete: postgres-20260420-100000.sql

# Manual subcommands
strut my-stack backup offsite status
strut my-stack backup offsite sync         # bulk-sync all local backups
strut my-stack backup offsite list
strut my-stack backup offsite restore postgres-20260420-100000.sql
```

## Test plan
- [x] 30 new BATS cases in `tests/test_backup_offsite.bats`
  - `offsite_provider` / `offsite_enabled` config + CLI presence gates
  - URL construction for S3, R2, B2 with and without prefix
  - R2 endpoint-url injection from `R2_ACCOUNT_ID`
  - `offsite_sync_file` shape per provider, DRY_RUN, missing-file, CLI failure
  - `offsite_sync_latest` picks newest match, no-ops when disabled or empty
  - `offsite_sync_all` skips `.meta`/`.json` sidecars
  - `offsite_list`, `offsite_restore` (including DRY_RUN), `offsite_status`
- [x] Full bats suite: 924/924 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)