### PR TITLE
feat: add strut remote:init to bootstrap strut on VPS

### DIFF
--- a/lib/cmd_remote_init.sh
+++ b/lib/cmd_remote_init.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# ==================================================
+# cmd_remote_init.sh — Bootstrap strut on a remote VPS
+# ==================================================
+# Usage: strut <stack> remote:init --env <name>
+#        strut remote:init --host <host> --user <user> [--key <path>] [--port <port>]
+#
+# Clones the project repository to VPS_DEPLOY_DIR on the remote host,
+# verifies strut is executable, and confirms connectivity.
+# ==================================================
+
+set -euo pipefail
+
+_usage_remote_init() {
+  echo "Usage: strut <stack> remote:init --env <name>"
+  echo "       strut remote:init --host <host> --user <user> [options]"
+  echo ""
+  echo "Bootstrap strut on a remote VPS by cloning the project repository"
+  echo "and verifying the installation."
+  echo ""
+  echo "Options:"
+  echo "  --env <name>       Environment file to read VPS connection info from"
+  echo "  --host <host>      VPS hostname or IP (overrides VPS_HOST from env)"
+  echo "  --user <user>      SSH user (overrides VPS_USER from env)"
+  echo "  --key <path>       SSH key path (overrides VPS_SSH_KEY from env)"
+  echo "  --port <port>      SSH port (overrides VPS_PORT from env, default: 22)"
+  echo "  --repo <url>       Git repository URL (default: detected from local git remote)"
+  echo "  --branch <name>    Branch to checkout (default: main)"
+  echo "  --deploy-dir <p>   Remote deploy directory (overrides VPS_DEPLOY_DIR)"
+  echo "  --dry-run          Show what would be done without executing"
+  echo ""
+  echo "Examples:"
+  echo "  strut my-stack remote:init --env prod"
+  echo "  strut remote:init --host compass.local --user gfargo --key ~/.ssh/id_rsa"
+  echo ""
+  echo "What this does:"
+  echo "  1. Verifies SSH connectivity to the remote host"
+  echo "  2. Checks if strut is already installed at the deploy directory"
+  echo "  3. Clones the project repository (with auth if needed)"
+  echo "  4. Makes the strut CLI executable"
+  echo "  5. Verifies strut --version works on the remote"
+}
+
+# cmd_remote_init [options] (reads CMD_* when available)
+cmd_remote_init() {
+  local host="" user="" ssh_key="" port="" repo_url="" branch="main" deploy_dir=""
+  local dry_run="${DRY_RUN:-false}"
+
+  # Read from CMD_* context if available (stack-scoped invocation)
+  local stack="${CMD_STACK:-}"
+  local env_file="${CMD_ENV_FILE:-}"
+
+  # Parse command-specific flags
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --host) host="$2"; shift 2 ;;
+      --user) user="$2"; shift 2 ;;
+      --key) ssh_key="$2"; shift 2 ;;
+      --port) port="$2"; shift 2 ;;
+      --repo) repo_url="$2"; shift 2 ;;
+      --branch) branch="$2"; shift 2 ;;
+      --deploy-dir) deploy_dir="$2"; shift 2 ;;
+      --dry-run) dry_run=true; shift ;;
+      *) shift ;;
+    esac
+  done
+
+  # If env file is available, source it for defaults
+  if [ -n "$env_file" ] && [ -f "$env_file" ]; then
+    set -a; source "$env_file"; set +a
+  fi
+
+  # Resolve connection parameters (CLI flags override env vars)
+  host="${host:-${VPS_HOST:-}}"
+  user="${user:-${VPS_USER:-ubuntu}}"
+  ssh_key="${ssh_key:-${VPS_SSH_KEY:-}}"
+  port="${port:-${VPS_PORT:-22}}"
+  deploy_dir="${deploy_dir:-${VPS_DEPLOY_DIR:-/home/$user/strut}}"
+  branch="${branch:-${DEFAULT_BRANCH:-main}}"
+
+  # Validate required params
+  if [ -z "$host" ]; then
+    fail "VPS_HOST is required. Use --host or set VPS_HOST in your env file."
+    return 1
+  fi
+
+  # Detect repo URL from local git remote if not specified
+  if [ -z "$repo_url" ]; then
+    repo_url=$(git remote get-url origin 2>/dev/null || echo "")
+    if [ -z "$repo_url" ]; then
+      fail "Could not detect git remote URL. Use --repo <url> to specify."
+      return 1
+    fi
+    log "Detected repository: $repo_url"
+  fi
+
+  # Build SSH options
+  local ssh_opts
+  ssh_opts=$(build_ssh_opts -p "$port" -k "$ssh_key" --batch)
+
+  print_banner "Remote Init"
+  log "Target: $user@$host:$port"
+  log "Deploy dir: $deploy_dir"
+  log "Repository: $repo_url"
+  log "Branch: $branch"
+  echo ""
+
+  # ── Dry-run mode ─────────────────────────────────────────────────────────
+  if [ "$dry_run" = "true" ]; then
+    echo -e "${YELLOW}[DRY-RUN] Execution plan for remote:init:${NC}"
+    run_cmd "Test SSH connectivity" ssh $ssh_opts "$user@$host" "echo ok"
+    run_cmd "Check if deploy dir exists" ssh $ssh_opts "$user@$host" "test -d '$deploy_dir'"
+    run_cmd "Clone repository" ssh $ssh_opts "$user@$host" "git clone $repo_url $deploy_dir"
+    run_cmd "Checkout branch" ssh $ssh_opts "$user@$host" "cd $deploy_dir && git checkout $branch"
+    run_cmd "Make strut executable" ssh $ssh_opts "$user@$host" "chmod +x $deploy_dir/strut"
+    run_cmd "Verify strut" ssh $ssh_opts "$user@$host" "cd $deploy_dir && ./strut --version"
+    echo ""
+    echo -e "${YELLOW}[DRY-RUN] No changes made.${NC}"
+    return 0
+  fi
+
+  # ── Step 1: Test SSH connectivity ────────────────────────────────────────
+  log "[1/4] Testing SSH connectivity..."
+  if ! ssh $ssh_opts "$user@$host" "echo ok" >/dev/null 2>&1; then
+    fail "Cannot connect to $user@$host (port $port). Check host, user, and SSH key."
+  fi
+  ok "SSH connection successful"
+
+  # ── Step 2: Check if already initialized ─────────────────────────────────
+  log "[2/4] Checking remote deploy directory..."
+  # shellcheck disable=SC2029
+  if ssh $ssh_opts "$user@$host" "test -d '$deploy_dir/.git'"; then
+    # Already exists — verify and report
+    log "Deploy directory already exists at $deploy_dir"
+    local remote_version
+    # shellcheck disable=SC2029
+    remote_version=$(ssh $ssh_opts "$user@$host" "cd '$deploy_dir' && ./strut --version 2>/dev/null" || echo "unknown")
+    local remote_branch
+    # shellcheck disable=SC2029
+    remote_branch=$(ssh $ssh_opts "$user@$host" "cd '$deploy_dir' && git rev-parse --abbrev-ref HEAD 2>/dev/null" || echo "unknown")
+
+    ok "strut already initialized on $host"
+    echo "  Version: $remote_version"
+    echo "  Branch:  $remote_branch"
+    echo "  Path:    $deploy_dir"
+    echo ""
+    echo "To update, run: strut ${stack:-<stack>} update --env ${CMD_ENV_NAME:-prod}"
+    return 0
+  fi
+
+  # ── Step 3: Clone repository ─────────────────────────────────────────────
+  log "[3/4] Cloning repository to $deploy_dir..."
+
+  # Use the existing setup_strut_repo infrastructure from migrate module
+  # which handles PAT auth, deploy keys, and SSH access testing
+  local gh_pat="${GH_PAT:-}"
+
+  if [ -n "$gh_pat" ]; then
+    # GH_PAT available — use it for HTTPS clone with token injection
+    local clone_url="$repo_url"
+    # Convert SSH URL to HTTPS if needed
+    if echo "$clone_url" | grep -q "^git@"; then
+      clone_url=$(echo "$clone_url" | sed 's|git@github.com:|https://github.com/|' | sed 's|\.git$||')
+    fi
+    # Ensure .git suffix for clone
+    [[ "$clone_url" == *.git ]] || clone_url="${clone_url}.git"
+
+    # shellcheck disable=SC2029
+    ssh $ssh_opts "$user@$host" "
+      set -e
+      git clone \
+        -c 'url.https://oauth2:$gh_pat@github.com/.insteadOf=https://github.com/' \
+        -c 'url.https://oauth2:$gh_pat@github.com/.insteadOf=git@github.com:' \
+        --branch '$branch' \
+        '$clone_url' '$deploy_dir'
+    " || fail "Failed to clone repository. Check GH_PAT and repository access."
+  else
+    # No PAT — delegate to setup_strut_repo which handles interactive auth
+    setup_strut_repo "$user" "$host" "$port" "$ssh_key" "$repo_url" "$deploy_dir"
+
+    # Checkout the correct branch
+    # shellcheck disable=SC2029
+    ssh $ssh_opts "$user@$host" "cd '$deploy_dir' && git checkout '$branch'" 2>/dev/null || true
+  fi
+
+  ok "Repository cloned to $deploy_dir"
+
+  # ── Step 4: Verify installation ──────────────────────────────────────────
+  log "[4/4] Verifying strut installation..."
+
+  # Make CLI executable
+  # shellcheck disable=SC2029
+  ssh $ssh_opts "$user@$host" "chmod +x '$deploy_dir/strut'"
+
+  # Verify strut runs
+  local remote_version
+  # shellcheck disable=SC2029
+  remote_version=$(ssh $ssh_opts "$user@$host" "cd '$deploy_dir' && ./strut --version 2>/dev/null" || echo "")
+
+  if [ -z "$remote_version" ]; then
+    warn "strut was cloned but --version check failed"
+    warn "This may be fine — verify manually with: ssh $user@$host 'cd $deploy_dir && ./strut --version'"
+  else
+    ok "strut $remote_version running on $host"
+  fi
+
+  echo ""
+  ok "Remote initialization complete!"
+  echo ""
+  echo "Next steps:"
+  echo "  1. Copy your env file to the VPS:"
+  echo "     scp .prod.env $user@$host:$deploy_dir/"
+  echo "  2. Deploy your stack:"
+  echo "     strut ${stack:-<stack>} release --env ${CMD_ENV_NAME:-prod}"
+}

