### PR TITLE
fix: config section parsing + audit directory path

### DIFF
--- a/completions/bash.sh
+++ b/completions/bash.sh
@@ -68,7 +68,7 @@ _strut_completions() {
   cword=$COMP_CWORD
 
   local top_cmds="init list scaffold upgrade doctor status-all posture group monitoring audit audit:list audit:generate migrate migrate:status notify skills help completions --version -v --help -h"
-  local per_stack_cmds="update release deploy stop diff lock health logs logs:download logs:rotate migrate backup restore db:pull db:push db:schema shell exec status volumes prune local prod staging dev debug keys validate rollback domain --help"
+  local per_stack_cmds="update release deploy rebuild stop diff lock health logs logs:download logs:rotate migrate backup restore db:pull db:push db:schema shell exec remote:init status volumes prune local prod staging dev debug keys validate rollback domain --help"
   local profiles="messaging ui full gdrive"
 
   # Flag-value completions — operate on prev regardless of position
@@ -173,7 +173,11 @@ _strut_completions() {
       [ "$cword" -eq 3 ] && mapfile -t COMPREPLY < <(compgen -W "neo4j postgres --status --up --down" -- "$cur") && return 0
       ;;
     deploy)
-      mapfile -t COMPREPLY < <(compgen -W "--env --services --pull-only --skip-validation --force-unlock --no-lock --dry-run" -- "$cur")
+      mapfile -t COMPREPLY < <(compgen -W "--env --services --pull-only --skip-validation --force-unlock --no-lock --force-local --blue-green --standard --dry-run" -- "$cur")
+      return 0
+      ;;
+    rebuild)
+      mapfile -t COMPREPLY < <(compgen -W "--env --no-cache --pull --dry-run" -- "$cur")
       return 0
       ;;
     health)

--- a/lib/audit.sh
+++ b/lib/audit.sh
@@ -362,8 +362,12 @@ audit_vps() {
   log "Auditing VPS: $vps_user@$vps_host"
   [ -n "$_sudo" ] && log "  (using sudo for docker commands)"
 
-  local audit_dir="$CLI_ROOT/audits/$(date +%Y%m%d-%H%M%S)-$vps_host"
-  mkdir -p "$audit_dir"
+  local audit_dir
+  # Prefer project root for audit output; fall back to current directory
+  # when running outside a project (e.g. `strut audit` from anywhere).
+  local audit_base="${PROJECT_ROOT:-$PWD}"
+  audit_dir="$audit_base/audits/$(date +%Y%m%d-%H%M%S)-$vps_host"
+  mkdir -p "$audit_dir" || fail "Cannot create audit directory: $audit_dir"
 
   # Run each audit category
   _audit_docker   "$ssh_opts" "$vps_user" "$vps_host" "$_sudo" "$audit_dir"

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -55,7 +55,31 @@ _preprocess_config() {
 
   local dir line inc_path
   dir=$(dirname "$abs")
+  local _in_section=false
   while IFS= read -r line || [ -n "$line" ]; do
+    # Detect INI-style section headers — these are parsed by topology.sh,
+    # not sourced as bash. Skip the header and all lines within the section.
+    if [[ "$line" =~ ^\[([a-zA-Z_-]+)\][[:space:]]*$ ]]; then
+      _in_section=true
+      continue
+    fi
+
+    # Lines inside a section use "key = value" format (spaces around =).
+    # A bash-style assignment (KEY=value, no spaces around =) or another
+    # section header signals the end of the section.
+    if [ "$_in_section" = "true" ]; then
+      # Stay in section for: blank lines and comments
+      if [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]]; then
+        continue
+      fi
+      # Section content: "key = value" (has space before =)
+      if [[ "$line" =~ ^[[:space:]]*[a-zA-Z0-9_-]+[[:space:]]+= ]]; then
+        continue
+      fi
+      # Anything else (bash assignment KEY=val, other content) = left section
+      _in_section=false
+    fi
+
     if [[ "$line" =~ ^[[:space:]]*include[[:space:]]*=[[:space:]]*(.+)$ ]]; then
       inc_path="${BASH_REMATCH[1]}"
       # Trim trailing whitespace

--- a/tests/test_config_include.bats
+++ b/tests/test_config_include.bats
@@ -240,3 +240,69 @@ EOF
   [ "$COMMON_PORT" = "9000" ]
   [ "$API_PORT" = "8080" ]
 }
