### PR TITLE
fix: Linux CI portability and ShellCheck findings

### DIFF
--- a/lib/cmd_doctor.sh
+++ b/lib/cmd_doctor.sh
@@ -126,7 +126,7 @@ _doc_check_ssh_key() {
 
       # Check private key permissions (should be 600 or 400)
       local perms
-      perms=$(stat -f "%Lp" "$key" 2>/dev/null || stat -c "%a" "$key" 2>/dev/null || echo "unknown")
+      perms=$(stat -c "%a" "$key" 2>/dev/null || stat -f "%Lp" "$key" 2>/dev/null || echo "unknown")
       case "$perms" in
         600|400) _doc_pass "SSH key permissions" "$(basename "$key") is $perms" ;;
         unknown) ;; # stat failed, skip
@@ -141,7 +141,7 @@ _doc_check_ssh_key() {
   # Check ~/.ssh directory permissions (should be 700)
   if [ -d "$HOME/.ssh" ]; then
     local dir_perms
-    dir_perms=$(stat -f "%Lp" "$HOME/.ssh" 2>/dev/null || stat -c "%a" "$HOME/.ssh" 2>/dev/null || echo "unknown")
+    dir_perms=$(stat -c "%a" "$HOME/.ssh" 2>/dev/null || stat -f "%Lp" "$HOME/.ssh" 2>/dev/null || echo "unknown")
     case "$dir_perms" in
       700) ;; # OK, don't clutter output
       unknown) ;; # stat failed, skip

--- a/lib/cmd_group.sh
+++ b/lib/cmd_group.sh
@@ -251,6 +251,7 @@ _group_logs() {
   local idx=0
   local stack
 
+  # shellcheck disable=SC2317,SC2329 # invoked via trap handlers below
   _group_logs_cleanup() {
     local p
     for p in "${child_pids[@]+"${child_pids[@]}"}"; do

--- a/lib/cmd_posture.sh
+++ b/lib/cmd_posture.sh
@@ -60,6 +60,8 @@ check_placeholder_secrets() {
   local env_file
   for env_file in "$CLI_ROOT"/.env "$CLI_ROOT"/.*.env; do
     [ -f "$env_file" ] || continue
+    local env_base
+    env_base=$(basename "$env_file")
     local line key val
     while IFS= read -r line; do
       # Skip blanks and comments
@@ -75,7 +77,7 @@ check_placeholder_secrets() {
       lower=$(printf '%s' "$val" | tr '[:upper:]' '[:lower:]')
       if [[ "$lower" =~ $_POSTURE_PLACEHOLDERS_REGEX ]]; then
         posture_emit "fail" "secrets" "$stack" \
-          "$(basename "$env_file"): $key appears to be a placeholder ('$val')" \
+          "$env_base: $key appears to be a placeholder ('$val')" \
           "Set a real value for $key in $env_file"
         return 0
       fi

--- a/lib/cmd_status_all.sh
+++ b/lib/cmd_status_all.sh
@@ -15,11 +15,9 @@ set -euo pipefail
 _status_mtime() {
   local p="$1"
   [ -e "$p" ] || return 0
-  if stat -f %m "$p" 2>/dev/null; then
-    :
-  else
-    stat -c %Y "$p" 2>/dev/null || true
-  fi
+  # GNU first (Linux CI), BSD fallback (macOS). BSD order fails on Linux
+  # because GNU `stat -f` means filesystem mode — it succeeds with wrong output.
+  stat -c %Y "$p" 2>/dev/null || stat -f %m "$p" 2>/dev/null || true
 }
 
 # _status_humanize_age <seconds> — "4h ago", "2d ago", etc.

--- a/lib/lock.sh
+++ b/lib/lock.sh
@@ -212,6 +212,9 @@ lock_acquire_remote() {
   dir_expr=$(_lock_remote_dir_expr "$stack" "$env")
 
   # shellcheck disable=SC2086
+  # shellcheck disable=SC2087
+  # SC2087: heredoc is unquoted intentionally — $dir_expr expands client-side
+  # while all \$-escaped vars expand server-side.
   ssh $ssh_opts "$user@$host" bash -s -- "$stack" "$env" "$cmd" <<REMOTE
 set -eu
 stack="\$1"; env="\$2"; cmd="\$3"

--- a/lib/output.sh
+++ b/lib/output.sh
@@ -91,7 +91,7 @@ out_table_row() {
   for v in "$@"; do
     plain=$(_out_strip_ansi "$v")
     if [ "$i" -lt "${#_OUT_TABLE_WIDTHS[@]}" ]; then
-      [ "${#plain}" -gt "${_OUT_TABLE_WIDTHS[$i]}" ] && _OUT_TABLE_WIDTHS[$i]=${#plain}
+      [ "${#plain}" -gt "${_OUT_TABLE_WIDTHS[i]}" ] && _OUT_TABLE_WIDTHS[i]=${#plain}
     else
       _OUT_TABLE_WIDTHS+=("${#plain}")
     fi
@@ -203,7 +203,7 @@ _out_json_comma_if_needed() {
   if [ "${#_OUT_JSON_STACK[@]}" -gt 0 ]; then
     local depth=$((${#_OUT_JSON_STACK[@]} - 1))
     if [ "${_OUT_JSON_FIRST[$depth]}" = "1" ]; then
-      _OUT_JSON_FIRST[$depth]=0
+      _OUT_JSON_FIRST[depth]=0
     else
       printf ','
     fi

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -305,7 +305,7 @@ ssh_mux_cleanup() {
   dir="${dir%/}"
   local sock
   # Sockets are named strut-ssh-<pid>-<user>@<host>:<port>
-  for sock in "$dir"/strut-ssh-$$-*; do
+  for sock in "$dir"/strut-ssh-"$$"-*; do
     [ -S "$sock" ] || continue
     # Extract user@host:port from filename suffix
     local suffix="${sock##*/strut-ssh-$$-}"


### PR DESCRIPTION
## Summary

Fixes CI failures on `Tests` and `ShellCheck Lint` workflows that have been red since v0.11.0.

### Linux portability (Tests)

Four tests failing on Linux CI (all pass on macOS local) because `stat -f` was tried first as the BSD form. GNU stat's `-f` means filesystem mode — it succeeds with mount-point output (e.g. `/`) rather than erroring, so the fallback to `stat -c` never fires. Flip the order in `lib/cmd_status_all.sh` and `lib/cmd_doctor.sh`.

Failing tests now fixed:
- `_status_last_deploy: returns a timestamp when snapshot exists`
- `_status_backup_age: returns a timestamp when backup exists`
- `cmd_status_all: text mode renders header and stack row`
- `cmd_doctor --json: includes SSH key permissions check for secure key perms`

### ShellCheck findings

- **SC2094** (`lib/cmd_posture.sh`): hoist `basename` out of `while read` loop over same file
- **SC2004** (`lib/output.sh`): drop `$/${}` on arithmetic subscripts
- **SC2317/SC2329** (`lib/cmd_group.sh`): disable on `_group_logs_cleanup` — invoked indirectly via `trap`
- **SC2231** (`lib/utils.sh`): quote `$$` in glob expansion
- **SC2087** (`lib/lock.sh`): disable on intentional mixed-expansion heredoc (client-side `$dir_expr`, server-side `\$`-escaped vars)

## Test plan

- [x] `bats tests/` — 924/924 green locally
- [x] `find lib -name '*.sh' -print0 | xargs -0 shellcheck -s bash` — clean locally
- [ ] CI `Tests` job green on Linux
- [ ] CI `ShellCheck Lint` job green