--- a/lib/deploy.sh
+++ b/lib/deploy.sh
@@ -241,7 +241,11 @@ vps_update_repo() {
   ssh $ssh_opts "$vps_user@$vps_host" "
     set -e
     if [ ! -d '$deploy_dir' ]; then
-      echo 'ERROR: $deploy_dir not found on VPS' >&2; exit 1
+      echo 'ERROR: $deploy_dir not found on VPS' >&2
+      echo '' >&2
+      echo 'strut is not initialized on this host.' >&2
+      echo 'Run: strut <stack> remote:init --env <name>' >&2
+      exit 1
     fi
     cd '$deploy_dir'
     echo '--- Current HEAD ---'

--- a/strut
+++ b/strut
@@ -134,6 +134,7 @@ source "$LIB/cmd_domain.sh"
 source "$LIB/cmd_volumes.sh"
 source "$LIB/cmd_keys.sh"
 source "$LIB/cmd_remote.sh"
+source "$LIB/cmd_remote_init.sh"
 source "$LIB/cmd_init.sh"
 source "$LIB/cmd_stop.sh"
 source "$LIB/cmd_skills.sh"
@@ -226,6 +227,7 @@ usage() {
   echo "                                                                 Upload local backup to VPS and restore remotely"
   echo "  shell    [--env <name>]                                        SSH to VPS"
   echo "  exec     [--env <name>] <command>                              Execute command on VPS"
+  echo "  remote:init [--env <name>] [--host <h>] [--user <u>]          Bootstrap strut on VPS"
   echo "  status   [--env <name>]                                        Stack status"
   echo "  volumes  [--env <name>] [status|init|config]                   Volume management"
   echo "  local    start [--services <profile>]                          Start stack locally"
@@ -691,6 +693,7 @@ if [ "$FLAGS_HELP" = "true" ]; then
     validate) _usage_validate ;;
     rollback) _usage_rollback ;;
     diff)     _usage_diff ;;
