### PR TITLE
fix: audit format strings over SSH + VPS hostname detection

### DIFF
--- a/lib/audit.sh
+++ b/lib/audit.sh
@@ -31,18 +31,18 @@ _audit_docker() {
 
   log "Collecting container information..."
 
-  ssh $ssh_opts "$vps_user@$vps_host" "${_sudo}docker ps --format '{{json .}}'" > "$audit_dir/containers.jsonl" 2>/dev/null || {
+  ssh $ssh_opts "$vps_user@$vps_host" "${_sudo}docker ps --format json" > "$audit_dir/containers.jsonl" 2>/dev/null || {
     warn "Failed to get container list. Is Docker running?"
     return 1
   }
   log "  ✓ Containers collected"
 
-  ssh $ssh_opts "$vps_user@$vps_host" "${_sudo}docker ps -a --format '{{json .}}'" > "$audit_dir/containers-all.jsonl" 2>/dev/null
-  ssh $ssh_opts "$vps_user@$vps_host" "${_sudo}docker volume ls --format '{{json .}}'" > "$audit_dir/volumes.jsonl" 2>/dev/null
+  ssh $ssh_opts "$vps_user@$vps_host" "${_sudo}docker ps -a --format json" > "$audit_dir/containers-all.jsonl" 2>/dev/null
+  ssh $ssh_opts "$vps_user@$vps_host" "${_sudo}docker volume ls --format json" > "$audit_dir/volumes.jsonl" 2>/dev/null
   log "  ✓ Volumes collected"
 
-  ssh $ssh_opts "$vps_user@$vps_host" "${_sudo}docker network ls --format '{{json .}}'" > "$audit_dir/networks.jsonl" 2>/dev/null
-  ssh $ssh_opts "$vps_user@$vps_host" "${_sudo}docker images --format '{{json .}}'" > "$audit_dir/images.jsonl" 2>/dev/null
+  ssh $ssh_opts "$vps_user@$vps_host" "${_sudo}docker network ls --format json" > "$audit_dir/networks.jsonl" 2>/dev/null
+  ssh $ssh_opts "$vps_user@$vps_host" "${_sudo}docker images --format json" > "$audit_dir/images.jsonl" 2>/dev/null
   log "  ✓ Images collected"
 
   ssh $ssh_opts "$vps_user@$vps_host" "ss -tuln | grep LISTEN" > "$audit_dir/ports.txt" 2>/dev/null
@@ -62,7 +62,8 @@ _audit_nginx() {
   log "Collecting nginx configuration..."
   mkdir -p "$audit_dir/nginx"
 
-  ssh $ssh_opts "$vps_user@$vps_host" "${_sudo}docker ps --format '{{.Names}}' | grep -i nginx" > "$audit_dir/nginx/nginx-containers.txt" 2>/dev/null || true
+  # shellcheck disable=SC2029
+  ssh $ssh_opts "$vps_user@$vps_host" "${_sudo}docker ps --format '{{.Names}}'" 2>/dev/null | grep -i nginx > "$audit_dir/nginx/nginx-containers.txt" || true
   ssh $ssh_opts "$vps_user@$vps_host" "systemctl is-active nginx 2>/dev/null || echo 'not-running'" > "$audit_dir/nginx/nginx-service-status.txt" 2>/dev/null || true
 
   local nginx_containers
@@ -93,7 +94,8 @@ _audit_caddy() {
   log "Collecting Caddy configuration..."
   mkdir -p "$audit_dir/caddy"
 
-  ssh $ssh_opts "$vps_user@$vps_host" "${_sudo}docker ps --format '{{.Names}}' | grep -i caddy" > "$audit_dir/caddy/caddy-containers.txt" 2>/dev/null || true
+  # shellcheck disable=SC2029
+  ssh $ssh_opts "$vps_user@$vps_host" "${_sudo}docker ps --format '{{.Names}}'" 2>/dev/null | grep -i caddy > "$audit_dir/caddy/caddy-containers.txt" || true
   ssh $ssh_opts "$vps_user@$vps_host" "systemctl is-active caddy 2>/dev/null || echo 'not-running'" > "$audit_dir/caddy/caddy-service-status.txt" 2>/dev/null || true
 
   local caddy_containers
@@ -191,7 +193,12 @@ _audit_secrets() {
   container_ids=$(ssh $ssh_opts "$vps_user@$vps_host" "${_sudo}docker ps -q" 2>/dev/null || echo "")
   if [ -n "$container_ids" ]; then
     for cid in $container_ids; do
-      ssh $ssh_opts "$vps_user@$vps_host" "${_sudo}docker inspect $cid --format='{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null | cut -d'=' -f1 | sort -u" > "$audit_dir/secrets/container-${cid}-env-keys.txt" 2>/dev/null || true
+      # Use docker inspect JSON output and extract env var names locally
+      # to avoid Go template brace escaping issues over SSH
+      # shellcheck disable=SC2029
+      ssh $ssh_opts "$vps_user@$vps_host" "${_sudo}docker inspect $cid" 2>/dev/null \
+        | grep -oP '"[A-Z_][A-Z0-9_]*=' | tr -d '"' | tr -d '=' | sort -u \
+        > "$audit_dir/secrets/container-${cid}-env-keys.txt" 2>/dev/null || true
     done
   fi
   log "  ✓ Environment patterns collected"
@@ -205,7 +212,8 @@ _audit_databases() {
   log "Detecting database services..."
   mkdir -p "$audit_dir/databases"
 
-  ssh $ssh_opts "$vps_user@$vps_host" "${_sudo}docker ps --format '{{.Names}}\t{{.Image}}' | grep -E '(postgres|mysql|mariadb|mongo|redis|neo4j)'" > "$audit_dir/databases/database-containers.txt" 2>/dev/null || echo "No database containers found" > "$audit_dir/databases/database-containers.txt"
+  # shellcheck disable=SC2029
+  ssh $ssh_opts "$vps_user@$vps_host" "${_sudo}docker ps --format '{{.Names}}\t{{.Image}}'" 2>/dev/null | grep -E '(postgres|mysql|mariadb|mongo|redis|neo4j)' > "$audit_dir/databases/database-containers.txt" || echo "No database containers found" > "$audit_dir/databases/database-containers.txt"
   ssh $ssh_opts "$vps_user@$vps_host" "systemctl list-units --type=service --state=running --no-pager | grep -E '(postgres|mysql|mariadb|mongo|redis)'" > "$audit_dir/databases/database-services.txt" 2>/dev/null || echo "No database system services found" > "$audit_dir/databases/database-services.txt"
   ssh $ssh_opts "$vps_user@$vps_host" "ss -tuln | grep -E ':(5432|3306|27017|6379|7687)'" > "$audit_dir/databases/database-ports.txt" 2>/dev/null || echo "No database ports detected" > "$audit_dir/databases/database-ports.txt"
 }

--- a/lib/cmd_deploy.sh
+++ b/lib/cmd_deploy.sh
@@ -85,6 +85,7 @@ cmd_deploy() {
   local skip_validation=false
   local force_unlock=false
   local skip_lock=false
+  local force_local=false
   # Mode: honor DEPLOY_MODE config default; --blue-green / --standard on the
   # CLI always wins. `mode_flag=""` means "not overridden — use config".
   local mode_flag=""
@@ -94,6 +95,7 @@ cmd_deploy() {
       --skip-validation) skip_validation=true; shift ;;
       --force-unlock) force_unlock=true; shift ;;
       --no-lock) skip_lock=true; shift ;;
+      --force-local) force_local=true; shift ;;
       --blue-green) mode_flag="blue-green"; shift ;;
       --standard)   mode_flag="standard";   shift ;;
       *) shift ;;
