### PR TITLE
feat: shell completions for bash, zsh, fish (#20)

### DIFF
--- a/completions/bash.sh
+++ b/completions/bash.sh
@@ -1,0 +1,194 @@
+# bash completion for strut
+# ===========================
+# Source: `eval "$(strut completions bash)"` in your .bashrc.
+#
+# Completes:
+#   - stack names (from $PROJECT_ROOT/stacks/*/)
+#   - top-level commands + per-stack commands + their subcommands
+#   - environment names (from .*env files at PROJECT_ROOT)
+#   - service profiles for --services
+#   - known flags per command
+
+_strut_find_project_root() {
+  local dir="$PWD"
+  while [ "$dir" != "/" ]; do
+    if [ -f "$dir/strut.conf" ]; then
+      printf '%s\n' "$dir"
+      return 0
+    fi
+    dir=$(dirname "$dir")
+  done
+  return 1
+}
+
+_strut_stacks() {
+  local root
+  root=$(_strut_find_project_root) || return 0
+  [ -d "$root/stacks" ] || return 0
+  local d
+  for d in "$root/stacks"/*/; do
+    [ -d "$d" ] || continue
+    local name
+    name=$(basename "$d")
+    [ "$name" = "shared" ] && continue
+    printf '%s\n' "$name"
+  done
+}
+
+_strut_envs() {
+  local root
+  root=$(_strut_find_project_root) || return 0
+  local f name
+  for f in "$root"/.*.env "$root"/.env; do
+    [ -f "$f" ] || continue
+    name=$(basename "$f")
+    # Strip leading dot and trailing .env; map .env itself to "prod"
+    case "$name" in
+      .env) printf '%s\n' "prod" ;;
+      .*.env)
+        name=${name#.}
+        name=${name%.env}
+        printf '%s\n' "$name"
+        ;;
+    esac
+  done
+}
+
+_strut_groups() {
+  local root
+  root=$(_strut_find_project_root) || return 0
+  [ -f "$root/groups.conf" ] || return 0
+  awk -F'=' '/^[a-zA-Z_][a-zA-Z0-9_-]*=/{print $1}' "$root/groups.conf" 2>/dev/null
+}
+
+_strut_completions() {
+  local cur prev words cword
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
+  cword=$COMP_CWORD
+
+  local top_cmds="init list scaffold upgrade doctor status-all posture group monitoring audit audit:list audit:generate migrate migrate:status notify skills help completions --version -v --help -h"
+  local per_stack_cmds="update release deploy stop diff lock health logs logs:download logs:rotate migrate backup restore db:pull db:push db:schema shell exec status volumes prune local prod staging dev debug keys validate rollback domain --help"
+  local profiles="messaging ui full gdrive"
+
+  # Flag-value completions — operate on prev regardless of position
+  case "$prev" in
+    --env)
+      local envs
+      envs=$(_strut_envs)
+      mapfile -t COMPREPLY < <(compgen -W "$envs" -- "$cur")
+      return 0
+      ;;
+    --services)
+      mapfile -t COMPREPLY < <(compgen -W "$profiles" -- "$cur")
+      return 0
+      ;;
+    --registry)
+      mapfile -t COMPREPLY < <(compgen -W "ghcr dockerhub ecr none" -- "$cur")
+      return 0
+      ;;
+    completions)
+      mapfile -t COMPREPLY < <(compgen -W "bash zsh fish" -- "$cur")
+      return 0
+      ;;
+  esac
+
+  if [ "$cword" -eq 1 ]; then
+    local stacks
+    stacks=$(_strut_stacks)
+    mapfile -t COMPREPLY < <(compgen -W "$top_cmds $stacks" -- "$cur")
+    return 0
+  fi
+
+  local root_word="${COMP_WORDS[1]}"
+
+  # Top-level dispatchers that take subcommands
+  case "$root_word" in
+    list)
+      [ "$cword" -eq 2 ] && mapfile -t COMPREPLY < <(compgen -W "plugins --json" -- "$cur") && return 0
+      ;;
+    group)
+      [ "$cword" -eq 2 ] && mapfile -t COMPREPLY < <(compgen -W "list show add remove $(_strut_groups)" -- "$cur") && return 0
+      ;;
+    monitoring)
+      [ "$cword" -eq 2 ] && mapfile -t COMPREPLY < <(compgen -W "deploy add-target remove-target alert-channel status" -- "$cur") && return 0
+      ;;
+    notify)
+      [ "$cword" -eq 2 ] && mapfile -t COMPREPLY < <(compgen -W "test" -- "$cur") && return 0
+      [ "$cword" -eq 3 ] && mapfile -t COMPREPLY < <(compgen -W "slack discord webhook" -- "$cur") && return 0
+      ;;
+    skills)
+      [ "$cword" -eq 2 ] && mapfile -t COMPREPLY < <(compgen -W "list install --format" -- "$cur") && return 0
+      ;;
+    help)
+      [ "$cword" -eq 2 ] && mapfile -t COMPREPLY < <(compgen -W "$top_cmds $per_stack_cmds" -- "$cur") && return 0
+      ;;
+    init)
+      mapfile -t COMPREPLY < <(compgen -W "--registry --org --completions" -- "$cur")
+      return 0
+      ;;
+    doctor)
+      mapfile -t COMPREPLY < <(compgen -W "--check-vps --json --fix" -- "$cur")
+      return 0
+      ;;
+  esac
+
+  # Stack-level: strut <stack> <cmd> ...
+  if [ "$cword" -eq 2 ]; then
+    mapfile -t COMPREPLY < <(compgen -W "$per_stack_cmds" -- "$cur")
+    return 0
+  fi
+
+  # Per-command subcommands + flags
+  local cmd="${COMP_WORDS[2]}"
+  case "$cmd" in
+    backup)
+      [ "$cword" -eq 3 ] && mapfile -t COMPREPLY < <(compgen -W "postgres neo4j mysql sqlite gdrive-transcripts all verify list health schedule retention" -- "$cur") && return 0
+      ;;
+    drift)
+      [ "$cword" -eq 3 ] && mapfile -t COMPREPLY < <(compgen -W "detect report fix monitor history auto-fix" -- "$cur") && return 0
+      ;;
+    db:pull|db:push)
+      [ "$cword" -eq 3 ] && mapfile -t COMPREPLY < <(compgen -W "postgres neo4j mysql sqlite all --download-only --upload-only --file" -- "$cur") && return 0
+      ;;
+    db:schema)
+      [ "$cword" -eq 3 ] && mapfile -t COMPREPLY < <(compgen -W "apply verify all" -- "$cur") && return 0
+      ;;
+    volumes)
+      [ "$cword" -eq 3 ] && mapfile -t COMPREPLY < <(compgen -W "status init config" -- "$cur") && return 0
+      ;;
+    lock)
+      [ "$cword" -eq 3 ] && mapfile -t COMPREPLY < <(compgen -W "status release --force --remote --local" -- "$cur") && return 0
+      ;;
+    local|prod|staging|dev)
+      [ "$cword" -eq 3 ] && mapfile -t COMPREPLY < <(compgen -W "start stop reset sync-env sync-db logs test debug" -- "$cur") && return 0
+      ;;
+    debug)
+      [ "$cword" -eq 3 ] && mapfile -t COMPREPLY < <(compgen -W "exec shell port-forward copy snapshot inspect-env stats" -- "$cur") && return 0
+      ;;
+    keys)
+      [ "$cword" -eq 3 ] && mapfile -t COMPREPLY < <(compgen -W "rotate status check env ssh github" -- "$cur") && return 0
+      ;;
+    migrate)
+      [ "$cword" -eq 3 ] && mapfile -t COMPREPLY < <(compgen -W "neo4j postgres --status --up --down" -- "$cur") && return 0
+      ;;
+    deploy)
+      mapfile -t COMPREPLY < <(compgen -W "--env --services --pull-only --skip-validation --force-unlock --no-lock --dry-run" -- "$cur")
+      return 0
+      ;;
+    health)
+      mapfile -t COMPREPLY < <(compgen -W "--env --services --json" -- "$cur")
+      return 0
+      ;;
+    diff)
+      mapfile -t COMPREPLY < <(compgen -W "--env --json" -- "$cur")
+      return 0
+      ;;
+  esac
+
+  # Fallback: common global flags
+  mapfile -t COMPREPLY < <(compgen -W "--env --services --json --dry-run --help" -- "$cur")
+  return 0
+}
+
+complete -F _strut_completions strut

--- a/completions/fish.fish
+++ b/completions/fish.fish
@@ -1,0 +1,125 @@
+# fish completion for strut
+# =========================
+# Install: `strut completions fish > ~/.config/fish/completions/strut.fish`
+
+function __strut_project_root
+    set -l dir $PWD
+    while test "$dir" != /
+        if test -f "$dir/strut.conf"
+            echo $dir
+            return 0
+        end
+        set dir (dirname $dir)
+    end
+    return 1
+end
+
+function __strut_stacks
+    set -l root (__strut_project_root); or return 0
+    test -d "$root/stacks"; or return 0
+    for d in "$root/stacks"/*/
+        set -l name (basename $d)
+        test "$name" = shared; and continue
+        echo $name
+    end
+end
+
+function __strut_envs
+    set -l root (__strut_project_root); or return 0
+    for f in "$root"/.*.env "$root"/.env
+        test -f "$f"; or continue
+        set -l name (basename $f)
+        switch $name
+            case .env
+                echo prod
+            case '.*.env'
+                set name (string replace -r '^\.' '' $name)
+                set name (string replace -r '\.env$' '' $name)
+                echo $name
+        end
+    end
+end
+
+function __strut_groups
+    set -l root (__strut_project_root); or return 0
+    test -f "$root/groups.conf"; or return 0
+    awk -F'=' '/^[a-zA-Z_][a-zA-Z0-9_-]*=/{print $1}' "$root/groups.conf" 2>/dev/null
+end
+
+# Position helpers — fish gives us the whole tokenized command
+function __strut_at_pos
+    set -l tokens (commandline -opc)
+    test (count $tokens) -eq $argv[1]
+end
+
+function __strut_tok
+    set -l tokens (commandline -opc)
+    if test (count $tokens) -ge $argv[1]
+        echo $tokens[$argv[1]]
+    end
+end
+
+set -l top_cmds init list scaffold upgrade doctor status-all posture group monitoring audit audit:list audit:generate migrate migrate:status notify skills help completions
+set -l per_stack_cmds update release deploy stop diff lock health logs logs:download logs:rotate migrate backup restore db:pull db:push db:schema shell exec status volumes prune local prod staging dev debug keys validate rollback domain
+
+# Disable file completion by default; re-enable where relevant
+complete -c strut -f
+
+# Top-level: stacks + commands (position 1)
+complete -c strut -n '__strut_at_pos 1' -a '(__strut_stacks)' -d 'stack'
+complete -c strut -n '__strut_at_pos 1' -a "$top_cmds" -d 'command'
+
+# Flag-value completions — position-independent
+complete -c strut -l env -x -a '(__strut_envs)' -d 'environment'
+complete -c strut -l services -x -a 'messaging ui full gdrive' -d 'service profile'
+complete -c strut -l registry -x -a 'ghcr dockerhub ecr none' -d 'registry type'
+complete -c strut -l json -d 'JSON output'
+complete -c strut -l dry-run -d 'preview without executing'
+complete -c strut -l help -s h -d 'show help'
+
+# completions <shell>
+complete -c strut -n '__strut_tok 2 = completions' -a 'bash zsh fish'
+
+# list subcommand
+complete -c strut -n '__strut_tok 2 = list; and __strut_at_pos 2' -a 'plugins' -d 'list plugins'
+
+# group subcommand
+complete -c strut -n '__strut_tok 2 = group; and __strut_at_pos 2' -a 'list show add remove (__strut_groups)'
+
+# monitoring subcommand
+complete -c strut -n '__strut_tok 2 = monitoring; and __strut_at_pos 2' -a 'deploy add-target remove-target alert-channel status'
+
+# notify subcommand
+complete -c strut -n '__strut_tok 2 = notify; and __strut_at_pos 2' -a 'test'
+complete -c strut -n '__strut_tok 2 = notify; and __strut_tok 3 = test; and __strut_at_pos 3' -a 'slack discord webhook'
+
+# skills subcommand
+complete -c strut -n '__strut_tok 2 = skills; and __strut_at_pos 2' -a 'list install'
+
+# help <cmd>
+complete -c strut -n '__strut_tok 2 = help; and __strut_at_pos 2' -a "$top_cmds $per_stack_cmds"
+
+# Per-stack: position 2 after a stack name
+complete -c strut -n 'contains -- (__strut_tok 2) (__strut_stacks); and __strut_at_pos 2' -a "$per_stack_cmds"
+
+# Per-stack subcommand completions (position 3)
+complete -c strut -n 'contains -- (__strut_tok 2) (__strut_stacks); and __strut_tok 3 = backup; and __strut_at_pos 3' \
+    -a 'postgres neo4j mysql sqlite gdrive-transcripts all verify list health schedule retention'
+complete -c strut -n 'contains -- (__strut_tok 2) (__strut_stacks); and __strut_tok 3 = drift; and __strut_at_pos 3' \
+    -a 'detect report fix monitor history auto-fix'
+complete -c strut -n 'contains -- (__strut_tok 2) (__strut_stacks); and contains -- (__strut_tok 3) db:pull db:push; and __strut_at_pos 3' \
+    -a 'postgres neo4j mysql sqlite all'
+complete -c strut -n 'contains -- (__strut_tok 2) (__strut_stacks); and __strut_tok 3 = db:schema; and __strut_at_pos 3' \
+    -a 'apply verify all'
+complete -c strut -n 'contains -- (__strut_tok 2) (__strut_stacks); and __strut_tok 3 = volumes; and __strut_at_pos 3' \
+    -a 'status init config'
+complete -c strut -n 'contains -- (__strut_tok 2) (__strut_stacks); and __strut_tok 3 = lock; and __strut_at_pos 3' \
+    -a 'status release'
+complete -c strut -n 'contains -- (__strut_tok 2) (__strut_stacks); and contains -- (__strut_tok 3) local prod staging dev; and __strut_at_pos 3' \
+    -a 'start stop reset sync-env sync-db logs test debug'
+complete -c strut -n 'contains -- (__strut_tok 2) (__strut_stacks); and __strut_tok 3 = debug; and __strut_at_pos 3' \
+    -a 'exec shell port-forward copy snapshot inspect-env stats'
+complete -c strut -n 'contains -- (__strut_tok 2) (__strut_stacks); and __strut_tok 3 = keys; and __strut_at_pos 3' \
+    -a 'rotate status check env ssh github'
+complete -c strut -n 'contains -- (__strut_tok 2) (__strut_stacks); and __strut_tok 3 = migrate; and __strut_at_pos 3' \
+    -a 'neo4j postgres'

--- a/completions/zsh.sh
+++ b/completions/zsh.sh
@@ -1,0 +1,178 @@
+#compdef strut
+# zsh completion for strut
+# ========================
+# Source: `eval "$(strut completions zsh)"` in your .zshrc, or save to
+# a file on $fpath named `_strut`.
+
+_strut_find_project_root() {
+  local dir="$PWD"
+  while [ "$dir" != "/" ]; do
+    if [ -f "$dir/strut.conf" ]; then
+      print -- "$dir"
+      return 0
+    fi
+    dir=${dir:h}
+  done
+  return 1
+}
+
+_strut_stacks() {
+  local root stack
+  root=$(_strut_find_project_root) || return 0
+  [ -d "$root/stacks" ] || return 0
+  for stack in "$root"/stacks/*(/N); do
+    local name=${stack:t}
+    [ "$name" = shared ] && continue
+    print -- "$name"
+  done
+}
+
+_strut_envs() {
+  local root f name
+  root=$(_strut_find_project_root) || return 0
+  for f in "$root"/.*.env(N) "$root"/.env(N); do
+    name=${f:t}
+    case "$name" in
+      .env)   print -- prod ;;
+      .*.env) name=${name#.}; name=${name%.env}; print -- "$name" ;;
+    esac
+  done
+}
+
+_strut_groups() {
+  local root
+  root=$(_strut_find_project_root) || return 0
+  [ -f "$root/groups.conf" ] || return 0
+  awk -F'=' '/^[a-zA-Z_][a-zA-Z0-9_-]*=/{print $1}' "$root/groups.conf" 2>/dev/null
+}
+
+_strut() {
+  local -a top_cmds per_stack_cmds profiles
+  top_cmds=(init list scaffold upgrade doctor status-all posture group monitoring audit audit:list audit:generate migrate migrate:status notify skills help completions --version --help)
+  per_stack_cmds=(update release deploy stop diff lock health logs logs:download logs:rotate migrate backup restore db:pull db:push db:schema shell exec status volumes prune local prod staging dev debug keys validate rollback domain --help)
+  profiles=(messaging ui full gdrive)
+
+  local -a words_arr
+  words_arr=("${(@)words}")
+  local n=$#words_arr
+  local pos=$CURRENT
+
+  # Flag-value completions — look at previous word
+  local prev="${words_arr[pos-1]:-}"
+  case "$prev" in
+    --env)
+      local -a envs
+      envs=("${(@f)$(_strut_envs)}")
+      compadd -a envs
+      return 0
+      ;;
+    --services)
+      compadd -a profiles
+      return 0
+      ;;
+    --registry)
+      compadd ghcr dockerhub ecr none
+      return 0
+      ;;
+    completions)
+      compadd bash zsh fish
+      return 0
+      ;;
+  esac
+
+  if [ "$pos" -eq 2 ]; then
+    local -a stacks
+    stacks=("${(@f)$(_strut_stacks)}")
+    compadd -a stacks
+    compadd -a top_cmds
+    return 0
+  fi
+
+  local root_word="${words_arr[2]:-}"
+
+  case "$root_word" in
+    list)
+      [ "$pos" -eq 3 ] && { compadd plugins --json; return 0 }
+      ;;
+    group)
+      [ "$pos" -eq 3 ] && { local -a groups; groups=("${(@f)$(_strut_groups)}"); compadd list show add remove; compadd -a groups; return 0 }
+      ;;
+    monitoring)
+      [ "$pos" -eq 3 ] && { compadd deploy add-target remove-target alert-channel status; return 0 }
+      ;;
+    notify)
+      [ "$pos" -eq 3 ] && { compadd test; return 0 }
+      [ "$pos" -eq 4 ] && { compadd slack discord webhook; return 0 }
+      ;;
+    skills)
+      [ "$pos" -eq 3 ] && { compadd list install --format; return 0 }
+      ;;
+    help)
+      [ "$pos" -eq 3 ] && { compadd -a top_cmds; compadd -a per_stack_cmds; return 0 }
+      ;;
+    init)
+      compadd --registry --org --completions
+      return 0
+      ;;
+    doctor)
+      compadd --check-vps --json --fix
+      return 0
+      ;;
+  esac
+
+  # Stack-level: strut <stack> <cmd>
+  if [ "$pos" -eq 3 ]; then
+    compadd -a per_stack_cmds
+    return 0
+  fi
+
+  local cmd="${words_arr[3]:-}"
+  case "$cmd" in
+    backup)
+      [ "$pos" -eq 4 ] && { compadd postgres neo4j mysql sqlite gdrive-transcripts all verify list health schedule retention; return 0 }
+      ;;
+    drift)
+      [ "$pos" -eq 4 ] && { compadd detect report fix monitor history auto-fix; return 0 }
+      ;;
+    db:pull|db:push)
+      [ "$pos" -eq 4 ] && { compadd postgres neo4j mysql sqlite all --download-only --upload-only --file; return 0 }
+      ;;
+    db:schema)
+      [ "$pos" -eq 4 ] && { compadd apply verify all; return 0 }
+      ;;
+    volumes)
+      [ "$pos" -eq 4 ] && { compadd status init config; return 0 }
+      ;;
+    lock)
+      [ "$pos" -eq 4 ] && { compadd status release --force --remote --local; return 0 }
+      ;;
+    local|prod|staging|dev)
+      [ "$pos" -eq 4 ] && { compadd start stop reset sync-env sync-db logs test debug; return 0 }
+      ;;
+    debug)
+      [ "$pos" -eq 4 ] && { compadd exec shell port-forward copy snapshot inspect-env stats; return 0 }
+      ;;
+    keys)
+      [ "$pos" -eq 4 ] && { compadd rotate status check env ssh github; return 0 }
+      ;;
+    migrate)
+      [ "$pos" -eq 4 ] && { compadd neo4j postgres --status --up --down; return 0 }
+      ;;
+    deploy)
+      compadd --env --services --pull-only --skip-validation --force-unlock --no-lock --dry-run
+      return 0
+      ;;
+    health)
+      compadd --env --services --json
+      return 0
+      ;;
+    diff)
+      compadd --env --json
+      return 0
+      ;;
+  esac
+
+  compadd --env --services --json --dry-run --help
+}
+
+compdef _strut strut

--- a/lib/cmd_completions.sh
+++ b/lib/cmd_completions.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# ==================================================
+# lib/cmd_completions.sh — emit/install shell completion scripts
+# ==================================================
+#
+# `strut completions <shell>` prints the completion script for the target
+# shell (bash|zsh|fish) to stdout, ready to be eval'd or saved to the
+# shell's completions directory.
+#
+# `strut init --completions` auto-detects the user's shell (from $SHELL)
+# and installs the right script to a conventional location.
+
+set -euo pipefail
+
+cmd_completions() {
+  local shell="${1:-}"
+  local script_path
+
+  case "$shell" in
+    bash) script_path="$STRUT_HOME/completions/bash.sh" ;;
+    zsh)  script_path="$STRUT_HOME/completions/zsh.sh" ;;
+    fish) script_path="$STRUT_HOME/completions/fish.fish" ;;
+    ""|--help|-h)
+      echo "Usage: strut completions <bash|zsh|fish>"
+      echo ""
+      echo "Prints the completion script for your shell. Suggested install:"
+      echo ""
+      echo "  # bash"
+      echo "  echo 'eval \"\$(strut completions bash)\"' >> ~/.bashrc"
+      echo ""
+      echo "  # zsh"
+      echo "  echo 'eval \"\$(strut completions zsh)\"' >> ~/.zshrc"
+      echo ""
+      echo "  # fish"
+      echo "  strut completions fish > ~/.config/fish/completions/strut.fish"
+      echo ""
+      echo "Or run \`strut init --completions\` to auto-install for your current shell."
+      [ -z "$shell" ] && exit 1 || exit 0
+      ;;
+    *)
+      fail "Unknown shell: '$shell' (valid: bash, zsh, fish)"
+      ;;
+  esac
+
+  [ -f "$script_path" ] || fail "Completion script not found: $script_path"
+  cat "$script_path"
+}
+
+# install_completions — called by `strut init --completions`. Detects shell
+# from $SHELL and installs into the conventional location for that shell.
+# Idempotent: appends an eval line (bash/zsh) or writes the full script
+# (fish) only if the target is missing the strut hook.
+install_completions() {
+  local detected="${SHELL##*/}"
+  case "$detected" in
+    bash)
+      local rc="${HOME}/.bashrc"
+      # shellcheck disable=SC2016 # literal eval expression, stored verbatim in rc file
+      local line='eval "$(strut completions bash)"'
+      if grep -Fq "$line" "$rc" 2>/dev/null; then
+        log "bash completions already installed in $rc"
+      else
+        printf '\n# strut completions\n%s\n' "$line" >> "$rc"
+        ok "Installed bash completions (open a new shell or run: source $rc)"
+      fi
+      ;;
+    zsh)
+      local rc="${HOME}/.zshrc"
+      # shellcheck disable=SC2016 # literal eval expression, stored verbatim in rc file
+      local line='eval "$(strut completions zsh)"'
+      if grep -Fq "$line" "$rc" 2>/dev/null; then
+        log "zsh completions already installed in $rc"
+      else
+        printf '\n# strut completions\n%s\n' "$line" >> "$rc"
+        ok "Installed zsh completions (open a new shell or run: source $rc)"
+      fi
+      ;;
+    fish)
+      local dir="${HOME}/.config/fish/completions"
+      mkdir -p "$dir"
+      cat "$STRUT_HOME/completions/fish.fish" > "$dir/strut.fish"
+      ok "Installed fish completions to $dir/strut.fish"
+      ;;
+    *)
+      warn "Unrecognized shell '$detected' — run 'strut completions <bash|zsh|fish>' manually"
+      return 1
+      ;;
+  esac
+}

