### PR TITLE
feat: support BUILD_MODE=local for on-target image builds

### DIFF
--- a/lib/cmd_validate.sh
+++ b/lib/cmd_validate.sh
@@ -163,6 +163,33 @@ _validate_services_conf() {
         valid=false
       fi
     fi
+
+    # BUILD_MODE validation
+    if [[ "$key" == "BUILD_MODE" ]]; then
+      case "$val" in
+        local|registry|none) ;;
+        *)
+          _val_error "services.conf" "BUILD_MODE='$val' (must be local, registry, or none)"
+          valid=false
+          ;;
+      esac
+    fi
+
+    # BUILD_PULL validation
+    if [[ "$key" == "BUILD_PULL" ]]; then
+      if ! _is_valid_boolean "$val"; then
+        _val_error "services.conf" "BUILD_PULL='$val' (must be true or false)"
+        valid=false
+      fi
+    fi
+
+    # BUILD_PARALLEL validation
+    if [[ "$key" == "BUILD_PARALLEL" ]]; then
+      if ! _is_valid_boolean "$val"; then
+        _val_error "services.conf" "BUILD_PARALLEL='$val' (must be true or false)"
+        valid=false
+      fi
+    fi
   done < "$conf_file"
 
   $valid && _val_ok "services.conf" "valid ($service_count services, $db_count databases)"

