### PR TITLE
feat: project-local plugin system (#43)

### DIFF
--- a/lib/plugins.sh
+++ b/lib/plugins.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# ==================================================
+# lib/plugins.sh — Project-local plugin discovery & dispatch
+# ==================================================
+#
+# Plugins let operators extend strut with custom commands without forking.
+# Drop a file in .strut/plugins/cmd_<name>.sh under PROJECT_ROOT and strut
+# will discover it on startup and dispatch `strut <name> ...` (top-level)
+# or `strut <stack> <name> ...` (stack-level) to it.
+#
+# Plugin contract (bash):
+#   plugin_help()   — prints one-line description on stdout
+#   plugin_main()   — receives dispatched args; first two args are stack
+#                     and env_name when invoked in stack-level context
+#
+# Precedence: core strut commands always win. Plugins fall through only
+# when the command name doesn't match any core case.
+#
+# Isolation: plugins run in a subshell, so a plugin crash (set -e, exit,
+# unbound var) does not take down strut.
+#
+# Re-entrancy: plugins can call `strut` themselves — the entrypoint is on
+# PATH for the operator's shell.
+
+set -euo pipefail
+
+# Parallel arrays rather than associative — keeps bash 3 portability that
+# other lib/*.sh relies on.
+_STRUT_PLUGIN_NAMES=()
+_STRUT_PLUGIN_FILES=()
+
+# plugins_dir — resolve the directory strut scans for plugins.
+# Honors PROJECT_ROOT (set by lib/config.sh). Absent PROJECT_ROOT, returns
+# a path under $PWD so repeated invocations remain deterministic.
+plugins_dir() {
+  echo "${PROJECT_ROOT:-$PWD}/.strut/plugins"
+}
+
+# plugins_discover — (re)populate the plugin registry from plugins_dir.
+# Silent no-op when the directory doesn't exist. Called once at startup
+# and safe to call repeatedly (e.g. from tests).
+plugins_discover() {
+  _STRUT_PLUGIN_NAMES=()
+  _STRUT_PLUGIN_FILES=()
+  local dir
+  dir="$(plugins_dir)"
+  [ -d "$dir" ] || return 0
+
+  local f name
+  for f in "$dir"/cmd_*.sh; do
+    [ -f "$f" ] || continue
+    name="$(basename "$f" .sh)"
+    name="${name#cmd_}"
+    [ -n "$name" ] || continue
+    _STRUT_PLUGIN_NAMES+=("$name")
+    _STRUT_PLUGIN_FILES+=("$f")
+  done
+}
+
+# plugins_file_for <name> — print the file path for a plugin, or return 1.
+plugins_file_for() {
+  local want="$1" i
+  local count="${#_STRUT_PLUGIN_NAMES[@]}"
+  [ "$count" -eq 0 ] && return 1
+  for ((i = 0; i < count; i++)); do
+    if [ "${_STRUT_PLUGIN_NAMES[i]}" = "$want" ]; then
+      printf '%s\n' "${_STRUT_PLUGIN_FILES[i]}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# plugins_has <name> — predicate for dispatch fallthrough checks.
+plugins_has() {
+  plugins_file_for "$1" >/dev/null 2>&1
+}
+
+# plugins_run <name> [args...] — source the plugin in a subshell and call
+# plugin_main. Subshell keeps plugin state out of strut's process and
+# prevents plugin exit/set -e from killing the CLI.
+plugins_run() {
+  local name="$1"; shift
+  local file
+  file="$(plugins_file_for "$name")" || { fail "Plugin not found: $name"; }
+  (
+    set -euo pipefail
+    # shellcheck disable=SC1090
+    source "$file"
+    if ! declare -F plugin_main >/dev/null 2>&1; then
+      echo "[strut] plugin '$name' does not define plugin_main()" >&2
+      exit 1
+    fi
+    plugin_main "$@"
+  )
+}
+
+# plugins_help <name> — invoke plugin_help in a subshell. Returns an
+# empty string (not error) when the plugin omits plugin_help, so list
+# rendering stays tidy.
+plugins_help() {
+  local name="$1"
+  local file
+  file="$(plugins_file_for "$name")" || { fail "Plugin not found: $name"; }
+  (
+    set -euo pipefail
+    # shellcheck disable=SC1090
+    source "$file"
+    if declare -F plugin_help >/dev/null 2>&1; then
+      plugin_help
+    fi
+  )
+}
+
+# plugins_list_text — render discovered plugins as a table.
+plugins_list_text() {
+  local dir
+  dir="$(plugins_dir)"
+
+  if [ "${#_STRUT_PLUGIN_NAMES[@]}" -eq 0 ]; then
+    echo ""
+    echo "No plugins found."
+    echo "Plugins dir: $dir"
+    echo ""
+    echo "Drop a cmd_<name>.sh file in that directory with plugin_main/"
+    echo "plugin_help and re-run to pick it up."
+    echo ""
+    return 0
+  fi
+
+  echo ""
+  echo -e "${BLUE:-}Plugins:${NC:-}"
+  echo ""
+  out_table_header "Name" "Description" "File"
+  local i name file desc
+  for i in "${!_STRUT_PLUGIN_NAMES[@]}"; do
+    name="${_STRUT_PLUGIN_NAMES[i]}"
+    file="${_STRUT_PLUGIN_FILES[i]}"
+    desc="$(plugins_help "$name" 2>/dev/null | head -1 || true)"
+    [ -n "$desc" ] || desc="(no description)"
+    out_table_row "$name" "$desc" "$file"
+  done
+  out_table_render
+  echo ""
+}
+
+# plugins_list_json — stream discovered plugins as JSON.
+plugins_list_json() {
+  out_json_object
+    out_json_field "plugins_dir" "$(plugins_dir)"
+    out_json_array "plugins"
+    local i name file desc count="${#_STRUT_PLUGIN_NAMES[@]}"
+    for ((i = 0; i < count; i++)); do
+      name="${_STRUT_PLUGIN_NAMES[i]}"
+      file="${_STRUT_PLUGIN_FILES[i]}"
+      desc="$(plugins_help "$name" 2>/dev/null | head -1 || true)"
+      out_json_object
+        out_json_field "name" "$name"
+        out_json_field "description" "$desc"
+        out_json_field "file" "$file"
+      out_json_close_object
+    done
+    out_json_close_array
+  out_json_close_object
+  out_json_newline
+}

--- a/strut
+++ b/strut
@@ -131,6 +131,11 @@ source "$LIB/lock.sh"
 source "$LIB/cmd_lock.sh"
 source "$LIB/groups.sh"
 source "$LIB/cmd_group.sh"
+source "$LIB/plugins.sh"
+
+# Project-local plugins are discovered once PROJECT_ROOT is known. find_project_root
+# above populates it when strut is invoked inside a project; outside one this is a no-op.
+plugins_discover
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
@@ -190,6 +195,7 @@ usage() {
   echo "  keys     <subcommand> [options]                                Key management (SSH, API, env, GitHub)"
   echo "  domain   <domain> <email> [--skip-ssl]                         Configure domain/SSL"
   echo "  list                                                           List stacks"
+  echo "  list plugins [--json]                                          List discovered project plugins"
   echo "  status-all [--env <name>] [--json]                             Dashboard across all stacks"
   echo "  posture    [--stack <name>] [--category <c>] [--fail-on <l>]   Security/ops posture check"
   echo "  group      list|show|add|remove | <name> <command>             Stack groups (coordinated multi-stack ops)"
@@ -370,6 +376,14 @@ case "${1:-}" in
     for _arg in "$@"; do
       if [ "$_arg" = "--json" ]; then OUTPUT_MODE=json; break; fi
     done
+    if [ "${1:-}" = "plugins" ]; then
+      if [ "$(output_mode)" = "json" ]; then
+        plugins_list_json
+      else
+        plugins_list_text
+      fi
+      exit 0
+    fi
     cmd_list
     exit 0
     ;;
@@ -515,9 +529,28 @@ case "${1:-}" in
     esac
     exit 0
     ;;
-  --help|-h|help) usage; exit 0 ;;
+  --help|-h|help)
+    # `strut help <plugin>` routes to plugin_help for project plugins.
+    if [ -n "${2:-}" ] && plugins_has "$2"; then
+      plugins_help "$2"
+      exit 0
+    fi
+    usage
+    exit 0
+    ;;
   "")             usage; exit 1 ;;
 esac