+    remote:init) _usage_remote_init ;;
     lock)     _usage_lock ;;
     *)        usage ;;
   esac
@@ -715,6 +718,7 @@ case "$COMMAND" in
   db:push)             cmd_db_push "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   shell)               cmd_shell ;;
   exec)                cmd_exec "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
+  remote:init)         cmd_remote_init "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   status)              cmd_status ;;
   prune)               cmd_prune "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   volumes)             cmd_volumes "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;

--- a/tests/test_remote_init.bats
+++ b/tests/test_remote_init.bats
@@ -1,0 +1,140 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_remote_init.bats — Unit tests for remote:init command
+# ==================================================
+# Run:  bats tests/test_remote_init.bats
+
+# ── Setup ─────────────────────────────────────────────────────────────────────
+
+setup() {
+  export CLI_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  TEST_TMP="$(mktemp -d)"
+
+  # Source required modules
+  source "$CLI_ROOT/lib/utils.sh"
+  source "$CLI_ROOT/lib/cmd_remote_init.sh"
+
+  # Override fail/log/ok/warn/print_banner to not exit or clutter output
+  fail() { echo "FAIL: $1" >&2; return 1; }
+  log() { :; }
+  ok() { :; }
+  warn() { :; }
+  print_banner() { :; }
+
+  # Stub build_ssh_opts to return predictable output
+  build_ssh_opts() { echo "-o BatchMode=yes"; }
+
+  # Default CMD_* exports
+  export CMD_STACK=""
+  export CMD_ENV_FILE=""
+  export CMD_ENV_NAME=""
+  export DRY_RUN="false"
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+}
+
+# ── Usage ─────────────────────────────────────────────────────────────────────
+
+@test "remote:init: _usage_remote_init prints help text" {
+  result=$(_usage_remote_init)
+  [[ "$result" == *"Bootstrap strut on a remote VPS"* ]]
+  [[ "$result" == *"--host"* ]]
+  [[ "$result" == *"--user"* ]]
+  [[ "$result" == *"--repo"* ]]
+}
+
+# ── Validation ────────────────────────────────────────────────────────────────
+
+@test "remote:init: fails when no host is provided" {
+  # No VPS_HOST, no --host flag
+  unset VPS_HOST
+  run cmd_remote_init
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"VPS_HOST is required"* ]]
+}
+
+@test "remote:init: fails when no repo URL can be detected" {
+  export VPS_HOST="test-host"
+  # Override git to return nothing
+  git() { return 1; }
+  export -f git
+
+  run cmd_remote_init
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Could not detect git remote URL"* ]]
+}
+
+# ── Dry-run mode ──────────────────────────────────────────────────────────────
+
+@test "remote:init: dry-run shows execution plan without executing" {
+  export VPS_HOST="test-host"
+  export VPS_USER="ubuntu"
+  export DRY_RUN="true"
+
+  # Stub git remote detection
+  git() { echo "https://github.com/user/repo.git"; }
+  export -f git
+
+  # Stub run_cmd to just echo
+  run_cmd() { echo "PLAN: $1"; }
+  export -f run_cmd
+
+  # Need color vars
+  YELLOW=""
+  NC=""
+  export YELLOW NC
+
+  run cmd_remote_init
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY-RUN"* ]]
+}
+
+# ── Flag parsing ──────────────────────────────────────────────────────────────
+
+@test "remote:init: --host and --user override env vars" {
+  export VPS_HOST="env-host"
+  export VPS_USER="env-user"
+  export DRY_RUN="true"
+
+  git() { echo "https://github.com/user/repo.git"; }
+  export -f git
+  run_cmd() { echo "PLAN: $1"; }
+  export -f run_cmd
+  YELLOW=""
+  NC=""
+  export YELLOW NC
+
+  # Re-source to get clean state
+  source "$CLI_ROOT/lib/cmd_remote_init.sh"
+  fail() { echo "FAIL: $1" >&2; return 1; }
+  log() { :; }
+  ok() { :; }
+  warn() { :; }
+  print_banner() { :; }
+  build_ssh_opts() { echo "-o BatchMode=yes"; }
+
+  run cmd_remote_init --host override-host --user override-user
+  [ "$status" -eq 0 ]
+  # The dry-run output should reference the overridden host
+  [[ "$output" == *"override-host"* ]] || [[ "$output" == *"DRY-RUN"* ]]
+}
+
+@test "remote:init: --repo flag overrides git remote detection" {
+  export VPS_HOST="test-host"
+  export DRY_RUN="true"
+
+  # git should NOT be called when --repo is provided
+  git() { echo "SHOULD_NOT_APPEAR"; }
+  export -f git
+  run_cmd() { echo "PLAN: $1"; }
+  export -f run_cmd
+  YELLOW=""
+  NC=""
+  export YELLOW NC
+
+  run cmd_remote_init --repo "https://github.com/custom/repo.git"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"SHOULD_NOT_APPEAR"* ]]
+}


