### PR TITLE
feat: add [hosts]/[stacks] topology sections to strut.conf

### DIFF
--- a/lib/topology.sh
+++ b/lib/topology.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# ==================================================
+# lib/topology.sh — Multi-host topology from strut.conf
+# ==================================================
+# Parses [hosts] and [stacks] sections from strut.conf to provide
+# host-to-stack mapping for multi-host deployments.
+#
+# Format in strut.conf:
+#   [hosts]
+#   <alias> = <user>@<host>:<port> <ssh_key>
+#
+#   [stacks]
+#   <stack> = <host_alias>
+#
+# Provides:
+#   topology_load          — parse strut.conf sections into associative arrays
+#   topology_resolve_host  — get connection info for a stack
+#   topology_list_hosts    — list all defined hosts
+#   topology_list_stacks   — list stacks for a given host
+
+set -euo pipefail
+
+# Global topology state (populated by topology_load)
+declare -gA _TOPO_HOSTS=()       # alias → "user@host:port key_path"
+declare -gA _TOPO_STACK_HOST=()  # stack → host_alias
+_TOPO_LOADED=false
+
+# topology_load [config_file]
+#
+# Parses [hosts] and [stacks] sections from strut.conf.
+# Safe to call multiple times (no-ops after first load).
+topology_load() {
+  [ "$_TOPO_LOADED" = "true" ] && return 0
+
+  local conf="${1:-${PROJECT_ROOT:-}/strut.conf}"
+  [ -f "$conf" ] || return 0  # No config = no topology (not an error)
+
+  local section=""
+  local line key val
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    # Skip comments and empty lines
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+
+    # Detect section headers
+    if [[ "$line" =~ ^\[([a-zA-Z_-]+)\]$ ]]; then
+      section="${BASH_REMATCH[1]}"
+      continue
+    fi
+
+    # Parse key = value within sections
+    if [[ "$line" =~ ^[[:space:]]*([a-zA-Z0-9_-]+)[[:space:]]*=[[:space:]]*(.+)$ ]]; then
+      key="${BASH_REMATCH[1]}"
+      val="${BASH_REMATCH[2]}"
+      # Trim trailing whitespace
+      val="${val%"${val##*[![:space:]]}"}"
+
+      case "$section" in
+        hosts)
+          _TOPO_HOSTS["$key"]="$val"
+          ;;
+        stacks)
+          _TOPO_STACK_HOST["$key"]="$val"
+          ;;
+      esac
+    fi
+  done < "$conf"
+
+  _TOPO_LOADED=true
+}
+
+# topology_resolve_host <stack>
+#
+# Resolves connection info for a stack from the topology map.
+# Outputs space-separated: <user> <host> <port> <ssh_key>
+# Returns 1 if the stack has no host mapping.
+#
+# Usage:
+#   read -r user host port key <<< "$(topology_resolve_host my-stack)"
+topology_resolve_host() {
+  local stack="$1"
+  topology_load
+
+  local host_alias="${_TOPO_STACK_HOST[$stack]:-}"
+  [ -n "$host_alias" ] || return 1
+
+  local host_spec="${_TOPO_HOSTS[$host_alias]:-}"
+  [ -n "$host_spec" ] || return 1
+
+  # Parse: user@host:port /path/to/key
+  local conn_part key_path
+  conn_part="${host_spec%% *}"
+  key_path="${host_spec#* }"
+  # If no space (no key), key_path equals conn_part — clear it
+  [ "$key_path" = "$conn_part" ] && key_path=""
+
+  local user host port
+  # Parse user@host:port
+  if [[ "$conn_part" == *@* ]]; then
+    user="${conn_part%%@*}"
+    local host_port="${conn_part#*@}"
+  else
+    user="ubuntu"
+    local host_port="$conn_part"
+  fi
+
+  if [[ "$host_port" == *:* ]]; then
+    host="${host_port%%:*}"
+    port="${host_port#*:}"
+  else
+    host="$host_port"
+    port="22"
+  fi
+
+  echo "$user $host $port $key_path"
+}
+
+# topology_has_host <stack>
+#
+# Returns 0 if the stack has a host mapping in the topology.
+topology_has_host() {
+  local stack="$1"
+  topology_load
+  [ -n "${_TOPO_STACK_HOST[$stack]:-}" ]
+}
+
+# topology_list_hosts
+#
+# Lists all defined host aliases, one per line.
+topology_list_hosts() {
+  topology_load
+  local alias
+  for alias in "${!_TOPO_HOSTS[@]}"; do
+    echo "$alias"
+  done | sort
+}
+
+# topology_list_stacks [host_alias]
+#
+# Lists stacks, optionally filtered by host alias.
+topology_list_stacks() {
+  local filter="${1:-}"
+  topology_load
+  local stack
+  for stack in "${!_TOPO_STACK_HOST[@]}"; do
+    if [ -z "$filter" ] || [ "${_TOPO_STACK_HOST[$stack]}" = "$filter" ]; then
+      echo "$stack"
+    fi
+  done | sort
+}
+
+# topology_apply_to_env <stack>
+#
+# If the stack has a topology mapping, exports VPS_HOST, VPS_USER,
+# VPS_PORT, and VPS_SSH_KEY from the topology (unless already set
+# in the environment from the env file).
+# This allows topology to provide defaults that env files can override.
+topology_apply_to_env() {
+  local stack="$1"
+  topology_load
+
+  if ! topology_has_host "$stack"; then
+    return 0  # No topology for this stack — not an error
+  fi
+
+  local user host port key_path
+  read -r user host port key_path <<< "$(topology_resolve_host "$stack")"
+
+  # Only set if not already defined (env file takes precedence)
+  [ -z "${VPS_HOST:-}" ] && export VPS_HOST="$host"
+  [ -z "${VPS_USER:-}" ] && export VPS_USER="$user"
+  [ -z "${VPS_PORT:-}" ] && export VPS_PORT="$port"
+  [ -z "${VPS_SSH_KEY:-}" ] && [ -n "$key_path" ] && export VPS_SSH_KEY="$key_path"
+}

