### PR TITLE
fix: add IdentitiesOnly=yes when SSH key is specified

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -351,7 +351,7 @@ build_ssh_opts() {
   [[ "$batch" == true ]] && opts="$opts -o BatchMode=yes"
   [[ "$tty" == true ]] && opts="-t $opts"
   [[ "$keepalive" == true ]] && opts="$opts -o ServerAliveInterval=5 -o ServerAliveCountMax=2"
-  [[ -n "$ssh_key" ]] && opts="$opts -i $ssh_key"
+  [[ -n "$ssh_key" ]] && opts="$opts -o IdentitiesOnly=yes -i $ssh_key"
 
   if [[ "$no_mux" != true ]] && ssh_mux_enabled; then
     local ctl_path

--- a/tests/test_utils.bats
+++ b/tests/test_utils.bats
@@ -144,6 +144,21 @@ _load_utils() {
   [[ "$result" == *"ServerAliveInterval=5"* ]]
 }
 
+# ── IdentitiesOnly when key specified (issue #93) ────────────────────────────
+
+@test "build_ssh_opts: -k adds IdentitiesOnly=yes to prevent agent key offers" {
+  _load_utils
+  result=$(build_ssh_opts -k /home/user/.ssh/id_rsa)
+  [[ "$result" == *"IdentitiesOnly=yes"* ]]
+  [[ "$result" == *"-i /home/user/.ssh/id_rsa"* ]]
+}
+
+@test "build_ssh_opts: no IdentitiesOnly when no key specified" {
+  _load_utils
+  result=$(build_ssh_opts)
+  [[ "$result" != *"IdentitiesOnly"* ]]
+}
+
 # ── ControlMaster multiplexing (issue #37) ───────────────────────────────────
 
 @test "build_ssh_opts: includes ControlMaster options by default" {


### PR DESCRIPTION
## Summary

When `build_ssh_opts` is called with `-k <key>`, it now adds `-o IdentitiesOnly=yes` before `-i <key>`. This prevents the SSH agent from offering all loaded keys first, which causes "Too many authentication failures" on hosts with low `MaxAuthTries` (default 6).

## Changes

- **lib/utils.sh**: Added `-o IdentitiesOnly=yes` to SSH opts when a key is explicitly specified
- **tests/test_utils.bats**: Added two tests validating the fix and ensuring no regression when no key is specified

## Testing

```bash
bats tests/test_utils.bats  # 48 tests, 0 failures
shellcheck -s bash lib/utils.sh  # clean
```

Closes #93