--- a/lib/cmd_init.sh
+++ b/lib/cmd_init.sh
@@ -13,6 +13,7 @@ cmd_init() {
   # ── Parse flags ───────────────────────────────────
   local registry_flag=""
   local org_flag=""
+  local install_completions="false"
 
   while [[ $# -gt 0 ]]; do
     case $1 in
@@ -20,7 +21,8 @@ cmd_init() {
       --registry)   registry_flag="$2"; shift 2 ;;
       --org=*)      org_flag="${1#*=}"; shift ;;
       --org)        org_flag="$2"; shift 2 ;;
-      *)            fail "Unknown flag: $1  (usage: strut init [--registry <type>] [--org <name>])" ;;
+      --completions) install_completions="true"; shift ;;
+      *)            fail "Unknown flag: $1  (usage: strut init [--registry <type>] [--org <name>] [--completions])" ;;
     esac
   done
 
@@ -88,6 +90,13 @@ backups/
 data/
 GITIGNORE_EOF
   log "Generated .gitignore"
+
+  # ── Optional: install shell completions ──────────
+  if [ "$install_completions" = "true" ]; then
+    # shellcheck disable=SC1091
+    source "${STRUT_HOME:-$CLI_ROOT}/lib/cmd_completions.sh"
+    install_completions
+  fi
 
   # ── Next steps ────────────────────────────────────
   echo ""