--- a/strut
+++ b/strut
@@ -83,6 +83,7 @@ export CLI_ROOT
 load_strut_config
 
 source "$LIB/utils.sh"
+source "$LIB/topology.sh"
 
 # Unified EXIT trap — runs every cleanup registered via `strut_register_cleanup`.
 # Registered here (not in utils.sh) so sourcing the library in tests doesn't
@@ -665,6 +666,14 @@ export CMD_ENV_FILE="$ENV_FILE"
 export CMD_ENV_NAME="$ENV_NAME"
 export CMD_SERVICES="$SERVICES"
 export CMD_JSON="$JSON_FLAG"
+
+# Apply topology defaults — if [hosts]/[stacks] sections exist in strut.conf,
+# fill in VPS_HOST/VPS_USER/VPS_PORT/VPS_SSH_KEY from the topology map
+# (env file values take precedence when set).
+if [ -f "$ENV_FILE" ]; then
+  set -a; source "$ENV_FILE" 2>/dev/null; set +a
+fi
+topology_apply_to_env "$STACK"
 
 # Error context for fail/warn/error messages. Formats as
 # "stack/env/command" when all three are known, else falls back.

--- a/tests/test_topology.bats
+++ b/tests/test_topology.bats
@@ -1,0 +1,263 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_topology.bats — Tests for multi-host topology
+# ==================================================
+# Run:  bats tests/test_topology.bats
+
+setup() {
+  export CLI_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  TEST_TMP="$(mktemp -d)"
+
+  source "$CLI_ROOT/lib/utils.sh"
+  source "$CLI_ROOT/lib/topology.sh"
+  fail() { echo "FAIL: $1" >&2; return 1; }
+
+  # Reset topology state between tests
+  _TOPO_HOSTS=()
+  _TOPO_STACK_HOST=()
+  _TOPO_LOADED=false
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+}
+
+# ── topology_load ─────────────────────────────────────────────────────────────
+
+@test "topology_load: parses [hosts] section" {
+  cat > "$TEST_TMP/strut.conf" <<'EOF'
+REGISTRY_TYPE=none
+
+[hosts]
+compass = gfargo@compass.local:22 ~/.ssh/id_rsa
+mac = griffen@mac.local:22 ~/.ssh/id_rsa
+pi-ops = pi@pi-ops.local:2222 ~/.ssh/pi_key
+
+[stacks]
+plane = compass
+hub = compass
+immich = mac
+EOF
+
+  export PROJECT_ROOT="$TEST_TMP"
+  topology_load
+
+  [ "${_TOPO_HOSTS[compass]}" = "gfargo@compass.local:22 ~/.ssh/id_rsa" ]
+  [ "${_TOPO_HOSTS[mac]}" = "griffen@mac.local:22 ~/.ssh/id_rsa" ]
+  [ "${_TOPO_HOSTS[pi-ops]}" = "pi@pi-ops.local:2222 ~/.ssh/pi_key" ]
+}
+
+@test "topology_load: parses [stacks] section" {
+  cat > "$TEST_TMP/strut.conf" <<'EOF'
+[hosts]
+compass = gfargo@compass.local:22 ~/.ssh/id_rsa
+
+[stacks]
+plane = compass
+hub = compass
+EOF
+
+  export PROJECT_ROOT="$TEST_TMP"
+  topology_load
+
+  [ "${_TOPO_STACK_HOST[plane]}" = "compass" ]
+  [ "${_TOPO_STACK_HOST[hub]}" = "compass" ]
+}
+
+@test "topology_load: skips comments and empty lines" {
+  cat > "$TEST_TMP/strut.conf" <<'EOF'
+# This is a comment
+REGISTRY_TYPE=none
+
+[hosts]
+# Another comment
+compass = gfargo@compass.local:22 ~/.ssh/id_rsa
+
+[stacks]
+# Stack mapping
+plane = compass
+EOF
+
+  export PROJECT_ROOT="$TEST_TMP"
+  topology_load
+
+  [ "${_TOPO_HOSTS[compass]}" = "gfargo@compass.local:22 ~/.ssh/id_rsa" ]
+  [ "${_TOPO_STACK_HOST[plane]}" = "compass" ]
+}
+
+@test "topology_load: no-op when no strut.conf exists" {
+  export PROJECT_ROOT="$TEST_TMP/nonexistent"
+  topology_load
+  [ ${#_TOPO_HOSTS[@]} -eq 0 ]
+}
+
+# ── topology_resolve_host ─────────────────────────────────────────────────────
+
+@test "topology_resolve_host: returns user host port key" {
+  cat > "$TEST_TMP/strut.conf" <<'EOF'
+[hosts]
+compass = gfargo@compass.local:22 ~/.ssh/id_rsa
+
+[stacks]
+plane = compass
+EOF
+
+  export PROJECT_ROOT="$TEST_TMP"
+  local user host port key
+  read -r user host port key <<< "$(topology_resolve_host "plane")"
+
+  [ "$user" = "gfargo" ]
+  [ "$host" = "compass.local" ]
+  [ "$port" = "22" ]
+  [ "$key" = "~/.ssh/id_rsa" ]
+}
+
+@test "topology_resolve_host: handles custom port" {
+  cat > "$TEST_TMP/strut.conf" <<'EOF'
+[hosts]
+pi = pi@pi-ops.local:2222 ~/.ssh/pi_key
+
+[stacks]
+monitoring = pi
+EOF
+
+  export PROJECT_ROOT="$TEST_TMP"
+  local user host port key
+  read -r user host port key <<< "$(topology_resolve_host "monitoring")"
+
+  [ "$user" = "pi" ]
+  [ "$host" = "pi-ops.local" ]
+  [ "$port" = "2222" ]
+  [ "$key" = "~/.ssh/pi_key" ]
+}
+
+@test "topology_resolve_host: defaults port to 22 when not specified" {
+  cat > "$TEST_TMP/strut.conf" <<'EOF'
+[hosts]
+simple = user@host.example.com ~/.ssh/key
+
+[stacks]
+app = simple
+EOF
+
+  export PROJECT_ROOT="$TEST_TMP"
+  local user host port key
+  read -r user host port key <<< "$(topology_resolve_host "app")"
+
+  [ "$user" = "user" ]
+  [ "$host" = "host.example.com" ]
+  [ "$port" = "22" ]
+  [ "$key" = "~/.ssh/key" ]
+}
+
+@test "topology_resolve_host: returns 1 for unmapped stack" {
+  cat > "$TEST_TMP/strut.conf" <<'EOF'
+[hosts]
+compass = gfargo@compass.local:22
+
+[stacks]
+plane = compass
+EOF
+
+  export PROJECT_ROOT="$TEST_TMP"
+  run topology_resolve_host "unknown-stack"
+  [ "$status" -eq 1 ]
+}
+
+# ── topology_apply_to_env ─────────────────────────────────────────────────────
+
+@test "topology_apply_to_env: sets VPS_* vars from topology" {
+  cat > "$TEST_TMP/strut.conf" <<'EOF'
+[hosts]
+compass = gfargo@compass.local:22 ~/.ssh/id_rsa
+
+[stacks]
+plane = compass
+EOF
+
+  export PROJECT_ROOT="$TEST_TMP"
+  unset VPS_HOST VPS_USER VPS_PORT VPS_SSH_KEY
+
+  topology_apply_to_env "plane"
+
+  [ "$VPS_HOST" = "compass.local" ]
+  [ "$VPS_USER" = "gfargo" ]
+  [ "$VPS_PORT" = "22" ]
+  [ "$VPS_SSH_KEY" = "~/.ssh/id_rsa" ]
+}
+
+@test "topology_apply_to_env: env file values take precedence" {
+  cat > "$TEST_TMP/strut.conf" <<'EOF'
+[hosts]
+compass = gfargo@compass.local:22 ~/.ssh/id_rsa
+
+[stacks]
+plane = compass
+EOF
+
+  export PROJECT_ROOT="$TEST_TMP"
+  export VPS_HOST="override.example.com"
+  export VPS_USER="custom-user"
+  unset VPS_PORT VPS_SSH_KEY
+
+  topology_apply_to_env "plane"
+
+  # These should NOT be overridden
+  [ "$VPS_HOST" = "override.example.com" ]
+  [ "$VPS_USER" = "custom-user" ]
+  # These should be filled from topology
+  [ "$VPS_PORT" = "22" ]
+  [ "$VPS_SSH_KEY" = "~/.ssh/id_rsa" ]
+}
+
+@test "topology_apply_to_env: no-op for unmapped stack" {
+  cat > "$TEST_TMP/strut.conf" <<'EOF'
+[hosts]
+compass = gfargo@compass.local:22
+
+[stacks]
+plane = compass
+EOF
+
+  export PROJECT_ROOT="$TEST_TMP"
+  unset VPS_HOST VPS_USER VPS_PORT VPS_SSH_KEY
+
+  topology_apply_to_env "unknown-stack"
+
+  [ -z "${VPS_HOST:-}" ]
+}
+
+# ── topology_list_* ───────────────────────────────────────────────────────────
+
+@test "topology_list_hosts: lists all host aliases" {
+  cat > "$TEST_TMP/strut.conf" <<'EOF'
+[hosts]
+compass = gfargo@compass.local:22
+mac = griffen@mac.local:22
+pi-ops = pi@pi-ops.local:22
+EOF
+
+  export PROJECT_ROOT="$TEST_TMP"
+  result=$(topology_list_hosts)
+  [[ "$result" == *"compass"* ]]
+  [[ "$result" == *"mac"* ]]
+  [[ "$result" == *"pi-ops"* ]]
+}
+
+@test "topology_list_stacks: lists stacks for a host" {
+  cat > "$TEST_TMP/strut.conf" <<'EOF'
+[hosts]
+compass = gfargo@compass.local:22
+
+[stacks]
+plane = compass
+hub = compass
+immich = mac
+EOF
+
+  export PROJECT_ROOT="$TEST_TMP"
+  result=$(topology_list_stacks "compass")
+  [[ "$result" == *"plane"* ]]
+  [[ "$result" == *"hub"* ]]
+  [[ "$result" != *"immich"* ]]
+}


### PR DESCRIPTION
## Summary

Adds multi-host topology mapping to `strut.conf` via INI-style `[hosts]` and `[stacks]` sections. This provides a single source of truth for which stacks deploy where.

## Usage

```ini
# strut.conf
REGISTRY_TYPE=none

[hosts]
compass = gfargo@compass.local:22 ~/.ssh/id_rsa
mac = griffen@mac.local:22 ~/.ssh/id_rsa
pi-ops = pi@pi-ops.local:2222 ~/.ssh/pi_key

[stacks]
plane = compass
hub = compass
agent-platform = mac
immich = mac
monitoring = pi-ops
```

Now `strut plane release --env prod` automatically targets `compass` without needing `VPS_HOST` in the env file.

## How it works

- `topology_load` parses the sections into associative arrays
- `topology_apply_to_env` exports `VPS_HOST`, `VPS_USER`, `VPS_PORT`, `VPS_SSH_KEY` from the topology
- Env file values always take precedence (topology provides defaults)
- No topology = no change in behavior (fully backward compatible)

## API

| Function | Description |
|----------|-------------|
| `topology_resolve_host <stack>` | Returns: `user host port key_path` |
| `topology_has_host <stack>` | Returns 0 if stack has a mapping |
| `topology_list_hosts` | List all host aliases |
| `topology_list_stacks [host]` | List stacks, optionally filtered by host |
| `topology_apply_to_env <stack>` | Export VPS_* vars from topology |

## Testing

```bash
bats tests/test_topology.bats  # 13 tests, 0 failures
bats tests/test_config.bats    # 8 tests, 0 failures
shellcheck -s bash lib/topology.sh strut  # clean
```

Closes #104
