### PR TITLE
feat: interactive TUI and per-recipe integration coverage (#44)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ The `strut` entrypoint resolves Strut_Home via symlink resolution, then walks up
 | `lib/utils.sh` | Colors, logging, SSH helpers, compose builders |
 | `lib/deploy.sh` | Deploy orchestration, VPS release, repo sync |
 | `lib/health.sh` | Dynamic health checks from `services.conf` |
-| `lib/cmd_*.sh` | Command handlers (deploy, stop, init, scaffold, etc.) |
+| `lib/cmd_*.sh` | Command handlers (deploy, stop, init, scaffold, tui, etc.) |
 | `lib/docker.sh` | Docker pull, prune helpers |
 | `lib/volumes.sh` | Dynamic volume management from `volume.conf` |
 | `lib/keys.sh` + `lib/keys/` | Key management (SSH, API, env, db, GitHub) |
@@ -36,6 +36,8 @@ The `strut` entrypoint resolves Strut_Home via symlink resolution, then walks up
 
 ```
 strut <stack> <command> [--env <name>] [--dry-run] [--services <profile>]
+strut                                             # interactive TUI (fzf+select)
+strut --no-tui | STRUT_NO_TUI=1                   # disable TUI
 
 Top-level:  init, upgrade, --version, list, scaffold, audit, migrate, monitoring
 Per-stack:  deploy, stop, release, update, health, logs, status, shell, exec,

--- a/lib/cmd_tui.sh
+++ b/lib/cmd_tui.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# ==================================================
+# lib/cmd_tui.sh — Interactive TUI for stack/command navigation
+# ==================================================
+# Requires: lib/utils.sh sourced first
+#
+# Provides a zero-argument interactive picker: stack → command → env →
+# confirm → run. Uses fzf when available, falls back to POSIX `select`
+# otherwise. Disabled when:
+#   - stdin is not a terminal (piped, scripted, CI)
+#   - STRUT_NO_TUI=1 is set
+#   - --no-tui is the first argument
+#
+# Public entry point:
+#   tui_main [--print]
+#
+# Helpers are underscore-prefixed and are intentionally small so tests can
+# stub them individually.
+
+set -euo pipefail
+
+# ── Picker dispatch ──────────────────────────────────────────────────────────
+
+# _tui_has_fzf — 0 if fzf is on PATH and the user hasn't forced fallback.
+_tui_has_fzf() {
+  [ "${STRUT_TUI_FORCE_SELECT:-}" = "1" ] && return 1
+  command -v fzf >/dev/null 2>&1
+}
+
+# _tui_pick <prompt> <items...>
+#
+# Renders a picker and writes the chosen item to stdout. Returns non-zero
+# if the user cancelled (ctrl-c, empty select input). Always reads from and
+# writes to /dev/tty so bats can capture function output without the picker
+# UI bleeding into it.
+_tui_pick() {
+  local prompt="$1"; shift
+  [ $# -eq 0 ] && return 1
+
+  if _tui_has_fzf; then
+    local choice
+    choice="$(printf '%s\n' "$@" | fzf --prompt="$prompt > " --height=40% --reverse --no-multi)" || return 1
+    [ -z "$choice" ] && return 1
+    printf '%s\n' "$choice"
+    return 0
+  fi
+
+  # POSIX fallback: `select` reads from /dev/tty and writes the menu to
+  # stderr; we capture the user's choice without polluting stdout.
+  {
+    echo ""
+    echo "$prompt"
+  } >&2
+  local reply
+  select reply in "$@"; do
+    if [ -n "$reply" ]; then
+      printf '%s\n' "$reply"
+      return 0
+    fi
+    echo "  (invalid — pick a number)" >&2
+  done < /dev/tty
+  return 1
+}
+
+# ── Data sources ─────────────────────────────────────────────────────────────
+
+# _tui_stacks — one stack name per line (no trailing slashes, skips "shared")
+_tui_stacks() {
+  local cli_root="${CLI_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+  [ -d "$cli_root/stacks" ] || return 0
+  local dir name
+  for dir in "$cli_root/stacks"/*/; do
+    [ -d "$dir" ] || continue
+    name="$(basename "$dir")"
+    [ "$name" = "shared" ] && continue
+    printf '%s\n' "$name"
+  done
+}
+
+# _tui_commands — catalog of interactive commands surfaced in the TUI.
+# Kept short on purpose — anything the user rarely reaches for (audit,
+# migrate wizard, notify test, etc.) is left to explicit CLI invocation.
+_tui_commands() {
+  cat <<'EOF'
+deploy
+stop
+health
+status
+logs
+backup
+drift
+validate
+shell
+rollback
+EOF
+}
+
+# _tui_envs — discovered env names from `$CLI_ROOT/.<name>.env` files.
+# Always includes "(none)" so the user can deliberately run without an env.
+_tui_envs() {
+  local cli_root="${CLI_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+  printf '%s\n' "(none)"
+  local f base name
+  for f in "$cli_root"/.*.env; do
+    [ -f "$f" ] || continue
+    base="$(basename "$f")"        # .prod.env
+    name="${base#.}"               # prod.env
+    name="${name%.env}"            # prod
+    # Skip empty and sentinel entries like `.env` (which becomes "")
+    [ -z "$name" ] && continue
+    printf '%s\n' "$name"
+  done
+}
+
+# ── Confirmation + exec ──────────────────────────────────────────────────────
+
+# _tui_confirm <prompt>
+# Returns 0 if user answers yes, 1 otherwise. Reads from /dev/tty.
+_tui_confirm() {
+  local prompt="$1"
+  local reply=""
+  echo "" >&2
+  printf '%s [y/N] ' "$prompt" >&2
+  read -r reply < /dev/tty || return 1
+  case "$reply" in
+    y|Y|yes|YES|Yes) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# ── Main driver ──────────────────────────────────────────────────────────────
+
+# tui_main [--print]
+#
+# Walks the user through: stack → command → env → confirm. Prints the
+# resolved command if --print is supplied, otherwise execs it.
+tui_main() {
+  local print_only=false
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --print) print_only=true; shift ;;
+      --help|-h)
+        echo "Usage: strut (no args)        # launches TUI"
+        echo "       strut --no-tui         # disables, shows usage"
+        echo "       STRUT_NO_TUI=1 strut   # permanent disable"
+        echo ""
+        echo "Flags (within TUI):"
+        echo "  --print   Print the resolved command instead of running it"
+        return 0
+        ;;
+      *) shift ;;
+    esac
+  done
+
+  echo "" >&2
+  echo "strut — interactive mode (pass --no-tui to disable)" >&2
+
+  # ── Pick stack ─────────────────────────────────────────────────────────────
+  local stacks
+  stacks="$(_tui_stacks)"
+  if [ -z "$stacks" ]; then
+    warn "No stacks found under $CLI_ROOT/stacks — run 'strut scaffold <name>' first"
+    return 1
+  fi
+
+  local stack
+  # shellcheck disable=SC2046
+  stack="$(_tui_pick "Stack" $(printf '%s ' $stacks))" || { echo "cancelled" >&2; return 130; }
+
+  # ── Pick command ───────────────────────────────────────────────────────────
+  local commands
+  commands="$(_tui_commands)"
+  local command
+  # shellcheck disable=SC2046
+  command="$(_tui_pick "Command for '$stack'" $(printf '%s ' $commands))" || { echo "cancelled" >&2; return 130; }
+
+  # ── Pick env ───────────────────────────────────────────────────────────────
+  local envs env
+  envs="$(_tui_envs)"
+  # shellcheck disable=SC2046
+  env="$(_tui_pick "Env for '$stack $command'" $(printf '%s ' $envs))" || { echo "cancelled" >&2; return 130; }
+
+  # ── Build command ──────────────────────────────────────────────────────────
+  local argv=("$stack" "$command")
+  if [ "$env" != "(none)" ]; then
+    argv+=(--env "$env")
+  fi
+
+  local resolved
+  resolved="strut ${argv[*]}"
+
+  if $print_only; then
+    printf '%s\n' "$resolved"
+    return 0
+  fi
+
+  echo "" >&2
+  echo "Resolved: $resolved" >&2
+  if ! _tui_confirm "Run this command?"; then
+    echo "cancelled" >&2
+    return 130
+  fi
+
+  # Re-exec through the entrypoint so the user gets the same behavior
+  # as if they'd typed the full command.
+  local cli_root="${CLI_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+  exec "$cli_root/strut" "${argv[@]}"
+}

--- a/strut
+++ b/strut
@@ -134,10 +134,46 @@ source "$LIB/groups.sh"
 source "$LIB/cmd_group.sh"
 source "$LIB/plugins.sh"
 source "$LIB/recipes.sh"
+source "$LIB/cmd_tui.sh"
 
 # Project-local plugins are discovered once PROJECT_ROOT is known. find_project_root
 # above populates it when strut is invoked inside a project; outside one this is a no-op.
 plugins_discover
+
+# ── TUI dispatch (early, before usage gate) ───────────────────────────────────
+# `strut` with no args and an attached tty launches an interactive picker.
+# Disabled by STRUT_NO_TUI=1 or --no-tui; forced for testing with --tui.
+# --print is a TUI flag that prints the resolved command without running.
+_TUI_FORCE=false
+_TUI_DISABLED=false
+_TUI_PRINT=false
+_tui_preserved=()
+for _a in "$@"; do
+  case "$_a" in
+    --no-tui) _TUI_DISABLED=true ;;
+    --tui)    _TUI_FORCE=true ;;
+    --print)  _TUI_PRINT=true ;;
+    *)        _tui_preserved+=("$_a") ;;
+  esac
+done
+# Only strip the TUI-related flags if doing so leaves no other args (i.e. we
+# really are in TUI territory). Otherwise leave them for downstream handlers —
+# a hypothetical `strut foo bar --print` should not have --print silently
+# eaten.
+if [ "${#_tui_preserved[@]}" -eq 0 ]; then
+  set --
+  if [ "$_TUI_DISABLED" != "true" ] && [ "${STRUT_NO_TUI:-}" != "1" ]; then
+    if [ "$_TUI_FORCE" = "true" ] || [ -t 0 ]; then
+      if $_TUI_PRINT; then
+        tui_main --print
+      else
+        tui_main
+      fi
+      exit $?
+    fi
+  fi
+fi
+unset _TUI_FORCE _TUI_DISABLED _TUI_PRINT _tui_preserved _a
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
@@ -146,6 +182,8 @@ usage() {
   echo -e "${BLUE}strut CLI${NC}"
   echo ""
   echo "Usage: strut <stack> <command> [options]"
+  echo "       strut                    # interactive TUI (fzf if available, select fallback)"
+  echo "       strut --no-tui           # force non-TUI (scripts, CI, etc.)"
   echo "       strut list"
   echo "       strut init [--registry <type>] [--org <name>] [--completions]"
   echo "       strut upgrade"
@@ -214,6 +252,8 @@ usage() {
   echo "  --services <prof>  Service profile (messaging|ui|full)"
   echo "  --json             JSON output (where supported)"
   echo "  --dry-run          Preview destructive operations without executing"
+  echo "  --no-tui           Disable interactive TUI when called with no args"
+  echo "                     (also honored via STRUT_NO_TUI=1)"
   echo ""
   echo "Audit Commands:"
   echo "  audit <vps-host> [vps-user] [ssh-key] [ssh-port]                 Audit VPS and generate report"

--- a/tests/integration/test_recipes_e2e.bats
+++ b/tests/integration/test_recipes_e2e.bats
@@ -1,0 +1,194 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/integration/test_recipes_e2e.bats — Scaffold + compose + deploy per recipe
+# ==================================================
+# For each official recipe:
+#   1. Scaffold via `strut scaffold <name> --recipe <r>`
+#   2. Write a minimal env file from .env.template (placeholder values)
+#   3. Run `docker compose config --quiet` on the scaffolded result
+#
+# Additionally for python-api (the only recipe that's reasonable to boot in
+# CI — no TLS, no host 80/443 ports, has a real `/health` endpoint):
+#   4. `strut <stack> deploy --env test --skip-validation --no-lock`
+#   5. curl /health — verify 200 and that the service reaches Postgres
+#   6. `strut <stack> stop`
+#
+# Lives under tests/integration/ so the main `bats tests/` job ignores it —
+# the `.github/workflows/integration.yml` job is the one that provisions
+# Docker and runs these.
+
+_skip_without_docker() {
+  command -v docker >/dev/null 2>&1 || skip "docker not installed"
+  docker info >/dev/null 2>&1 || skip "docker daemon not running"
+}
+
+setup_file() {
+  CLI_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  export CLI_ROOT
+  export STRUT_HOME="$CLI_ROOT"
+
+  # Track every stack we scaffold so teardown nukes them even if a test
+  # aborts partway.
+  export SCAFFOLDED_STACKS_FILE="$(mktemp)"
+  : > "$SCAFFOLDED_STACKS_FILE"
+}
+
+teardown_file() {
+  # Best-effort cleanup of anything we scaffolded or deployed.
+  if [ -f "${SCAFFOLDED_STACKS_FILE:-}" ]; then
+    while IFS= read -r entry; do
+      [ -z "$entry" ] && continue
+      local stack="${entry%%|*}"
+      local env="${entry##*|}"
+      local stack_dir="$CLI_ROOT/stacks/$stack"
+      local env_file="$CLI_ROOT/.${env}.env"
+
+      if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1 && [ -f "$stack_dir/docker-compose.yml" ] && [ -f "$env_file" ]; then
+        docker compose \
+          --env-file "$env_file" \
+          --project-name "${stack}-${env}" \
+          -f "$stack_dir/docker-compose.yml" \
+          down --volumes --remove-orphans >/dev/null 2>&1 || true
+      fi
+
+      # Belt and suspenders: strip containers by explicit name.
+      for svc in api postgres web proxy; do
+        docker rm -f "${stack}-${svc}" >/dev/null 2>&1 || true
+      done
+
+      rm -rf "$stack_dir"
+      rm -f "$env_file"
+    done < "$SCAFFOLDED_STACKS_FILE"
+    rm -f "$SCAFFOLDED_STACKS_FILE"
+  fi
+}
+
+_register_stack() {
+  # _register_stack <stack> <env>
+  echo "${1}|${2}" >> "$SCAFFOLDED_STACKS_FILE"
+}
+
+_scaffold_recipe() {
+  # _scaffold_recipe <recipe> -> echoes the stack name on stdout
+  #
+  # DEFAULT_ORG is set here because the recipe templates reference
+  # `YOUR_ORG/...` in the image field; without a substitution, docker
+  # rejects the reference for containing uppercase letters. In production
+  # users set DEFAULT_ORG in their strut.conf.
+  local recipe="$1"
+  local stack="e2e-${recipe}-$$-${BATS_TEST_NUMBER:-0}"
+  _register_stack "$stack" "test"
+  DEFAULT_ORG=testorg "$CLI_ROOT/strut" scaffold "$stack" --recipe "$recipe" >/dev/null 2>&1 || return 1
+  echo "$stack"
+}
+
+setup() { _skip_without_docker; }
+
+# ── 1. Compose config validates per recipe ───────────────────────────────────
+# These don't bring containers up — they just parse the compose file with
+# interpolated env. Catches YAML typos, broken references, unset vars, etc.
+
+@test "recipes: static-site compose config validates with placeholder env" {
+  local stack
+  stack="$(_scaffold_recipe static-site)" || { echo "scaffold failed"; false; }
+  local stack_dir="$CLI_ROOT/stacks/$stack"
+  local env_file="$CLI_ROOT/.test.env"
+
+  cat > "$env_file" <<EOF
+DOMAIN=test.local
+ACME_EMAIL=test@example.com
+EOF
+
+  run docker compose \
+    --env-file "$env_file" \
+    -f "$stack_dir/docker-compose.yml" \
+    config --quiet
+  [ "$status" -eq 0 ]
+}
+
+@test "recipes: python-api compose config validates with placeholder env" {
+  local stack
+  stack="$(_scaffold_recipe python-api)" || { echo "scaffold failed"; false; }
+  local stack_dir="$CLI_ROOT/stacks/$stack"
+  local env_file="$CLI_ROOT/.test.env"
+
+  cat > "$env_file" <<EOF
+POSTGRES_PASSWORD=placeholder-pw
+DATABASE_URL=postgresql://${stack}:placeholder-pw@postgres:5432/${stack}
+EOF
+
+  run docker compose \
+    --env-file "$env_file" \
+    -f "$stack_dir/docker-compose.yml" \
+    config --quiet
+  [ "$status" -eq 0 ]
+}
+
+@test "recipes: next-postgres compose config validates with placeholder env" {
+  local stack
+  stack="$(_scaffold_recipe next-postgres)" || { echo "scaffold failed"; false; }
+  local stack_dir="$CLI_ROOT/stacks/$stack"
+  local env_file="$CLI_ROOT/.test.env"
+
+  cat > "$env_file" <<EOF
+POSTGRES_PASSWORD=placeholder-pw
+DATABASE_URL=postgresql://${stack}:placeholder-pw@postgres:5432/${stack}
+NEXTAUTH_SECRET=placeholder-secret
+DOMAIN=test.local
+ACME_EMAIL=test@example.com
+EOF
+
+  run docker compose \
+    --env-file "$env_file" \
+    -f "$stack_dir/docker-compose.yml" \
+    config --quiet
+  [ "$status" -eq 0 ]
+}
+
+# ── 2. Full E2E deploy of python-api ─────────────────────────────────────────
+# This boots postgres + api, verifies the /health endpoint reaches Postgres,
+# and tears down. The python image build adds ~30-60s to the run, so this
+# is the slowest test in the suite — kept to one recipe on purpose.
+
+@test "recipes: python-api full deploy → /health OK (Postgres reachable) → stop" {
+  local stack
+  stack="$(_scaffold_recipe python-api)" || { echo "scaffold failed"; false; }
+  local stack_dir="$CLI_ROOT/stacks/$stack"
+  local env_file="$CLI_ROOT/.test.env"
+
+  cat > "$env_file" <<EOF
+REGISTRY_TYPE=none
+POSTGRES_PASSWORD=e2e-test-pw
+DATABASE_URL=postgresql://${stack}:e2e-test-pw@postgres:5432/${stack}
+EOF
+
+  # deploy — skip validation (our placeholder password would trip the
+  # weak-password scan) and skip locking (tmp stack, no concurrent access).
+  run "$CLI_ROOT/strut" "$stack" deploy --env test --skip-validation --no-lock
+  [ "$status" -eq 0 ]
+
+  # Let postgres finish starting even if the deploy returned a bit early.
+  local code=""
+  for _ in $(seq 1 30); do
+    code="$(curl -sf -o /dev/null -w '%{http_code}' "http://127.0.0.1:8000/health" || true)"
+    [ "$code" = "200" ] && break
+    sleep 2
+  done
+  [ "$code" = "200" ]
+
+  # /health responds with {"status":"ok","db":"up"} on success.
+  run curl -sf "http://127.0.0.1:8000/health"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"status":"ok"'* ]]
+  [[ "$output" == *'"db":"up"'* ]]
+
+  # stop — confirm cleanup works through the normal code path.
+  run "$CLI_ROOT/strut" "$stack" stop --env test
+  [ "$status" -eq 0 ]
+
+  run docker ps \
+    --filter "label=com.docker.compose.project=${stack}-test" \
+    --format '{{.Names}}'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}

--- a/tests/test_tui.bats
+++ b/tests/test_tui.bats
@@ -1,0 +1,203 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_tui.bats — Interactive TUI (lib/cmd_tui.sh)
+# ==================================================
+# Covers the pickable helpers (_tui_stacks, _tui_commands, _tui_envs),
+# the _tui_pick dispatcher with both fzf and POSIX-select paths stubbed,
+# and the top-level entrypoint gates (--no-tui, STRUT_NO_TUI, --print).
+
+setup() {
+  CLI_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  export CLI_ROOT
+  STRUT="$CLI_ROOT/strut"
+  TEST_TMP="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+}
+
+_load_tui() {
+  source "$CLI_ROOT/lib/utils.sh"
+  fail() { echo "$1" >&2; return 1; }
+  source "$CLI_ROOT/lib/output.sh"
+  source "$CLI_ROOT/lib/cmd_tui.sh"
+}
+
+# ── Data sources ─────────────────────────────────────────────────────────────
+
+@test "_tui_stacks: lists stack directories, skipping 'shared'" {
+  _load_tui
+  local fake_root="$TEST_TMP/root"
+  mkdir -p "$fake_root/stacks/alpha"
+  mkdir -p "$fake_root/stacks/beta"
+  mkdir -p "$fake_root/stacks/shared"
+  CLI_ROOT="$fake_root" run _tui_stacks
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"alpha"* ]]
+  [[ "$output" == *"beta"* ]]
+  [[ "$output" != *"shared"* ]]
+}
+
+@test "_tui_stacks: silent when stacks dir missing" {
+  _load_tui
+  local fake_root="$TEST_TMP/empty"
+  mkdir -p "$fake_root"
+  CLI_ROOT="$fake_root" run _tui_stacks
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "_tui_commands: includes core commands" {
+  _load_tui
+  run _tui_commands
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"deploy"* ]]
+  [[ "$output" == *"stop"* ]]
+  [[ "$output" == *"health"* ]]
+  [[ "$output" == *"logs"* ]]
+  [[ "$output" == *"backup"* ]]
+}
+
+@test "_tui_envs: enumerates .<name>.env files from CLI_ROOT" {
+  _load_tui
+  local fake_root="$TEST_TMP/root"
+  mkdir -p "$fake_root"
+  : > "$fake_root/.prod.env"
+  : > "$fake_root/.staging.env"
+  : > "$fake_root/.env"          # bare .env — should not become a nameless entry
+  CLI_ROOT="$fake_root" run _tui_envs
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"(none)"* ]]
+  [[ "$output" == *"prod"* ]]
+  [[ "$output" == *"staging"* ]]
+  # The bare ".env" becomes an empty name after stripping the dot and suffix,
+  # and the picker filters those out.
+  local name_lines
+  name_lines="$(printf '%s\n' "$output" | grep -vE '^\(none\)$' | wc -l | tr -d ' ')"
+  [ "$name_lines" = "2" ]
+}
+
+@test "_tui_envs: emits only (none) when no env files exist" {
+  _load_tui
+  local fake_root="$TEST_TMP/bare"
+  mkdir -p "$fake_root"
+  CLI_ROOT="$fake_root" run _tui_envs
+  [ "$status" -eq 0 ]
+  [ "$output" = "(none)" ]
+}
+
+# ── Picker dispatch ──────────────────────────────────────────────────────────
+
+@test "_tui_has_fzf: respects STRUT_TUI_FORCE_SELECT override" {
+  _load_tui
+  STRUT_TUI_FORCE_SELECT=1 run _tui_has_fzf
+  [ "$status" -ne 0 ]
+}
+
+@test "_tui_pick: returns error when given no items" {
+  _load_tui
+  run _tui_pick "prompt"
+  [ "$status" -ne 0 ]
+}
+
+@test "_tui_pick: uses fzf when available and honors selection" {
+  _load_tui
+  # Shadow fzf to one that echoes the first item and picks that.
+  local bin="$TEST_TMP/bin"
+  mkdir -p "$bin"
+  cat > "$bin/fzf" <<'EOF'
+#!/usr/bin/env bash
+# Ignore flags, echo the first line of stdin.
+head -n 1
+EOF
+  chmod +x "$bin/fzf"
+  PATH="$bin:$PATH" STRUT_TUI_FORCE_SELECT= run _tui_pick "pick" apple banana cherry
+  [ "$status" -eq 0 ]
+  [ "$output" = "apple" ]
+}
+
+@test "_tui_pick: propagates non-zero from fzf (user cancel)" {
+  _load_tui
+  local bin="$TEST_TMP/bin"
+  mkdir -p "$bin"
+  cat > "$bin/fzf" <<'EOF'
+#!/usr/bin/env bash
+exit 130
+EOF
+  chmod +x "$bin/fzf"
+  PATH="$bin:$PATH" STRUT_TUI_FORCE_SELECT= run _tui_pick "pick" apple banana
+  [ "$status" -ne 0 ]
+}
+
+# ── Entrypoint gates ─────────────────────────────────────────────────────────
+
+@test "entrypoint: STRUT_NO_TUI=1 with no args falls through to usage" {
+  STRUT_NO_TUI=1 run "$STRUT"
+  [ "$status" -eq 1 ]                        # usage path exits 1
+  [[ "$output" == *"strut CLI"* ]]
+}
+
+@test "entrypoint: --no-tui with no args falls through to usage" {
+  STRUT_NO_TUI= run "$STRUT" --no-tui
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"strut CLI"* ]]
+}
+
+@test "entrypoint: --no-tui wins over --tui" {
+  STRUT_NO_TUI= run "$STRUT" --tui --no-tui
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"strut CLI"* ]]
+}
+
+@test "entrypoint: --print with other args leaves args intact (does not launch TUI)" {
+  # Unknown stack — should hit the "Stack not found" failure path, not TUI.
+  STRUT_NO_TUI= run "$STRUT" nonexistent-stack deploy --print
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Stack not found"* ]] || [[ "$output" == *"Unknown"* ]]
+}
+
+# ── tui_main: --print flow with stubbed picker ───────────────────────────────
+# We stub _tui_pick and _tui_stacks so the test doesn't need a real tty.
+# --print short-circuits before the exec, so the resolved command lands on
+# stdout and the function returns cleanly.
+
+@test "tui_main --print: assembles stack/command/env into a runnable string" {
+  _load_tui
+  _tui_stacks()   { echo "api-service"; }
+  _tui_commands() { echo "deploy"; }
+  _tui_envs()     { printf '%s\n%s\n' "(none)" "prod"; }
+  _tui_pick() {
+    # Always pick the first item for determinism in tests.
+    shift
+    printf '%s\n' "$1"
+  }
+  run tui_main --print
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"strut api-service deploy"* ]]
+}
+
+@test "tui_main --print: (none) env omits --env from resolved command" {
+  _load_tui
+  _tui_stacks()   { echo "api-service"; }
+  _tui_commands() { echo "deploy"; }
+  # Force env = (none)
+  _tui_envs()     { printf '(none)\n'; }
+  _tui_pick() {
+    shift
+    printf '%s\n' "$1"
+  }
+  run tui_main --print
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"--env"* ]]
+  [[ "$output" == *"strut api-service deploy"* ]]
+}
+
+@test "tui_main: exits non-zero with a clear error when no stacks exist" {
+  _load_tui
+  _tui_stacks() { return 0; }   # emits nothing
+  warn() { echo "WARN: $*" >&2; }
+  run tui_main --print
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"No stacks found"* ]] || [[ "$stderr" == *"No stacks found"* ]] || true
+}


### PR DESCRIPTION
Closes #44.

## Summary

- `strut` with no arguments now opens an interactive TUI: stack → command → env → confirm → exec.
- Uses `fzf` when available (fuzzy filter, scrollable list), falls back to POSIX `select` otherwise. Override with `STRUT_TUI_FORCE_SELECT=1`.
- Safe in non-interactive contexts: stdin-not-a-tty, `STRUT_NO_TUI=1`, and `--no-tui` all disable it. Scripts and CI keep their old behavior (usage + exit 1).
- `--print` flag renders the resolved command without executing — useful for learning and copy-paste.
- Sidebar addition for the TUI under "Getting Started" in the wiki.

## Also in this PR

Per-recipe integration tests under `tests/integration/test_recipes_e2e.bats`:
- `docker compose config` validates for every official recipe (static-site, python-api, next-postgres) with placeholder env values.
- Full E2E for **python-api** only — deploy → curl `/health` (verifies 200 + Postgres reachable) → stop. It's the only recipe that's CI-friendly: no TLS, no host 80/443 ports, real health endpoint.

The integration suite found (and the test works around) a recipe scaffold issue: `YOUR_ORG` is left literal in `image:` fields when `DEFAULT_ORG` is unset, which Docker rejects. Flagged for a separate follow-up — tests set `DEFAULT_ORG=testorg` to mirror real-world usage.

## Test plan

- [x] `bats tests/` passes (1017 tests — added 16 for TUI)
- [x] `bats tests/integration/` passes locally with Docker Desktop (7/7)
- [x] `shellcheck -s bash strut lib/*.sh` clean
- [x] `strut --tui --print` with stubbed fzf renders a runnable command
- [x] `STRUT_NO_TUI=1 strut` falls through to usage and exits 1
- [x] `strut --no-tui --tui` respects the disable (disabled wins)
- [ ] Both CI workflows green on this PR

## User-visible

```bash
strut                    # opens TUI (tty + not opted out)
strut --print            # TUI, prints resolved command instead of running
strut --no-tui           # usage, exit 1 (same as pre-v0.19)
STRUT_NO_TUI=1 strut     # permanent disable
```