--- a/lib/deploy.sh
+++ b/lib/deploy.sh
@@ -96,18 +96,26 @@ deploy_stack() {
 
   # Dry-run: show execution plan and exit early
   if [ "$DRY_RUN" = "true" ]; then
+    load_services_conf "$stack_dir"
+    local dry_build_mode="${BUILD_MODE:-registry}"
     echo ""
-    echo -e "${YELLOW}[DRY-RUN] Execution plan for deploy:${NC}"
-    local registry_type="${REGISTRY_TYPE:-none}"
-    if [ "$registry_type" != "none" ]; then
-      local registry_host="${REGISTRY_HOST:-}"
-      if [ -n "$registry_host" ]; then
-        run_cmd "Authenticate with registry ($registry_type: $registry_host)" echo "registry auth"
-      else
-        run_cmd "Authenticate with registry ($registry_type)" echo "registry auth"
+    echo -e "${YELLOW}[DRY-RUN] Execution plan for deploy (BUILD_MODE=$dry_build_mode):${NC}"
+    if [ "$dry_build_mode" = "registry" ]; then
+      local registry_type="${REGISTRY_TYPE:-none}"
+      if [ "$registry_type" != "none" ]; then
+        local registry_host="${REGISTRY_HOST:-}"
+        if [ -n "$registry_host" ]; then
+          run_cmd "Authenticate with registry ($registry_type: $registry_host)" echo "registry auth"
+        else
+          run_cmd "Authenticate with registry ($registry_type)" echo "registry auth"
+        fi
       fi
+      run_cmd "Pull latest images" $compose_cmd pull
+    elif [ "$dry_build_mode" = "local" ]; then
+      run_cmd "Build images on target" $compose_cmd build
+    else
+      run_cmd "Skip image pull/build (BUILD_MODE=$dry_build_mode)" echo "skipped"
     fi
-    run_cmd "Pull latest images" $compose_cmd pull
     run_cmd "Create data directories" mkdir -p "$stack_dir/data/..."
     run_cmd "Stop existing containers" $compose_cmd down --remove-orphans
     run_cmd "Start services" $compose_cmd up -d --remove-orphans
@@ -121,21 +129,45 @@ deploy_stack() {
     return 0
   fi
 
-  # Registry login (dispatches based on REGISTRY_TYPE from config)
-  log "[2/5] Authenticating with registry..."
-  registry_login
+  # Load services.conf early so BUILD_MODE and other config is available
+  # for the registry/build decision below.
+  load_services_conf "$stack_dir"
+  local build_mode="${BUILD_MODE:-registry}"
 
-  # Save rollback snapshot before pulling new images
+  # Registry login (dispatches based on REGISTRY_TYPE from config)
+  # Skipped when BUILD_MODE=local or BUILD_MODE=none (no registry needed)
+  if [ "$build_mode" = "registry" ]; then
+    log "[2/5] Authenticating with registry..."
+    registry_login
+  elif [ "$build_mode" = "local" ]; then
+    log "[2/5] Skipping registry auth (BUILD_MODE=local)"
+  else
+    log "[2/5] Skipping registry auth (BUILD_MODE=$build_mode)"
+  fi
+
+  # Save rollback snapshot before pulling/building new images
   source "$cli_root/lib/rollback.sh"
   rollback_save_snapshot "$stack" "$compose_cmd" "$env_name"
 
-  # Pull images
-  log "[3/5] Pulling latest images..."
-  docker_pull_stack "$compose_cmd"
+  # Pull or build images based on BUILD_MODE
+  if [ "$build_mode" = "local" ]; then
+    log "[3/5] Building images on target..."
+    local build_args="${BUILD_ARGS:-}"
+    local build_cmd="$compose_cmd build"
+    [ "${BUILD_PULL:-false}" = "true" ] && build_cmd="$build_cmd --pull"
+    [ "${BUILD_PARALLEL:-true}" = "true" ] && build_cmd="$build_cmd --parallel"
+    [ -n "$build_args" ] && build_cmd="$build_cmd $build_args"
+    $build_cmd || fail "Image build failed"
+    ok "Images built successfully"
+  elif [ "$build_mode" = "none" ]; then
+    log "[3/5] Skipping image pull/build (BUILD_MODE=none)"
+  else
+    log "[3/5] Pulling latest images..."
+    docker_pull_stack "$compose_cmd"
+  fi
 
   # Data directories — read from services.conf or use defaults
   log "[4/5] Creating data directories..."
-  load_services_conf "$stack_dir"
   local data_dirs="${STACK_DATA_DIRS:-data/postgres data/redis data/gdrive}"
   for dir in $data_dirs; do
     mkdir -p "$stack_dir/$dir"
@@ -264,7 +296,8 @@ vps_update_repo() {
 }
 
 # pull_only_stack <stack> <env_file> [services_profile]
-# Only pulls images without starting services
+# Only pulls images without starting services.
+# When BUILD_MODE=local, builds images instead of pulling.
 pull_only_stack() {
   local stack="$1"
   local env_file="$2"
@@ -276,9 +309,28 @@ pull_only_stack() {
   local compose_cmd
   compose_cmd=$(resolve_compose_cmd "$stack" "$env_file" "$services_profile")
 
-  registry_login
-  docker_pull_stack "$compose_cmd"
-  ok "Pull complete."
+  local cli_root="${CLI_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+  local stack_dir="$cli_root/stacks/$stack"
+  load_services_conf "$stack_dir"
+  local build_mode="${BUILD_MODE:-registry}"
+
+  if [ "$build_mode" = "local" ]; then
+    log "Building images on target (BUILD_MODE=local)..."
+    local build_args="${BUILD_ARGS:-}"
+    local build_cmd="$compose_cmd build"
+    [ "${BUILD_PULL:-false}" = "true" ] && build_cmd="$build_cmd --pull"
+    [ "${BUILD_PARALLEL:-true}" = "true" ] && build_cmd="$build_cmd --parallel"
+    [ -n "$build_args" ] && build_cmd="$build_cmd $build_args"
+    $build_cmd || fail "Image build failed"
+    ok "Build complete."
+  elif [ "$build_mode" = "none" ]; then
+    log "Skipping pull/build (BUILD_MODE=none)"
+    ok "Nothing to pull or build."
+  else
+    registry_login
+    docker_pull_stack "$compose_cmd"
+    ok "Pull complete."
+  fi
 }
 
 # vps_release <stack> <env_file> [services_profile]

--- a/templates/services.conf.template
+++ b/templates/services.conf.template
@@ -4,6 +4,19 @@
 # Place this file in your stack directory (stacks/<name>/services.conf).
 # The health engine reads this to discover services and databases.
 #
+# ── Build Mode ─────────────────────────────────────
+# Controls how images are obtained during deploy.
+#   registry — pull from container registry (default)
+#   local    — build on target host (docker compose build)
+#   none     — images already exist, skip both build and pull
+#
+# BUILD_MODE=registry
+#
+# When BUILD_MODE=local, optional build settings:
+# BUILD_ARGS=--no-cache        # extra args passed to docker compose build
+# BUILD_PULL=false             # pull base images before build (default: false)
+# BUILD_PARALLEL=true          # parallel builds for multi-service stacks (default: true)
+#
 # ── Application Services ───────────────────────────
 # Declare each service with <NAME>_PORT and an optional <NAME>_HEALTH_PATH.
 #

--- a/tests/test_build_mode.bats
+++ b/tests/test_build_mode.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_build_mode.bats — Tests for BUILD_MODE support in deploy
+# ==================================================
+# Run:  bats tests/test_build_mode.bats
+# Covers: BUILD_MODE=local|registry|none in deploy_stack and pull_only_stack
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_docker
+
+  source "$CLI_ROOT/lib/config.sh"
+  source "$CLI_ROOT/lib/deploy.sh"
+
+  # Stubs for functions called during deploy
+  registry_login() { echo "REGISTRY_LOGIN_CALLED"; }
+  docker_pull_stack() { echo "DOCKER_PULL_CALLED: $*"; }
+  rollback_save_snapshot() { :; }
+  export_volume_paths() { :; }
+  fire_hook() { return 0; }
+  fire_hook_or_warn() { :; }
+  notify_event() { :; }
+  print_banner() { :; }
+  require_cmd() { :; }
+  is_running_on_vps() { return 0; }
+  export -f registry_login docker_pull_stack rollback_save_snapshot \
+            export_volume_paths fire_hook fire_hook_or_warn notify_event \
+            print_banner require_cmd is_running_on_vps
+
+  # Create stack structure
+  mkdir -p "$TEST_TMP/stacks/hub"
+  cat > "$TEST_TMP/stacks/hub/docker-compose.yml" <<'EOF'
+services:
+  app:
+    build: .
+    image: hub-app
+EOF
+
+  cat > "$TEST_TMP/.prod.env" <<'EOF'
+VPS_HOST=10.0.0.1
+EOF
+
+  export CLI_ROOT="$TEST_TMP"
+  export DRY_RUN="false"
+  export PRE_DEPLOY_VALIDATE="false"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ── pull_only_stack with BUILD_MODE ──────────────────────────────────────────
+
+@test "pull_only_stack: BUILD_MODE=registry calls registry_login and docker_pull" {
+  cat > "$TEST_TMP/stacks/hub/services.conf" <<'EOF'
+BUILD_MODE=registry
+API_PORT=8000
+EOF
+
+  run pull_only_stack "hub" "$TEST_TMP/.prod.env" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"REGISTRY_LOGIN_CALLED"* ]]
+  [[ "$output" == *"DOCKER_PULL_CALLED"* ]]
+}
+
+@test "pull_only_stack: BUILD_MODE=local runs docker compose build instead of pull" {
+  cat > "$TEST_TMP/stacks/hub/services.conf" <<'EOF'
+BUILD_MODE=local
+EOF
+
+  # Stub docker and compose to capture the build command
+  docker() {
+    if [[ "$1" == "compose" ]]; then
+      echo "DOCKER_COMPOSE $*"
+      return 0
+    fi
+  }
+  export -f docker
+
+  run pull_only_stack "hub" "$TEST_TMP/.prod.env" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"build"* ]]
+  [[ "$output" != *"REGISTRY_LOGIN_CALLED"* ]]
+  [[ "$output" != *"DOCKER_PULL_CALLED"* ]]
+}
+
+@test "pull_only_stack: BUILD_MODE=none skips both pull and build" {
+  cat > "$TEST_TMP/stacks/hub/services.conf" <<'EOF'
+BUILD_MODE=none
+EOF
+
+  run pull_only_stack "hub" "$TEST_TMP/.prod.env" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"REGISTRY_LOGIN_CALLED"* ]]
+  [[ "$output" != *"DOCKER_PULL_CALLED"* ]]
+  [[ "$output" == *"Nothing to pull or build"* ]]
+}
+
+@test "pull_only_stack: no BUILD_MODE defaults to registry behavior" {
+  # No services.conf at all
+  run pull_only_stack "hub" "$TEST_TMP/.prod.env" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"REGISTRY_LOGIN_CALLED"* ]]
+  [[ "$output" == *"DOCKER_PULL_CALLED"* ]]
+}
+
+# ── BUILD_ARGS, BUILD_PULL, BUILD_PARALLEL ───────────────────────────────────
+
+@test "pull_only_stack: BUILD_ARGS are passed to docker compose build" {
+  cat > "$TEST_TMP/stacks/hub/services.conf" <<'EOF'
+BUILD_MODE=local
+BUILD_ARGS=--no-cache
+BUILD_PULL=true
+BUILD_PARALLEL=true
+EOF
+
+  docker() {
+    if [[ "$1" == "compose" ]]; then
+      echo "DOCKER_COMPOSE $*"
+      return 0
+    fi
+  }
+  export -f docker
+
+  run pull_only_stack "hub" "$TEST_TMP/.prod.env" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--no-cache"* ]]
+  [[ "$output" == *"--pull"* ]]
+  [[ "$output" == *"--parallel"* ]]
+}
+
+# ── Validation ───────────────────────────────────────────────────────────────
+
+@test "validate: BUILD_MODE=local is valid" {
+  source "$CLI_ROOT/../lib/cmd_validate.sh" 2>/dev/null || source "$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/lib/cmd_validate.sh"
+
+  # Reset CLI_ROOT to real project for validation functions
+  local real_root="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  mkdir -p "$TEST_TMP/validate-stack"
+  cat > "$TEST_TMP/validate-stack/services.conf" <<'EOF'
+BUILD_MODE=local
+BUILD_PULL=true
+BUILD_PARALLEL=false
+API_PORT=8000
+EOF
+
+  # Capture validation output
+  _val_ok() { echo "OK: $1 $2"; }
+  _val_error() { echo "ERROR: $1 $2"; return 1; }
+  _val_warn() { echo "WARN: $1 $2"; }
+
+  run _validate_services_conf "$TEST_TMP/validate-stack"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+  [[ "$output" != *"ERROR"* ]]
+}
+
+@test "validate: BUILD_MODE=invalid is rejected" {
+  source "$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/lib/cmd_validate.sh"
+
+  mkdir -p "$TEST_TMP/validate-bad"
+  cat > "$TEST_TMP/validate-bad/services.conf" <<'EOF'
+BUILD_MODE=invalid
+EOF
+
+  _val_ok() { echo "OK: $1 $2"; }
+  _val_error() { echo "ERROR: $1 $2"; }
+  _val_warn() { echo "WARN: $1 $2"; }
+  _is_valid_port() { [[ "$1" =~ ^[0-9]+$ ]] && [ "$1" -ge 1 ] && [ "$1" -le 65535 ]; }
+  _is_valid_boolean() { [[ "$1" == "true" || "$1" == "false" ]]; }
+
+  run _validate_services_conf "$TEST_TMP/validate-bad"
+  [[ "$output" == *"ERROR"* ]]
+  [[ "$output" == *"BUILD_MODE"* ]]
+  [[ "$output" == *"must be local, registry, or none"* ]]
+}