+
+# Top-level plugin dispatch — only reached when $1 didn't match any core
+# command. Precedence: core commands above always win. If $1 matches a
+# stack directory, fall through to the stack dispatcher so plugins never
+# shadow real stacks.
+if [ -n "${1:-}" ] && plugins_has "$1" && [ ! -d "$CLI_ROOT/stacks/$1" ]; then
+  _plugin_name="$1"
+  shift
+  plugins_run "$_plugin_name" "$@"
+  exit $?
+fi
 
 STACK="${1:-}"
 COMMAND="${2:-}"
@@ -618,5 +651,15 @@ case "$COMMAND" in
   domain)              cmd_domain "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   diff)                cmd_diff "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   lock)                cmd_lock "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
-  *)                   usage; fail "Unknown command: '$COMMAND'" ;;
+  *)
+    # Stack-level plugin fallthrough — `strut <stack> <plugin> ...`.
+    # Plugin contract: plugin_main receives stack, env_name, then the
+    # parsed positional args (already stripped of global flags).
+    if plugins_has "$COMMAND"; then
+      plugins_run "$COMMAND" "$STACK" "$ENV_NAME" "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}"
+      exit $?
+    fi
+    usage
+    fail "Unknown command: '$COMMAND'"
+    ;;
 esac

--- a/tests/test_plugins.bats
+++ b/tests/test_plugins.bats
@@ -1,0 +1,323 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_plugins.bats — Project-local plugin discovery & dispatch
+# ==================================================
+# Run:  bats tests/test_plugins.bats
+# Covers: plugins_discover, plugins_has, plugins_run, plugins_help,
+# plugins_list_text/json, end-to-end dispatch through the strut entrypoint.
+
+setup() {
+  CLI_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  export CLI_ROOT
+  CLI="$CLI_ROOT/strut"
+  TEST_TMP="$(mktemp -d)"
+  export PROJECT_ROOT="$TEST_TMP"
+  mkdir -p "$PROJECT_ROOT/.strut/plugins"
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+  # Remove any test stack dropped under the strut repo
+  rm -rf "$CLI_ROOT/stacks/test-plugin-stack"
+  unset PROJECT_ROOT
+}
+
+_load_plugins() {
+  source "$CLI_ROOT/lib/utils.sh"
+  fail() { echo "$1" >&2; return 1; }
+  source "$CLI_ROOT/lib/output.sh"
+  source "$CLI_ROOT/lib/plugins.sh"
+}
+
+_make_plugin() {
+  local name="$1" body="$2"
+  cat > "$PROJECT_ROOT/.strut/plugins/cmd_${name}.sh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+$body
+EOF
+}
+
+# ── Discovery ─────────────────────────────────────────────────────────────────
+
+@test "plugins_discover: picks up cmd_*.sh files" {
+  _load_plugins
+  _make_plugin "foo" '
+plugin_help() { echo "foo desc"; }
+plugin_main() { echo "foo main: $@"; }
+'
+  _make_plugin "bar" '
+plugin_help() { echo "bar desc"; }
+plugin_main() { echo "bar main"; }
+'
+  plugins_discover
+  plugins_has "foo"
+  plugins_has "bar"
+}
+
+@test "plugins_discover: ignores non-cmd files" {
+  _load_plugins
+  _make_plugin "real" 'plugin_main() { :; }'
+  cat > "$PROJECT_ROOT/.strut/plugins/helper.sh" <<'EOF'
+# not a plugin — should be ignored
+echo "should not run"
+EOF
+  plugins_discover
+  plugins_has "real"
+  run plugins_has "helper"
+  [ "$status" -ne 0 ]
+}
+
+@test "plugins_discover: no-op when plugins dir missing" {
+  _load_plugins
+  rm -rf "$PROJECT_ROOT/.strut"
+  run plugins_discover
+  [ "$status" -eq 0 ]
+  run plugins_has "anything"
+  [ "$status" -ne 0 ]
+}
+
+@test "plugins_file_for: returns path for known plugin, fails for unknown" {
+  _load_plugins
+  _make_plugin "ship" 'plugin_main() { :; }'
+  plugins_discover
+  run plugins_file_for "ship"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"cmd_ship.sh" ]]
+  run plugins_file_for "missing"
+  [ "$status" -ne 0 ]
+}
+
+# ── plugins_run ───────────────────────────────────────────────────────────────
+
+@test "plugins_run: invokes plugin_main with forwarded args" {
+  _load_plugins
+  _make_plugin "echoer" '
+plugin_main() { echo "got: $*"; }
+'
+  plugins_discover
+  run plugins_run "echoer" a b c
+  [ "$status" -eq 0 ]
+  [[ "$output" == "got: a b c" ]]
+}
+
+@test "plugins_run: errors when plugin_main missing" {
+  _load_plugins
+  _make_plugin "noop" '
+plugin_help() { echo "no main here"; }
+'
+  plugins_discover
+  run plugins_run "noop"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"plugin_main"* ]]
+}
+
+@test "plugins_run: subshell isolation — plugin exit does not kill parent" {
+  _load_plugins
+  _make_plugin "crasher" '
+plugin_main() { exit 7; }
+'
+  plugins_discover
+  # The parent shell keeps running even though plugin_main exited.
+  run plugins_run "crasher"
+  [ "$status" -eq 7 ]
+  # Subsequent calls still work — proves we did not kill the parent.
+  run plugins_has "crasher"
+  [ "$status" -eq 0 ]
+}
+
+# ── plugins_help ──────────────────────────────────────────────────────────────
+
+@test "plugins_help: prints plugin_help output" {
+  _load_plugins
+  _make_plugin "docd" '
+plugin_help() { echo "Documented plugin"; }
+plugin_main() { :; }
+'
+  plugins_discover
+  run plugins_help "docd"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "Documented plugin" ]]
+}
+
+@test "plugins_help: empty output when plugin omits plugin_help" {
+  _load_plugins
+  _make_plugin "terse" '
+plugin_main() { :; }
+'
+  plugins_discover
+  run plugins_help "terse"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# ── plugins_list ──────────────────────────────────────────────────────────────
+
+@test "plugins_list_text: renders discovered plugins" {
+  _load_plugins
+  _make_plugin "alpha" '
+plugin_help() { echo "first plugin"; }
+plugin_main() { :; }
+'
+  _make_plugin "beta" '
+plugin_help() { echo "second plugin"; }
+plugin_main() { :; }
+'
+  plugins_discover
+  run plugins_list_text
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"alpha"* ]]
+  [[ "$output" == *"first plugin"* ]]
+  [[ "$output" == *"beta"* ]]
+  [[ "$output" == *"second plugin"* ]]
+}
+
+@test "plugins_list_text: empty-state message when no plugins" {
+  _load_plugins
+  plugins_discover
+  run plugins_list_text
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No plugins found"* ]]
+}
+
+@test "plugins_list_json: emits valid JSON with plugin metadata" {
+  _load_plugins
+  _make_plugin "jsonplug" '
+plugin_help() { echo "json desc"; }
+plugin_main() { :; }
+'
+  plugins_discover
+  export OUTPUT_MODE=json
+  run plugins_list_json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"\"plugins\""* ]]
+  [[ "$output" == *"\"name\":\"jsonplug\""* ]]
+  [[ "$output" == *"\"description\":\"json desc\""* ]]
+}
+
+# ── Entrypoint dispatch (end-to-end) ──────────────────────────────────────────
+
+@test "strut <plugin>: top-level dispatch runs plugin_main" {
+  _make_plugin "greet" '
+plugin_help() { echo "greets"; }
+plugin_main() { echo "hello from plugin: $*"; }
+'
+  # Invoke from PROJECT_ROOT so find_project_root picks it up
+  cat > "$PROJECT_ROOT/strut.conf" <<'EOF'
+BANNER_TEXT="test"
+EOF
+  cd "$PROJECT_ROOT"
+  run bash "$CLI" greet world
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hello from plugin: world"* ]]
+}
+
+@test "strut <stack> <plugin>: stack-level dispatch passes stack + env" {
+  mkdir -p "$CLI_ROOT/stacks/test-plugin-stack"
+  touch "$CLI_ROOT/stacks/test-plugin-stack/docker-compose.yml"
+  _make_plugin "ship" '
+plugin_help() { echo "ship it"; }
+plugin_main() {
+  local stack="$1" env_name="$2"; shift 2
+  echo "stack=$stack env=$env_name rest=$*"
+}
+'
+  cat > "$PROJECT_ROOT/strut.conf" <<'EOF'
+BANNER_TEXT="test"
+EOF
+  cd "$PROJECT_ROOT"
+  run bash "$CLI" test-plugin-stack ship --env prod extra
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"stack=test-plugin-stack"* ]]
+  [[ "$output" == *"env=prod"* ]]
+  [[ "$output" == *"rest=extra"* ]]
+}
+
+@test "strut <plugin>: core command shadows plugin of same name" {
+  _make_plugin "list" '
+plugin_main() { echo "plugin list ran"; }
+'
+  cat > "$PROJECT_ROOT/strut.conf" <<'EOF'
+BANNER_TEXT="test"
+EOF
+  cd "$PROJECT_ROOT"
+  run bash "$CLI" list
+  [ "$status" -eq 0 ]
+  # Core `list` renders the stacks header. Plugin must not have run.
+  [[ "$output" == *"Available stacks"* ]]
+  [[ "$output" != *"plugin list ran"* ]]
+}
+
+@test "strut <stack> <plugin>: core stack command shadows plugin of same name" {
+  mkdir -p "$CLI_ROOT/stacks/test-plugin-stack"
+  touch "$CLI_ROOT/stacks/test-plugin-stack/docker-compose.yml"
+  _make_plugin "deploy" '
+plugin_main() { echo "plugin deploy ran"; }
+'
+  cat > "$PROJECT_ROOT/strut.conf" <<'EOF'
+BANNER_TEXT="test"
+EOF
+  cd "$PROJECT_ROOT"
+  # `deploy` is a core command — should invoke core cmd_deploy (which will
+  # fail fast because test-plugin-stack has no .env), never the plugin.
+  run bash "$CLI" test-plugin-stack deploy
+  [[ "$output" != *"plugin deploy ran"* ]]
+}
+
+@test "strut list plugins: lists discovered plugins" {
+  _make_plugin "telemetry" '
+plugin_help() { echo "ship telemetry"; }
+plugin_main() { :; }
+'
+  cat > "$PROJECT_ROOT/strut.conf" <<'EOF'
+BANNER_TEXT="test"
+EOF
+  cd "$PROJECT_ROOT"
+  run bash "$CLI" list plugins
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"telemetry"* ]]
+  [[ "$output" == *"ship telemetry"* ]]
+}
+
+@test "strut list plugins --json: emits JSON" {
+  _make_plugin "jsonplug" '
+plugin_help() { echo "json ok"; }
+plugin_main() { :; }
+'
+  cat > "$PROJECT_ROOT/strut.conf" <<'EOF'
+BANNER_TEXT="test"
+EOF
+  cd "$PROJECT_ROOT"
+  run bash "$CLI" list plugins --json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"\"plugins\""* ]]
+  [[ "$output" == *"\"name\":\"jsonplug\""* ]]
+}
+
+@test "strut help <plugin>: runs plugin_help" {
+  _make_plugin "explained" '
+plugin_help() { echo "this is what I do"; }
+plugin_main() { :; }
+'
+  cat > "$PROJECT_ROOT/strut.conf" <<'EOF'
+BANNER_TEXT="test"
+EOF
+  cd "$PROJECT_ROOT"
+  run bash "$CLI" help explained
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"this is what I do"* ]]
+}
+
+@test "strut <plugin>: re-entrant — plugin can invoke strut itself" {
+  _make_plugin "relay" '
+plugin_main() { "'"$CLI"'" --version; }
+'
+  cat > "$PROJECT_ROOT/strut.conf" <<'EOF'
+BANNER_TEXT="test"
+EOF
+  cd "$PROJECT_ROOT"
+  run bash "$CLI" relay
+  [ "$status" -eq 0 ]
+  # --version prints the VERSION file contents
+  [ -n "$output" ]
+}


