### PR TITLE
fix: respect COMPOSE_PROJECT_NAME during stack takeover

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -393,6 +393,10 @@ validate_env_file() {
 # and optional service profile. All compose command construction should
 # go through this function to ensure consistent --project-name format.
 #
+# Project name resolution order:
+#   1. COMPOSE_PROJECT_NAME from env file (respects existing deployments)
+#   2. Auto-generated: <stack>-<env_name> (avoids double-prefix)
+#
 # Requires: _docker_sudo() from lib/docker.sh (available at call time)
 resolve_compose_cmd() {
   local stack="$1"
@@ -404,13 +408,19 @@ resolve_compose_cmd() {
   local env_name
   env_name=$(extract_env_name "$env_file")
 
-  # Avoid double-prefixing: if env_name already starts with "<stack>-" (e.g.,
-  # jitsi-prod for the jitsi stack), use it as-is; otherwise prepend stack name.
-  local project_name
-  if [[ "$env_name" == "${stack}-"* ]]; then
-    project_name="$env_name"
-  else
-    project_name="${stack}-${env_name}"
+  # If COMPOSE_PROJECT_NAME is explicitly set in the environment (sourced from
+  # the env file by validate_env_file upstream), respect it. This allows strut
+  # to manage existing deployments that use a custom project name.
+  local project_name="${COMPOSE_PROJECT_NAME:-}"
+
+  if [ -z "$project_name" ]; then
+    # Avoid double-prefixing: if env_name already starts with "<stack>-" (e.g.,
+    # jitsi-prod for the jitsi stack), use it as-is; otherwise prepend stack name.
+    if [[ "$env_name" == "${stack}-"* ]]; then
+      project_name="$env_name"
+    else
+      project_name="${stack}-${env_name}"
+    fi
   fi
 
   local cmd="$(_docker_sudo)docker compose --env-file $env_file --project-name $project_name -f $compose_file"

--- a/tests/test_cli_resolve.bats
+++ b/tests/test_cli_resolve.bats
@@ -117,3 +117,44 @@ EOF
   result=$(resolve_compose_cmd "knowledge-graph" "$TEST_TMP/.local.env" "")
   [[ "$result" == *"--project-name knowledge-graph-local"* ]]
 }
+
+# ── COMPOSE_PROJECT_NAME override (issue #96) ────────────────────────────────
+
+@test "resolve_compose_cmd: respects COMPOSE_PROJECT_NAME from env file" {
+  _load_cli_functions
+  cat > "$TEST_TMP/.prod.env" <<'EOF'
+VPS_HOST=10.0.0.1
+COMPOSE_PROJECT_NAME=plane
+EOF
+  set -a; source "$TEST_TMP/.prod.env"; set +a
+
+  result=$(resolve_compose_cmd "plane" "$TEST_TMP/.prod.env" "")
+  # Should use "plane" not "plane-prod"
+  [[ "$result" == *"--project-name plane"* ]]
+  [[ "$result" != *"--project-name plane-prod"* ]]
+}
+
+@test "resolve_compose_cmd: COMPOSE_PROJECT_NAME takes precedence over auto-generated name" {
+  _load_cli_functions
+  cat > "$TEST_TMP/.local.env" <<'EOF'
+COMPOSE_PROJECT_NAME=my-custom-name
+EOF
+  set -a; source "$TEST_TMP/.local.env"; set +a
+
+  result=$(resolve_compose_cmd "knowledge-graph" "$TEST_TMP/.local.env" "")
+  [[ "$result" == *"--project-name my-custom-name"* ]]
+  [[ "$result" != *"knowledge-graph-local"* ]]
+}
+
+@test "resolve_compose_cmd: auto-generates name when COMPOSE_PROJECT_NAME is not set" {
+  _load_cli_functions
+  # Ensure COMPOSE_PROJECT_NAME is unset
+  unset COMPOSE_PROJECT_NAME
+  cat > "$TEST_TMP/.prod.env" <<'EOF'
+VPS_HOST=10.0.0.1
+EOF
+  set -a; source "$TEST_TMP/.prod.env"; set +a
+
+  result=$(resolve_compose_cmd "my-app" "$TEST_TMP/.prod.env" "")
+  [[ "$result" == *"--project-name my-app-prod"* ]]
+}


### PR DESCRIPTION
## Summary

When taking over an existing Docker Compose deployment, strut's auto-generated `--project-name` (`<stack>-<env>`) conflicts with the existing project name, causing Docker to create duplicate containers instead of managing the existing ones.

This fix makes `resolve_compose_cmd` respect `COMPOSE_PROJECT_NAME` when it's set in the env file, allowing strut to manage existing deployments in-place.

## How it works

Project name resolution order:
1. **`COMPOSE_PROJECT_NAME` from env file** — respects existing deployments
2. **Auto-generated `<stack>-<env_name>`** — default behavior (unchanged)

## Usage

Set `COMPOSE_PROJECT_NAME` in your env file to match the existing deployment:

```bash
# .prod.env
COMPOSE_PROJECT_NAME=plane
VPS_HOST=10.0.0.1
```

Now `strut plane deploy --env prod` uses `--project-name plane` instead of `--project-name plane-prod`, managing the existing containers in-place.

## Testing

```bash
bats tests/test_cli_resolve.bats  # 12 tests, 0 failures
bats tests/test_utils.bats        # 48 tests, 0 failures
shellcheck -s bash lib/utils.sh   # clean
```

3 new tests added:
- `COMPOSE_PROJECT_NAME` from env file is respected
- `COMPOSE_PROJECT_NAME` takes precedence over auto-generated name
- Auto-generates name when `COMPOSE_PROJECT_NAME` is not set (regression guard)

Closes #96