### PR DESCRIPTION
## Summary

Adds `BUILD_MODE` setting to `services.conf` that controls how images are obtained during deploy. This enables strut to manage stacks that build images directly on the target host (no registry needed).

## Usage

```ini
# stacks/hub/services.conf
BUILD_MODE=local
BUILD_ARGS=--no-cache
BUILD_PULL=true
BUILD_PARALLEL=true
```

```bash
strut hub deploy --env prod        # builds on target, then starts
strut hub deploy --env prod --dry-run  # shows build plan
```

## BUILD_MODE options

| Mode | Behavior |
|------|----------|
| `registry` | Pull from container registry (default, existing behavior) |
| `local` | Build on target host via `docker compose build` |
| `none` | Skip both build and pull (images already exist) |

## What changes in the deploy flow

When `BUILD_MODE=local`:
- Registry auth is skipped (step 2)
- `docker compose build` runs instead of `docker compose pull` (step 3)
- `BUILD_ARGS`, `BUILD_PULL`, `BUILD_PARALLEL` control build behavior
- Rollback snapshots still work
- Full pipeline (health checks, notifications) still applies

## Files changed

- `lib/deploy.sh` — BUILD_MODE logic in `deploy_stack` and `pull_only_stack`
- `lib/cmd_validate.sh` — Validation for BUILD_MODE, BUILD_PULL, BUILD_PARALLEL
- `templates/services.conf.template` — Documentation of new settings
- `tests/test_build_mode.bats` — 7 unit tests

## Testing

```bash
bats tests/test_build_mode.bats       # 7 tests, 0 failures
bats tests/test_cmd_deploy.bats       # 12 tests, 0 failures
bats tests/test_dry_run_commands.bats  # 10 tests, 0 failures
shellcheck -s bash lib/deploy.sh lib/cmd_validate.sh  # clean
```

Closes #99