+
+# ── INI section skipping (issue #110) ────────────────────────────────────────
+
+@test "preprocess_config: skips [section] headers and their content" {
+  cat > "$TEST_TMP/with-sections.conf" <<'EOF'
+REGISTRY_TYPE=ghcr
+DEFAULT_ORG=my-org
+
+[hosts]
+compass = gfargo@compass.local:22 ~/.ssh/id_rsa
+mac = griffen@mac.local:22
+
+[stacks]
+plane = compass
+hub = compass
+
+BANNER_TEXT=after-sections
+EOF
+
+  result=$(preprocess_config "$TEST_TMP/with-sections.conf")
+  # Global keys should be present
+  [[ "$result" == *"REGISTRY_TYPE=ghcr"* ]]
+  [[ "$result" == *"DEFAULT_ORG=my-org"* ]]
+  [[ "$result" == *"BANNER_TEXT=after-sections"* ]]
+  # Section headers and content should NOT be present
+  [[ "$result" != *"[hosts]"* ]]
+  [[ "$result" != *"[stacks]"* ]]
+  [[ "$result" != *"compass"* ]]
+  [[ "$result" != *"plane"* ]]
+}
+
+@test "preprocess_config: global keys after sections are preserved" {
+  cat > "$TEST_TMP/sections-then-global.conf" <<'EOF'
+FIRST=one
+
+[hosts]
+myhost = user@host:22
+
+SECOND=two
+EOF
+
+  result=$(preprocess_config "$TEST_TMP/sections-then-global.conf")
+  [[ "$result" == *"FIRST=one"* ]]
+  [[ "$result" == *"SECOND=two"* ]]
+  [[ "$result" != *"[hosts]"* ]]
+  [[ "$result" != *"myhost"* ]]
+}
+
+@test "load_strut_config: works with [hosts] and [stacks] sections present" {
+  cat > "$TEST_TMP/strut.conf" <<'EOF'
+REGISTRY_TYPE=ecr
+DEFAULT_ORG=acme
+
+[hosts]
+prod-server = deploy@10.0.0.1:22 ~/.ssh/deploy_key
+
+[stacks]
+api = prod-server
+web = prod-server
+EOF
+
+  export PROJECT_ROOT="$TEST_TMP"
+  load_strut_config
+  [ "$REGISTRY_TYPE" = "ecr" ]
+  [ "$DEFAULT_ORG" = "acme" ]
+}


### PR DESCRIPTION
## Summary

Fixes two bugs that made v0.22.0 features unusable, plus updates shell completions.

### Fix 1: preprocess_config crashes on [section] headers (#110)

`[hosts]` and `[stacks]` lines were being sourced as bash commands, causing `[hosts]: command not found`. Now `preprocess_config` detects INI section headers and skips them (along with their `key = value` content). Global assignments after sections are preserved.

### Fix 2: Audit output directory uses wrong path (#109)

`audit_dir` was based on `CLI_ROOT` which falls back to `STRUT_HOME` when running outside a project. Now uses `PROJECT_ROOT` or `$PWD` as the base, with explicit error on mkdir failure.

### Completions update

Added `rebuild`, `remote:init`, `--force-local`, `--blue-green`, `--standard` to bash completions.

## Testing

```bash
bats tests/test_config.bats tests/test_config_include.bats tests/test_topology.bats
# 40 tests, 0 failures
shellcheck -s bash lib/config.sh lib/audit.sh completions/bash.sh  # clean
```

Closes #109, Closes #110