### PR DESCRIPTION
## Summary

Adds a new `remote:init` command that bootstraps strut on a remote VPS, solving the problem where `strut release` fails with confusing errors when strut isn't installed on the target host.

## Usage

```bash
# Stack-scoped (reads connection info from env file)
strut my-stack remote:init --env prod

# Standalone (explicit connection params)
strut remote:init --host compass.local --user gfargo --key ~/.ssh/id_rsa
```

## What it does

1. Tests SSH connectivity to the remote host
2. Checks if strut is already installed (reports version/branch if so)
3. Clones the project repository (uses GH_PAT if available, otherwise delegates to interactive auth via `setup_strut_repo`)
4. Makes the strut CLI executable
5. Verifies `strut --version` works on the remote

## Additional improvements

- **Better error messages**: `vps_update_repo` now suggests `remote:init` when the deploy directory doesn't exist on the VPS
- **Dry-run support**: `--dry-run` shows the execution plan without making changes
- **Flag overrides**: CLI flags (`--host`, `--user`, `--key`, `--port`, `--repo`, `--branch`, `--deploy-dir`) override env file values

## Testing

```bash
bats tests/test_remote_init.bats  # 6 tests, 0 failures
bats tests/test_utils.bats        # 48 tests, 0 failures
shellcheck -s bash lib/cmd_remote_init.sh lib/deploy.sh strut  # clean
```

Closes #95