@@ -129,8 +131,8 @@ cmd_deploy() {
     fi
   fi
 
-  # Check if this is a VPS environment and warn user (skip if we're ON the VPS)
-  if [ -f "$env_file" ]; then
+  # Check if this is a VPS environment and warn user (skip if we're ON the VPS or --force-local)
+  if [ "$force_local" != "true" ] && [ -f "$env_file" ]; then
     set -a; source "$env_file"; set +a
     if [ -n "${VPS_HOST:-}" ] && ! is_running_on_vps; then
       warn "Detected VPS environment (VPS_HOST=$VPS_HOST)"

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -235,11 +235,22 @@ vps_sudo_prefix() {
 # ── Misc helpers ─────────────────────────────────────────────────────────────
 
 # is_running_on_vps
-# Returns 0 if the current machine appears to be the VPS (VPS_HOST matches a local IP).
+# Returns 0 if the current machine appears to be the VPS target.
+# Checks: hostname match, hostname.local match, and local IP match.
 # Requires VPS_HOST to be set in the environment.
 is_running_on_vps() {
   local vps_host="${VPS_HOST:-}"
   [ -n "$vps_host" ] || return 1  # silent check — no VPS_HOST means not on VPS
+
+  # Check if VPS_HOST matches the current hostname (with or without .local)
+  local current_hostname
+  current_hostname=$(hostname 2>/dev/null || echo "")
+  if [ -n "$current_hostname" ]; then
+    [[ "$current_hostname" == "$vps_host" ]] && return 0
+    [[ "${current_hostname}.local" == "$vps_host" ]] && return 0
+    # Also handle case where VPS_HOST has .local but hostname doesn't
+    [[ "$current_hostname" == "${vps_host%.local}" ]] && return 0
+  fi
 
   # Check if VPS_HOST matches any local IP address
   if command -v hostname &>/dev/null; then


### PR DESCRIPTION
## Summary

Two fixes in one PR:

### Fix 1: Audit docker format strings mangled over SSH (#100)

Replaced `docker --format '{{json .}}'` with `--format json` (Docker 23.0+) for all JSON output in `audit.sh`. The Go template braces were getting mangled when passed through SSH batch mode.

For non-JSON format strings (`{{.Names}}`), moved `grep` to the local side so the format string stays intact on the remote.

For `docker inspect` env extraction, switched to raw JSON output parsed locally.

### Fix 2: Allow deploy when already on target host (#102)

`is_running_on_vps` now checks hostname and hostname.local in addition to IP addresses. This means `strut deploy --env prod` works without prompting when you're already SSH'd into the target VPS.

Also adds `--force-local` flag to skip the VPS detection warning entirely:
```bash
strut plane deploy --env prod --force-local
```

## Testing

```bash
bats tests/test_resource_checks.bats  # 26 tests, 0 failures
bats tests/test_cmd_deploy.bats       # 12 tests, 0 failures
bats tests/test_utils.bats            # 48 tests, 0 failures
shellcheck -s bash lib/audit.sh lib/utils.sh lib/cmd_deploy.sh  # clean
```

Closes #100, Closes #102