--- a/strut
+++ b/strut
@@ -145,7 +145,7 @@ usage() {
   echo ""
   echo "Usage: strut <stack> <command> [options]"
   echo "       strut list"
-  echo "       strut init [--registry <type>] [--org <name>]"
+  echo "       strut init [--registry <type>] [--org <name>] [--completions]"
   echo "       strut upgrade"
   echo "       strut doctor [--check-vps] [--json] [--fix]"
   echo "       strut --version"
@@ -203,6 +203,7 @@ usage() {
   echo "  init     [--registry <type>] [--org <name>]                    Initialize new project"
   echo "  upgrade                                                        Upgrade strut to latest version"
   echo "  skills   [list|install] [--format kiro|claude|cursor|generic|all]  AI agent context"
+  echo "  completions <bash|zsh|fish>                                    Print shell completion script"
   echo "  --version                                                      Show strut version"
   echo ""
   echo "Global flags:"
@@ -388,6 +389,12 @@ case "${1:-}" in
     exit 0
     ;;
   scaffold)       cmd_scaffold "${2:-}"; exit 0 ;;
+  completions)
+    shift
+    source "$LIB/cmd_completions.sh"
+    cmd_completions "$@"
+    exit 0
+    ;;
   doctor)
     shift
     source "$LIB/cmd_doctor.sh"

