### PR TITLE
fix: warn when scaffold leaves YOUR_ORG placeholder in image: fields

### DIFF
--- a/lib/cmd_scaffold.sh
+++ b/lib/cmd_scaffold.sh
@@ -237,4 +237,22 @@ _scaffold_substitute() {
       xargs -0 sed -i.bak "s/YOUR_ORG/${DEFAULT_ORG}/g" 2>/dev/null
   fi
   find "$target" -name "*.bak" -delete 2>/dev/null || true
+
+  # If DEFAULT_ORG was unset and the scaffold still contains YOUR_ORG in any
+  # image: field, Docker will reject the stack on deploy ("repository name must
+  # be lowercase"). Warn loudly so the user fixes it before running deploy.
+  if [ -z "${DEFAULT_ORG:-}" ]; then
+    local offenders
+    offenders=$(grep -rl -E '^\s*image:.*YOUR_ORG' "$target" 2>/dev/null || true)
+    if [ -n "$offenders" ]; then
+      warn "Scaffolded files contain literal 'YOUR_ORG' in image: fields."
+      warn "Docker will reject these on deploy (repository name must be lowercase)."
+      warn "Fix by setting DEFAULT_ORG=<your-org> in strut.conf and re-scaffolding,"
+      warn "or edit the image: fields in:"
+      while IFS= read -r f; do
+        [ -z "$f" ] && continue
+        warn "  - ${f#"$target/"}"
+      done <<< "$offenders"
+    fi
+  fi
 }

--- a/tests/test_scaffold.bats
+++ b/tests/test_scaffold.bats
@@ -52,6 +52,42 @@ teardown() {
   [ "$status" -eq 0 ]  # YOUR_ORG still present
 }
 
+# ── Regression: warn when YOUR_ORG survives scaffold ─────────────────────────
+# Docker rejects uppercase repository names on deploy. When DEFAULT_ORG is
+# unset and the selected recipe has `image: YOUR_ORG/...:latest`, scaffold
+# must emit a warning so the user fixes it before `strut deploy`.
+
+@test "scaffold: recipe with YOUR_ORG in image: emits warning when DEFAULT_ORG unset" {
+  source "$CLI_ROOT/lib/recipes.sh"
+  unset DEFAULT_ORG
+  export DEFAULT_ORG=""
+  run cmd_scaffold "py-stack" --recipe python-api
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"YOUR_ORG"* ]]
+  [[ "$output" == *"repository name must be lowercase"* ]]
+  [[ "$output" == *"docker-compose.yml"* ]]
+}
+
+@test "scaffold: recipe with DEFAULT_ORG set produces no uppercase tokens in image: fields" {
+  source "$CLI_ROOT/lib/recipes.sh"
+  export DEFAULT_ORG="acme-corp"
+  run cmd_scaffold "clean-stack" --recipe python-api
+  [ "$status" -eq 0 ]
+
+  local compose="$TEST_TMP/stacks/clean-stack/docker-compose.yml"
+  [ -f "$compose" ]
+
+  # Every image: line must be entirely lowercase (digits, lowercase letters,
+  # and these separators only: /  :  -  _  .). Any uppercase in an image: line
+  # would be rejected by Docker at deploy time.
+  run grep -E '^\s*image:.*[A-Z]' "$compose"
+  [ "$status" -ne 0 ]
+
+  # No warning should fire in the happy path
+  run cmd_scaffold "clean-stack-2" --recipe python-api
+  [[ "$output" != *"repository name must be lowercase"* ]]
+}
+
 @test "Property 10: random org names substitute correctly — 20 iterations" {
   for i in $(seq 1 20); do
     local org_name="org-${RANDOM}-${i}"


### PR DESCRIPTION
## Summary

- The `python-api` and `next-postgres` recipe compose files ship `image: YOUR_ORG/<stack>-<svc>:latest`. `lib/cmd_scaffold.sh :: _scaffold_substitute` only replaces `YOUR_ORG` when `DEFAULT_ORG` is set in `strut.conf`. Users who scaffold without setting it get a scaffold that fails at deploy time with Docker's `repository name must be lowercase`.
- `_scaffold_substitute` now post-scans the scaffold for `^\s*image:.*YOUR_ORG` when `DEFAULT_ORG` is empty and emits a clear multi-line warning listing the offending files, so the problem surfaces at scaffold time instead of `strut deploy` time.
- Two regression tests added under `tests/test_scaffold.bats` (per the brief — integration test at `tests/integration/test_recipes_e2e.bats` is intentionally not touched).

## Why a warning (vs. a `local` fallback or stripping `image:`)

- Preserves the existing documented behavior (`Property 10: DEFAULT_ORG unset leaves YOUR_ORG placeholder`) — users are expected to set `DEFAULT_ORG` in production. The warning reinforces that expectation rather than silently masking it with a `local` placeholder they might later push to a VPS.
- Keeps the `image:` field intact as a template for users to customize.

## Test plan

- [x] `bats tests/test_scaffold.bats` — 14/14 passing, including the two new regression tests.
- [x] `bats tests/` — full suite 1003/1003 passing.
- [x] Manual sanity: `DEFAULT_ORG=acme-corp strut scaffold foo --recipe python-api` produces lowercase `image: acme-corp/foo-api:latest` with no warning.
- [x] Manual sanity: `strut scaffold foo --recipe python-api` (no `DEFAULT_ORG`) emits the warning block naming `docker-compose.yml`.