### PR TITLE
fix: replace grep -P with POSIX-compatible alternatives

### DIFF
--- a/lib/audit.sh
+++ b/lib/audit.sh
@@ -197,7 +197,7 @@ _audit_secrets() {
       # to avoid Go template brace escaping issues over SSH
       # shellcheck disable=SC2029
       ssh $ssh_opts "$vps_user@$vps_host" "${_sudo}docker inspect $cid" 2>/dev/null \
-        | grep -oP '"[A-Z_][A-Z0-9_]*=' | tr -d '"' | tr -d '=' | sort -u \
+        | grep -Eo '"[A-Z_][A-Z0-9_]*=' | tr -d '"' | tr -d '=' | sort -u \
         > "$audit_dir/secrets/container-${cid}-env-keys.txt" 2>/dev/null || true
     done
   fi

--- a/lib/drift/schedule.sh
+++ b/lib/drift/schedule.sh
@@ -91,7 +91,8 @@ drift_schedule_list() {
     local schedule
     local stack_name
     schedule=$(echo "$job" | awk '{print $1, $2, $3, $4, $5}')
-    stack_name=$(echo "$job" | grep -oP 'cli\.sh \K[^ ]+' || echo "unknown")
+    stack_name=$(echo "$job" | sed -n 's/.*cli\.sh \([^ ]*\).*/\1/p')
+    [ -z "$stack_name" ] && stack_name="unknown"
 
     echo "Stack: $stack_name"
     echo "  Schedule: $schedule"

--- a/lib/keys/discovery.sh
+++ b/lib/keys/discovery.sh
@@ -178,7 +178,7 @@ discover_vps_keys() {
 
   # List authorized users
   local authorized_users
-  authorized_users=$(ssh $ssh_opts "$vps_user@$vps_host" "cat ~/.ssh/authorized_keys 2>/dev/null | grep -oP '(?<=\s)[^\s]+@[^\s]+$' || echo ''" 2>/dev/null || echo "")
+  authorized_users=$(ssh $ssh_opts "$vps_user@$vps_host" "cat ~/.ssh/authorized_keys 2>/dev/null | awk '{print \$NF}' | grep '@' || echo ''" 2>/dev/null || echo "")
 
   # Check for .env files
   local env_files


### PR DESCRIPTION
Replaces all `grep -P` (GNU Perl regex) with macOS-compatible alternatives. BSD grep on macOS doesn't support `-P`, causing errors during audit's environment variable discovery phase.

Closes #112