--- a/tests/test_completions.bats
+++ b/tests/test_completions.bats
@@ -1,0 +1,173 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_completions.bats — Shell completion script generation
+# ==================================================
+# Run:  bats tests/test_completions.bats
+# Covers: strut completions bash|zsh|fish output, syntax validity,
+# content sanity (key tokens present), and error handling.
+
+setup() {
+  CLI_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  export CLI_ROOT
+  CLI="$CLI_ROOT/strut"
+}
+
+# ── Output sanity ────────────────────────────────────────────────────────────
+
+@test "strut completions bash: emits completion script" {
+  run bash "$CLI" completions bash
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"_strut_completions"* ]]
+  [[ "$output" == *"complete -F _strut_completions strut"* ]]
+}
+
+@test "strut completions zsh: emits completion script" {
+  run bash "$CLI" completions zsh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"#compdef strut"* ]]
+  [[ "$output" == *"compdef _strut strut"* ]]
+}
+
+@test "strut completions fish: emits completion script" {
+  run bash "$CLI" completions fish
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"complete -c strut"* ]]
+  [[ "$output" == *"__strut_stacks"* ]]
+}
+
+# ── Syntax validity ──────────────────────────────────────────────────────────
+
+@test "bash completion script has valid bash syntax" {
+  # Redirect to a temp file and bash -n parse-check it
+  local tmp
+  tmp=$(mktemp)
+  bash "$CLI" completions bash > "$tmp"
+  run bash -n "$tmp"
+  rm -f "$tmp"
+  [ "$status" -eq 0 ]
+}
+
+@test "zsh completion script has valid zsh syntax" {
+  if ! command -v zsh >/dev/null 2>&1; then
+    skip "zsh not installed"
+  fi
+  local tmp
+  tmp=$(mktemp)
+  bash "$CLI" completions zsh > "$tmp"
+  run zsh -n "$tmp"
+  rm -f "$tmp"
+  [ "$status" -eq 0 ]
+}
+
+@test "fish completion script has valid fish syntax" {
+  if ! command -v fish >/dev/null 2>&1; then
+    skip "fish not installed"
+  fi
+  local tmp
+  tmp=$(mktemp)
+  bash "$CLI" completions fish > "$tmp"
+  run fish -n "$tmp"
+  rm -f "$tmp"
+  [ "$status" -eq 0 ]
+}
+
+# ── Content coverage ─────────────────────────────────────────────────────────
+
+@test "bash completion: includes core commands" {
+  run bash "$CLI" completions bash
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"deploy"* ]]
+  [[ "$output" == *"backup"* ]]
+  [[ "$output" == *"init"* ]]
+  [[ "$output" == *"list"* ]]
+  [[ "$output" == *"doctor"* ]]
+}
+
+@test "bash completion: includes service profiles for --services" {
+  run bash "$CLI" completions bash
+  [[ "$output" == *"messaging"* ]]
+  [[ "$output" == *"full"* ]]
+  [[ "$output" == *"gdrive"* ]]
+}
+
+@test "bash completion: handles --env flag with dynamic env names" {
+  run bash "$CLI" completions bash
+  [[ "$output" == *"_strut_envs"* ]]
+  [[ "$output" == *".env"* ]]
+}
+
+@test "bash completion: handles --services flag" {
+  run bash "$CLI" completions bash
+  [[ "$output" == *"--services"* ]]
+}
+
+@test "zsh completion: includes core commands" {
+  run bash "$CLI" completions zsh
+  [[ "$output" == *"deploy"* ]]
+  [[ "$output" == *"backup"* ]]
+  [[ "$output" == *"list"* ]]
+}
+
+@test "fish completion: includes core commands" {
+  run bash "$CLI" completions fish
+  [[ "$output" == *"deploy"* ]]
+  [[ "$output" == *"backup"* ]]
+  [[ "$output" == *"list"* ]]
+}
+
+@test "bash completion: dynamic stack discovery function present" {
+  run bash "$CLI" completions bash
+  [[ "$output" == *"_strut_stacks"* ]]
+  [[ "$output" == *"stacks"* ]]
+}
+
+# ── Error handling ───────────────────────────────────────────────────────────
+
+@test "strut completions with no shell: shows usage and exits 1" {
+  run bash "$CLI" completions
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Usage: strut completions"* ]]
+}
+
+@test "strut completions --help: shows usage and exits 0" {
+  run bash "$CLI" completions --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: strut completions"* ]]
+}
+
+@test "strut completions with unknown shell: fails" {
+  run bash "$CLI" completions powershell
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unknown shell"* ]]
+}
+
+# ── Functional: source bash completion and verify complete() registered ──────
+
+@test "bash completion: can be sourced and registers complete function" {
+  local tmp
+  tmp=$(mktemp)
+  bash "$CLI" completions bash > "$tmp"
+  # Source in a subshell with a compspec-capable bash; look for the complete binding
+  run bash -c "source '$tmp' && complete -p strut"
+  rm -f "$tmp"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"_strut_completions"* ]]
+  [[ "$output" == *"strut"* ]]
+}
+
+# ── init --completions ───────────────────────────────────────────────────────
+
+@test "strut init --completions accepts the flag" {
+  local test_tmp
+  test_tmp=$(mktemp -d)
+  cd "$test_tmp"
+  # Force SHELL=bash so install targets ~/.bashrc.
+  # Point HOME at a temp dir so we don't touch the user's real rc.
+  local fake_home
+  fake_home=$(mktemp -d)
+  run env HOME="$fake_home" SHELL="/bin/bash" bash "$CLI" init --completions
+  local st="$status"
+  cd "$CLI_ROOT"
+  rm -rf "$test_tmp" "$fake_home"
+  [ "$st" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- `strut completions <bash|zsh|fish>` prints a ready-to-source completion script for the target shell.
- `strut init --completions` auto-installs into `~/.bashrc`, `~/.zshrc`, or `~/.config/fish/completions/strut.fish` based on `$SHELL`.
- Completions cover stack names (discovered from `stacks/*/` via walk-up for `strut.conf`), all top-level and per-stack commands, subcommands (`backup`, `drift`, `db:pull`, `volumes`, `keys`, `lock`, `debug`, `local`, `migrate`, …), environment names from `.*.env`, service profiles, and common flags.
- Stack / env / group discovery happens inside the completion script at TAB time, so new stacks or env files show up without re-sourcing.

Closes #20.

## Install
```bash
eval "$(strut completions bash)"                               # .bashrc
eval "$(strut completions zsh)"                                # .zshrc
strut completions fish > ~/.config/fish/completions/strut.fish
# or
strut init --completions                                       # auto-detect
```

## Docs
`wiki/Shell-Completions.md` added (committed to wiki checkout separately). Sidebar and `CLI-Reference.md` updated to link it.

## Test plan
- [x] `bats tests/test_completions.bats` — 18 tests (output emitted, bash/zsh syntax valid, required tokens present, error handling, bash script registers a working complete()).
- [x] `bats tests/` — full suite 942 passing, 0 failures.
- [x] `shellcheck -x strut lib/cmd_completions.sh completions/bash.sh lib/cmd_init.sh` clean.