### PR TITLE
feat: include directive for shared config (#46)

### DIFF
--- a/lib/backup.sh
+++ b/lib/backup.sh
@@ -38,12 +38,12 @@ _backup_dir() {
   # Try sourcing volume.conf then backup.conf for this stack
   local stack_dir="$cli_root/stacks/$stack"
   if [ -f "$stack_dir/volume.conf" ]; then
-    # shellcheck disable=SC1091
-    source "$stack_dir/volume.conf"
+    # shellcheck disable=SC1090
+    source <(preprocess_config "$stack_dir/volume.conf")
   fi
   if [ -f "$stack_dir/backup.conf" ]; then
-    # shellcheck disable=SC1091
-    source "$stack_dir/backup.conf"
+    # shellcheck disable=SC1090
+    source <(preprocess_config "$stack_dir/backup.conf")
   fi
 
   # BACKUP_LOCAL_DIR in backup.conf references ${BACKUP_PATH} from volume.conf

--- a/lib/cmd_posture.sh
+++ b/lib/cmd_posture.sh
@@ -196,7 +196,7 @@ check_required_vars() {
     if ! grep -qE "^${var}=.+" "$env_file" 2>/dev/null; then
       missing+=("$var")
     fi
-  done < "$req_file"
+  done < <(preprocess_config "$req_file")
 
   if [ "${#missing[@]}" -gt 0 ]; then
     local first="${missing[0]}"

--- a/lib/cmd_validate.sh
+++ b/lib/cmd_validate.sh
@@ -295,7 +295,7 @@ _validate_required_vars() {
       missing+=("$var")
       valid=false
     fi
-  done < "$vars_file"
+  done < <(preprocess_config "$vars_file")
 
   if [ ${#missing[@]} -gt 0 ]; then
     for var in "${missing[@]}"; do

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -8,8 +8,68 @@
 #   find_project_root   — walk-up search for strut.conf
 #   load_strut_config   — source strut.conf and apply defaults
 #   resolve_strut_home  — resolve real script directory (follows symlinks)
+#   preprocess_config   — expand `include = <path>` directives in config files
 
 set -euo pipefail
+
+# ── Include directive ─────────────────────────────────────────────────────────
+
+# State for cycle detection during a single preprocess_config invocation.
+# Reset by preprocess_config; _preprocess_config appends to it recursively.
+_CONFIG_INCLUDES_SEEN=()
+
+# preprocess_config <file>
+#
+# Emits the contents of <file> to stdout with any `include = <path>` lines
+# expanded inline. Base content appears at the directive's position, so any
+# assignments *after* the include in the parent file override base values.
+#
+# Relative include paths resolve against the including file's directory.
+# Circular includes abort via fail().
+#
+# Usage:
+#   source <(preprocess_config "$PROJECT_ROOT/strut.conf")
+#   while IFS= read -r line; do ... done < <(preprocess_config "$vars_file")
+preprocess_config() {
+  _CONFIG_INCLUDES_SEEN=()
+  _preprocess_config "$1"
+}
+
+_preprocess_config() {
+  local file="$1"
+  local abs
+  if [ ! -f "$file" ]; then
+    fail "config include target not found: $file"
+    return 1
+  fi
+  abs="$(cd "$(dirname "$file")" && pwd)/$(basename "$file")"
+
+  local seen
+  for seen in "${_CONFIG_INCLUDES_SEEN[@]+"${_CONFIG_INCLUDES_SEEN[@]}"}"; do
+    if [ "$seen" = "$abs" ]; then
+      fail "circular config include detected: $file"
+      return 1
+    fi
+  done
+  _CONFIG_INCLUDES_SEEN+=("$abs")
+
+  local dir line inc_path
+  dir=$(dirname "$abs")
+  while IFS= read -r line || [ -n "$line" ]; do
+    if [[ "$line" =~ ^[[:space:]]*include[[:space:]]*=[[:space:]]*(.+)$ ]]; then
+      inc_path="${BASH_REMATCH[1]}"
+      # Trim trailing whitespace
+      inc_path="${inc_path%"${inc_path##*[![:space:]]}"}"
+      # Strip optional surrounding quotes
+      inc_path="${inc_path#\"}"; inc_path="${inc_path%\"}"
+      inc_path="${inc_path#\'}"; inc_path="${inc_path%\'}"
+      [[ "$inc_path" != /* ]] && inc_path="$dir/$inc_path"
+      _preprocess_config "$inc_path" || return 1
+    else
+      printf '%s\n' "$line"
+    fi
+  done < "$abs"
+}
 
 # find_project_root
 #
@@ -51,8 +111,8 @@ find_project_root() {
 # Side effects: Exports all config variables
 load_strut_config() {
   if [ -n "${PROJECT_ROOT:-}" ] && [ -f "$PROJECT_ROOT/strut.conf" ]; then
-    # shellcheck disable=SC1091
-    source "$PROJECT_ROOT/strut.conf"
+    # shellcheck disable=SC1090
+    source <(preprocess_config "$PROJECT_ROOT/strut.conf")
   fi
 
   REGISTRY_TYPE="${REGISTRY_TYPE:-none}"

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -130,7 +130,7 @@ load_services_conf() {
   local conf="$stack_dir/services.conf"
   if [ -f "$conf" ]; then
     # shellcheck disable=SC1090
-    source "$conf"
+    source <(preprocess_config "$conf")
   fi
 }
 

--- a/lib/volumes.sh
+++ b/lib/volumes.sh
@@ -48,7 +48,8 @@ verify_volume_config() {
     return 1
   fi
 
-  source "$volume_conf"
+  # shellcheck disable=SC1090
+  source <(preprocess_config "$volume_conf")
 
   log_info "Volume Configuration:"
   echo "  Device: ${DATA_VOLUME_DEVICE:-not set}"
@@ -131,7 +132,8 @@ init_volume_directories() {
     return 1
   fi
 
-  source "$volume_conf"
+  # shellcheck disable=SC1090
+  source <(preprocess_config "$volume_conf")
 
   local mount_point="${DATA_VOLUME_MOUNT:-/mnt/data}"
 
@@ -193,7 +195,8 @@ export_volume_paths() {
   local volume_conf="$stack_dir/volume.conf"
 
   if [[ -f "$volume_conf" ]]; then
-    source "$volume_conf"
+    # shellcheck disable=SC1090
+  source <(preprocess_config "$volume_conf")
 
     # Read variable names from volume.conf and export matching patterns
     local var

--- a/templates/strut.conf.template
+++ b/templates/strut.conf.template
@@ -33,3 +33,11 @@
 # ── Branding ───────────────────────────────────────
 # Banner text shown in deploy/release output
 # BANNER_TEXT=strut
+
+# ── Includes ───────────────────────────────────────
+# Pull in shared config from another file. Base values load first,
+# child assignments below override. Relative paths resolve against
+# this file's directory. Supports nested includes and cycle detection.
+#
+# include = .strut/shared.conf
+# include = ../common/strut.conf

--- a/tests/test_backup_helpers.bats
+++ b/tests/test_backup_helpers.bats
@@ -11,6 +11,7 @@ setup() {
 
   # Source utils with fail() overridden
   source "$CLI_ROOT/lib/utils.sh"
+  source "$CLI_ROOT/lib/config.sh"
   fail() { echo "$1" >&2; return 1; }
   error() { echo "$1" >&2; }
 

--- a/tests/test_config_include.bats
+++ b/tests/test_config_include.bats
@@ -1,0 +1,242 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_config_include.bats — `include = <path>` directive
+# ==================================================
+
+setup() {
+  export CLI_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  TEST_TMP="$(mktemp -d)"
+  # Stub fail so tests can catch aborts
+  source "$CLI_ROOT/lib/utils.sh"
+  source "$CLI_ROOT/lib/config.sh"
+  fail() { echo "FAIL: $1" >&2; return 1; }
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+}
+
+# ── Smoke ─────────────────────────────────────────────────────────────────────
+
+@test "preprocess_config: passthrough when no include directive" {
+  cat > "$TEST_TMP/a.conf" <<EOF
+KEY=value
+OTHER=foo
+EOF
+  run preprocess_config "$TEST_TMP/a.conf"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"KEY=value"* ]]
+  [[ "$output" == *"OTHER=foo"* ]]
+}
+
+@test "preprocess_config: expands include inline before child content" {
+  cat > "$TEST_TMP/base.conf" <<EOF
+FROM_BASE=1
+EOF
+  cat > "$TEST_TMP/child.conf" <<EOF
+include = base.conf
+FROM_CHILD=1
+EOF
+  run preprocess_config "$TEST_TMP/child.conf"
+  [ "$status" -eq 0 ]
+  # Base must appear before child so later assignments override
+  local base_line child_line
+  base_line=$(echo "$output" | grep -n "FROM_BASE" | cut -d: -f1)
+  child_line=$(echo "$output" | grep -n "FROM_CHILD" | cut -d: -f1)
+  [ "$base_line" -lt "$child_line" ]
+}
+
+@test "preprocess_config: child assignment overrides base when both sourced" {
+  cat > "$TEST_TMP/base.conf" <<EOF
+BANNER=base
+EOF
+  cat > "$TEST_TMP/child.conf" <<EOF
+include = base.conf
+BANNER=child
+EOF
+  # shellcheck disable=SC1090
+  source <(preprocess_config "$TEST_TMP/child.conf")
+  [ "$BANNER" = "child" ]
+}
+
+@test "preprocess_config: relative include resolves against including file's dir" {
+  mkdir -p "$TEST_TMP/a/b"
+  cat > "$TEST_TMP/a/base.conf" <<EOF
+VAR=ok
+EOF
+  cat > "$TEST_TMP/a/b/child.conf" <<EOF
+include = ../base.conf
+EOF
+  # shellcheck disable=SC1090
+  source <(preprocess_config "$TEST_TMP/a/b/child.conf")
+  [ "$VAR" = "ok" ]
+}
+
+@test "preprocess_config: absolute include path works" {
+  cat > "$TEST_TMP/base.conf" <<EOF
+VAR=abs
+EOF
+  cat > "$TEST_TMP/child.conf" <<EOF
+include = $TEST_TMP/base.conf
+EOF
+  # shellcheck disable=SC1090
+  source <(preprocess_config "$TEST_TMP/child.conf")
+  [ "$VAR" = "abs" ]
+}
+
+@test "preprocess_config: multiple includes processed in order" {
+  cat > "$TEST_TMP/a.conf" <<EOF
+FROM_A=1
+EOF
+  cat > "$TEST_TMP/b.conf" <<EOF
+FROM_B=1
+EOF
+  cat > "$TEST_TMP/child.conf" <<EOF
+include = a.conf
+include = b.conf
+EOF
+  # shellcheck disable=SC1090
+  source <(preprocess_config "$TEST_TMP/child.conf")
+  [ "$FROM_A" = "1" ]
+  [ "$FROM_B" = "1" ]
+}
+
+@test "preprocess_config: later include overrides earlier include" {
+  cat > "$TEST_TMP/a.conf" <<EOF
+X=1
+EOF
+  cat > "$TEST_TMP/b.conf" <<EOF
+X=2
+EOF
+  cat > "$TEST_TMP/child.conf" <<EOF
+include = a.conf
+include = b.conf
+EOF
+  # shellcheck disable=SC1090
+  source <(preprocess_config "$TEST_TMP/child.conf")
+  [ "$X" = "2" ]
+}
+
+@test "preprocess_config: circular include rejected" {
+  cat > "$TEST_TMP/a.conf" <<EOF
+include = b.conf
+EOF
+  cat > "$TEST_TMP/b.conf" <<EOF
+include = a.conf
+EOF
+  run preprocess_config "$TEST_TMP/a.conf"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"circular"* ]] || [[ "$output" == *"FAIL"* ]]
+}
+
+@test "preprocess_config: missing include target fails with clear message" {
+  cat > "$TEST_TMP/child.conf" <<EOF
+include = nonexistent.conf
+EOF
+  run preprocess_config "$TEST_TMP/child.conf"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "preprocess_config: comment line starting with # is passthrough even if contains include" {
+  cat > "$TEST_TMP/child.conf" <<EOF
+# include = nonexistent.conf
+KEY=value
+EOF
+  run preprocess_config "$TEST_TMP/child.conf"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"include = nonexistent.conf"* ]]
+}
+
+@test "preprocess_config: quoted include path accepted" {
+  cat > "$TEST_TMP/base.conf" <<EOF
+VAR=quoted
+EOF
+  cat > "$TEST_TMP/child.conf" <<EOF
+include = "base.conf"
+EOF
+  # shellcheck disable=SC1090
+  source <(preprocess_config "$TEST_TMP/child.conf")
+  [ "$VAR" = "quoted" ]
+}
+
+@test "preprocess_config: plain-text file (required_vars style) supports include" {
+  cat > "$TEST_TMP/common.vars" <<EOF
+DB_URL
+SECRET_KEY
+EOF
+  cat > "$TEST_TMP/stack.vars" <<EOF
+include = common.vars
+STACK_SPECIFIC_VAR
+EOF
+  run preprocess_config "$TEST_TMP/stack.vars"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DB_URL"* ]]
+  [[ "$output" == *"SECRET_KEY"* ]]
+  [[ "$output" == *"STACK_SPECIFIC_VAR"* ]]
+}
+
+@test "preprocess_config: nested includes (A -> B -> C) work" {
+  cat > "$TEST_TMP/c.conf" <<EOF
+FROM_C=1
+EOF
+  cat > "$TEST_TMP/b.conf" <<EOF
+include = c.conf
+FROM_B=1
+EOF
+  cat > "$TEST_TMP/a.conf" <<EOF
+include = b.conf
+FROM_A=1
+EOF
+  # shellcheck disable=SC1090
+  source <(preprocess_config "$TEST_TMP/a.conf")
+  [ "$FROM_A" = "1" ]
+  [ "$FROM_B" = "1" ]
+  [ "$FROM_C" = "1" ]
+}
+
+@test "preprocess_config: include without whitespace around = works" {
+  cat > "$TEST_TMP/base.conf" <<EOF
+VAR=nospaces
+EOF
+  cat > "$TEST_TMP/child.conf" <<EOF
+include=base.conf
+EOF
+  # shellcheck disable=SC1090
+  source <(preprocess_config "$TEST_TMP/child.conf")
+  [ "$VAR" = "nospaces" ]
+}
+
+# ── Integration with actual loaders ──────────────────────────────────────────
+
+@test "load_strut_config: applies include from strut.conf" {
+  mkdir -p "$TEST_TMP/.strut"
+  cat > "$TEST_TMP/.strut/base.conf" <<EOF
+REGISTRY_TYPE=ghcr
+DEFAULT_ORG=shared-org
+BANNER_TEXT=shared
+EOF
+  cat > "$TEST_TMP/strut.conf" <<EOF
+include = .strut/base.conf
+BANNER_TEXT=child-banner
+EOF
+  export PROJECT_ROOT="$TEST_TMP"
+  load_strut_config
+  [ "$REGISTRY_TYPE" = "ghcr" ]
+  [ "$DEFAULT_ORG" = "shared-org" ]
+  [ "$BANNER_TEXT" = "child-banner" ]
+}
+
+@test "load_services_conf: applies include from services.conf" {
+  mkdir -p "$TEST_TMP/stacks/api"
+  cat > "$TEST_TMP/common.conf" <<EOF
+COMMON_PORT=9000
+EOF
+  cat > "$TEST_TMP/stacks/api/services.conf" <<EOF
+include = ../../common.conf
+API_PORT=8080
+EOF
+  load_services_conf "$TEST_TMP/stacks/api"
+  [ "$COMMON_PORT" = "9000" ]
+  [ "$API_PORT" = "8080" ]
+}

--- a/tests/test_posture.bats
+++ b/tests/test_posture.bats
@@ -6,6 +6,7 @@
 setup() {
   source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
   load_utils
+  source "$CLI_ROOT/lib/config.sh"
   source "$CLI_ROOT/lib/output.sh"
 
   export REAL_CLI_ROOT="$CLI_ROOT"

--- a/tests/test_resource_checks.bats
+++ b/tests/test_resource_checks.bats
@@ -10,6 +10,7 @@ setup() {
   export CLI_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
   TEST_TMP="$(mktemp -d)"
   source "$CLI_ROOT/lib/utils.sh"
+  source "$CLI_ROOT/lib/config.sh"
   fail() { echo "$1" >&2; return 1; }
 }
 

--- a/tests/test_services_conf.bats
+++ b/tests/test_services_conf.bats
@@ -15,6 +15,7 @@ teardown() {
 
 _load_utils() {
   source "$CLI_ROOT/lib/utils.sh"
+  source "$CLI_ROOT/lib/config.sh"
   fail() { echo "$1" >&2; return 1; }
 }
 

--- a/tests/test_validate.bats
+++ b/tests/test_validate.bats
@@ -12,6 +12,7 @@ setup() {
   TEST_TMP="$(mktemp -d)"
 
   source "$CLI_ROOT/lib/utils.sh"
+  source "$CLI_ROOT/lib/config.sh"
   fail() { echo "$1" >&2; return 1; }
   error() { echo "$1" >&2; }
 

--- a/tests/test_volumes.bats
+++ b/tests/test_volumes.bats
@@ -17,6 +17,7 @@ teardown() {
 
 _load_volumes() {
   source "$CLI_ROOT/lib/utils.sh"
+  source "$CLI_ROOT/lib/config.sh"
   # Stub log functions used in volumes.sh (not defined in utils.sh)
   log_info()    { echo "[info] $1"; }
   log_success() { echo "[ok] $1"; }


### PR DESCRIPTION
## Summary
- Adds `include = <path>` directive to config files so shared settings can be factored out (registry, banner, common required_vars, etc.)
- Relative paths resolve against the including file's directory; absolute paths work too. Nested includes, multiple includes, and cycle detection all supported.
- Assignments after an `include =` line override values from the included file — last-write-wins.

## Implementation
- New `preprocess_config` in `lib/config.sh` expands `include = path` lines inline, emitting base content at the directive's position. Callers use `source <(preprocess_config "$file")` (for shell-sourced files) or `while read < <(preprocess_config "$file")` (for line-oriented files like `required_vars`).
- Applied at every local config-loading site: `load_strut_config` (strut.conf), `load_services_conf` (services.conf), volume.conf sources in `lib/volumes.sh` and `lib/backup.sh`, backup.conf in `lib/backup.sh`, and `required_vars` readers in `lib/cmd_validate.sh` + `lib/cmd_posture.sh`.
- Remote VPS-side `ssh ... . file.conf` calls keep using plain `source` — include is a local CLI concern; VPS configs are typically single-file.
- `strut.conf.template` now documents the directive.

## Test plan
- [x] 15 new tests in `tests/test_config_include.bats` — passthrough, inline expansion, child override, relative/absolute paths, multiple includes, later-wins, cycle detection, missing-target error, comment passthrough, quoted paths, line-oriented files, nested A→B→C, no-space `include=path`, integration with `load_strut_config` and `load_services_conf`
- [x] Full bats suite passes (940 tests)
- [x] `shellcheck -x` on all modified lib/ files clean

Resolves #46