### PR TITLE
fix: engine/project separation + feat: strut rebuild command

### DIFF
--- a/lib/cmd_deploy.sh
+++ b/lib/cmd_deploy.sh
@@ -64,6 +64,56 @@ cmd_update() {
   vps_update_repo "$stack" "$env_file"
 }
 
+# cmd_rebuild [--no-cache] [--pull] (reads CMD_*)
+# Builds images and restarts services. Equivalent to deploy with BUILD_MODE=local.
+cmd_rebuild() {
+  local stack="$CMD_STACK"
+  local env_file="$CMD_ENV_FILE"
+  local services="$CMD_SERVICES"
+
+  # Parse rebuild-specific flags
+  local no_cache=false
+  local pull_base=false
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      --no-cache) no_cache=true; shift ;;
+      --pull) pull_base=true; shift ;;
+      *) shift ;;
+    esac
+  done
+
+  # Force BUILD_MODE=local for this deploy, with optional flags
+  export BUILD_MODE="local"
+  if [ "$no_cache" = "true" ]; then
+    export BUILD_ARGS="${BUILD_ARGS:+$BUILD_ARGS }--no-cache"
+  fi
+  if [ "$pull_base" = "true" ]; then
+    export BUILD_PULL="true"
+  fi
+
+  # Delegate to the standard deploy pipeline
+  deploy_stack "$stack" "$env_file" "$services"
+}
+
+_usage_rebuild() {
+  echo ""
+  echo "Usage: strut <stack> rebuild [--env <name>] [--no-cache] [--pull] [--dry-run]"
+  echo ""
+  echo "Build images on target and restart services."
+  echo "Equivalent to deploy with BUILD_MODE=local."
+  echo ""
+  echo "Options:"
+  echo "  --env <name>       Environment (reads .<name>.env)"
+  echo "  --no-cache         Build without using cache"
+  echo "  --pull             Pull base images before building"
+  echo "  --dry-run          Show execution plan without running"
+  echo ""
+  echo "Examples:"
+  echo "  strut hub rebuild --env prod"
+  echo "  strut hub rebuild --env prod --no-cache"
+  echo ""
+}
+
 # cmd_release (no args — reads CMD_*)
 cmd_release() {
   local stack="$CMD_STACK"

--- a/lib/deploy.sh
+++ b/lib/deploy.sh
@@ -65,7 +65,8 @@ deploy_stack() {
     log "[2/7] Pre-deploy validation..."
 
     # Run config schema validation
-    source "$cli_root/lib/cmd_validate.sh"
+    local strut_home="${STRUT_HOME:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+    source "$strut_home/lib/cmd_validate.sh"
     export CMD_STACK="$stack"
     export CMD_STACK_DIR="$stack_dir"
     export CMD_ENV_FILE="$env_file"
@@ -146,7 +147,8 @@ deploy_stack() {
   fi
 
   # Save rollback snapshot before pulling/building new images
-  source "$cli_root/lib/rollback.sh"
+  local strut_home="${STRUT_HOME:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+  source "$strut_home/lib/rollback.sh"
   rollback_save_snapshot "$stack" "$compose_cmd" "$env_name"
 
   # Pull or build images based on BUILD_MODE

--- a/lib/deploy_blue_green.sh
+++ b/lib/deploy_blue_green.sh
@@ -321,7 +321,7 @@ bg_deploy_stack() {
   # Pre-deploy validation (reuse standard path's contract)
   if [ "${SKIP_VALIDATION:-false}" != "true" ] && [ "${PRE_DEPLOY_VALIDATE:-true}" = "true" ]; then
     log "[2/9] Pre-deploy validation..."
-    source "$cli_root/lib/cmd_validate.sh"
+    source "${STRUT_HOME:-$cli_root}/lib/cmd_validate.sh"
     export CMD_STACK="$stack" CMD_STACK_DIR="$stack_dir" CMD_ENV_FILE="$env_file" CMD_ENV_NAME="$env_name"
     cmd_validate 2>/dev/null || fail "Pre-deploy validation failed — fix and retry: strut $stack validate --env $env_name"
 
@@ -359,7 +359,7 @@ bg_deploy_stack() {
   # Save rollback snapshot of the **current** color before we touch anything.
   # Restore paths: standard rollback restores images; blue-green rollback
   # flips the .bluegreen active_color and brings the old project back up.
-  source "$cli_root/lib/rollback.sh"
+  source "${STRUT_HOME:-$cli_root}/lib/rollback.sh"
   if [ "$old_color" != "none" ]; then
     rollback_save_snapshot "$stack" "$old_cmd" "$env_name" || true
   fi

--- a/strut
+++ b/strut
@@ -209,6 +209,7 @@ usage() {
   echo "  update   [--env <name>]                                        Pull latest strut on VPS"
   echo "  release  [--env <name>] [--services <profile>]                 Full VPS release (update + migrate + deploy)"
   echo "  deploy   [--env <name>] [--services <profile>] [--pull-only]  Deploy stack"
+  echo "  rebuild  [--env <name>] [--no-cache] [--pull]                  Build images + deploy"
   echo "  stop     [--env <name>] [--services <profile>] [--volumes]   Stop running containers"
   echo "  diff     [--env <name>] [--json]                              Preview pending changes vs VPS"
   echo "  lock     <status|release> [--env <name>] [--force]            Inspect/manage deploy locks"
@@ -677,6 +678,7 @@ fi
 if [ "$FLAGS_HELP" = "true" ]; then
   case "$COMMAND" in
     deploy)   _usage_deploy ;;
+    rebuild)  _usage_rebuild ;;
     stop)     _usage_stop ;;
     health)   _usage_health ;;
     logs)     _usage_logs ;;
@@ -704,6 +706,7 @@ case "$COMMAND" in
   update)              cmd_update "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   release)             cmd_release "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   deploy)              cmd_deploy "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
+  rebuild)             cmd_rebuild "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   stop)                cmd_stop "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   health)              cmd_health ;;
   logs)                cmd_logs "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;


### PR DESCRIPTION
## Summary

Two fixes in one PR:

### Fix: Resolve lib sources from STRUT_HOME (#101)

`deploy.sh` and `deploy_blue_green.sh` were sourcing `cmd_validate.sh` and `rollback.sh` relative to `CLI_ROOT` (the project directory). When the project is separate from the engine, these files don't exist.

Now uses `STRUT_HOME` for engine lib files, falling back to the old behavior when not set.

### Feature: Add `strut rebuild` command (#103)

New command that forces `BUILD_MODE=local` and runs the full deploy pipeline:

```bash
strut hub rebuild --env prod
strut hub rebuild --env prod --no-cache
strut hub rebuild --env prod --pull
```

This is the strut-native way to build + deploy for stacks with Dockerfiles.

## Testing

```bash
bats tests/test_cmd_deploy.bats tests/test_build_mode.bats tests/test_dry_run_commands.bats
# 29 tests, 0 failures
shellcheck -s bash lib/deploy.sh lib/deploy_blue_green.sh lib/cmd_deploy.sh strut  # clean
```

Closes #101, Closes #103