### PR DESCRIPTION
## Summary
- Add `lib/plugins.sh` — discovers `cmd_<name>.sh` files under `${PROJECT_ROOT}/.strut/plugins/` and exposes `plugins_discover / has / file_for / run / help / list_text / list_json`.
- Wire entrypoint dispatch: top-level (`strut <plugin>`) and stack-level (`strut <stack> <plugin>`), plus `strut list plugins [--json]` and `strut help <plugin>`.
- Core commands and stack directories always take precedence; plugins run in a subshell for crash isolation.

Closes #43.

## Plugin contract
```bash
# .strut/plugins/cmd_ship.sh
plugin_help() { echo "Validate, deploy, announce"; }
plugin_main() {
  local stack="$1" env="$2"; shift 2
  strut "$stack" validate --env "$env"
  strut "$stack" deploy   --env "$env"
  strut notify test slack
}
```

Stack-level dispatch passes stack and env as `$1`/`$2`; top-level dispatch forwards raw args. Plugins may call `strut` recursively.

## Docs
`wiki/Plugins.md` added (committed to wiki checkout separately) covering contract, dispatch, precedence, safety, and an end-to-end example. `wiki/CLI-Reference.md` and sidebar updated to link it.

## Test plan
- [x] `bats tests/test_plugins.bats` — 20 unit + e2e tests (discovery, file_for, has, run, help, list_text/list_json, entrypoint dispatch, precedence, re-entrancy, subshell isolation)
- [x] `bats tests/` — full suite 944 passing, 0 failures
- [x] `shellcheck -x strut lib/plugins.sh` clean