### PR TITLE
feat: strut ship + audit:diff commands

### DIFF
--- a/lib/audit.sh
+++ b/lib/audit.sh
@@ -1472,3 +1472,118 @@ audit_list() {
     echo ""
   done
 }
+
+# audit_diff <vps_host> [vps_user] [ssh_key] [ssh_port]
+#
+# Runs a fresh audit and compares it against the most recent previous audit
+# for the same host. Shows: new/removed containers, changed images, port
+# changes, and disk usage delta.
+audit_diff() {
+  local vps_host="$1"
+  local vps_user="${2:-ubuntu}"
+  local ssh_key="${3:-}"
+  local ssh_port="${4:-}"
+
+  [ -n "$vps_host" ] || fail "Usage: strut audit:diff <vps-host> [vps-user] [ssh-key] [ssh-port]"
+
+  local audit_base="${PROJECT_ROOT:-$PWD}"
+  local audits_dir="$audit_base/audits"
+
+  # Find the most recent audit for this host
+  local prev_audit=""
+  if [ -d "$audits_dir" ]; then
+    prev_audit=$(find "$audits_dir" -maxdepth 1 -type d -name "*-$vps_host" | sort | tail -1)
+  fi
+
+  if [ -z "$prev_audit" ] || [ ! -f "$prev_audit/containers.jsonl" ]; then
+    warn "No previous audit found for $vps_host"
+    log "Running initial audit..."
+    audit_vps "$vps_host" "$vps_user" "$ssh_key" "$ssh_port"
+    return 0
+  fi
+
+  log "Previous audit: $(basename "$prev_audit")"
+  log "Running fresh audit for comparison..."
+
+  # Run a new audit
+  audit_vps "$vps_host" "$vps_user" "$ssh_key" "$ssh_port"
+
+  # Find the new audit (most recent)
+  local new_audit
+  new_audit=$(find "$audits_dir" -maxdepth 1 -type d -name "*-$vps_host" | sort | tail -1)
+
+  if [ "$new_audit" = "$prev_audit" ]; then
+    warn "No new audit was created — cannot diff"
+    return 1
+  fi
+
+  echo ""
+  print_banner "Audit Diff"
+  log "Comparing: $(basename "$prev_audit") → $(basename "$new_audit")"
+  echo ""
+
+  # ── Container diff ───────────────────────────────────────────────────────
+  local prev_containers="$prev_audit/containers.jsonl"
+  local new_containers="$new_audit/containers.jsonl"
+
+  if [ -f "$prev_containers" ] && [ -f "$new_containers" ]; then
+    local prev_names new_names
+    prev_names=$(jq -r '.Names // .Name // empty' "$prev_containers" 2>/dev/null | sort)
+    new_names=$(jq -r '.Names // .Name // empty' "$new_containers" 2>/dev/null | sort)
+
+    local added removed
+    added=$(comm -13 <(echo "$prev_names") <(echo "$new_names"))
+    removed=$(comm -23 <(echo "$prev_names") <(echo "$new_names"))
+
+    if [ -n "$added" ]; then
+      echo -e "${GREEN}+ New containers:${NC}"
+      echo "$added" | sed 's/^/    + /'
+      echo ""
+    fi
+
+    if [ -n "$removed" ]; then
+      echo -e "${RED}- Removed containers:${NC}"
+      echo "$removed" | sed 's/^/    - /'
+      echo ""
+    fi
+
+    if [ -z "$added" ] && [ -z "$removed" ]; then
+      echo -e "${GREEN}  Containers: no changes${NC}"
+      echo ""
+    fi
+
+    # Image changes (same container, different image)
+    local prev_images new_images
+    prev_images=$(jq -r '(.Names // .Name) + "=" + (.Image // "")' "$prev_containers" 2>/dev/null | sort)
+    new_images=$(jq -r '(.Names // .Name) + "=" + (.Image // "")' "$new_containers" 2>/dev/null | sort)
+
+    local image_changes
+    image_changes=$(comm -3 <(echo "$prev_images") <(echo "$new_images") | grep -v "^$" || true)
+    if [ -n "$image_changes" ]; then
+      echo -e "${YELLOW}~ Image changes:${NC}"
+      echo "$image_changes" | sed 's/^/    ~ /'
+      echo ""
+    fi
+  fi
+
+  # ── Disk usage diff ──────────────────────────────────────────────────────
+  local prev_disk="$prev_audit/disk-usage.txt"
+  local new_disk="$new_audit/disk-usage.txt"
+
+  if [ -f "$prev_disk" ] && [ -f "$new_disk" ]; then
+    local prev_root new_root
+    prev_root=$(grep -E '\s/$' "$prev_disk" | awk '{print $3}' || echo "?")
+    new_root=$(grep -E '\s/$' "$new_disk" | awk '{print $3}' || echo "?")
+
+    if [ "$prev_root" != "$new_root" ]; then
+      echo -e "${YELLOW}  Disk usage (root): $prev_root → $new_root${NC}"
+    else
+      echo "  Disk usage (root): $new_root (unchanged)"
+    fi
+    echo ""
+  fi
+
+  ok "Diff complete"
+  echo "  Previous: $prev_audit"
+  echo "  Current:  $new_audit"
+}

--- a/lib/cmd_ship.sh
+++ b/lib/cmd_ship.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# ==================================================
+# cmd_ship.sh — Commit, push, and remote rebuild in one command
+# ==================================================
+# Usage: strut <stack> ship --env <name> [--message <msg>] [--no-commit]
+#
+# The "edit locally, deploy remotely" workflow in a single command:
+#   1. Commit staged changes (or verify clean tree)
+#   2. Push to remote
+#   3. SSH to target host
+#   4. git pull && strut <stack> rebuild --env <name>
+# ==================================================
+
+set -euo pipefail
+
+_usage_ship() {
+  echo ""
+  echo "Usage: strut <stack> ship --env <name> [options]"
+  echo ""
+  echo "Commit, push, and rebuild on the remote host in one step."
+  echo ""
+  echo "Options:"
+  echo "  --env <name>         Environment (required)"
+  echo "  --message <msg>      Commit message (default: 'update <stack>')"
+  echo "  -m <msg>             Short form of --message"
+  echo "  --no-commit          Skip commit (just push + remote rebuild)"
+  echo "  --no-push            Skip push (just remote rebuild)"
+  echo "  --no-cache           Pass --no-cache to remote rebuild"
+  echo "  --dry-run            Show execution plan without running"
+  echo ""
+  echo "Examples:"
+  echo "  strut hub ship --env prod"
+  echo "  strut hub ship --env prod -m 'fix dashboard layout'"
+  echo "  strut hub ship --env prod --no-commit"
+  echo ""
+  echo "What it does:"
+  echo "  1. git add -A && git commit -m '<message>'"
+  echo "  2. git push origin <branch>"
+  echo "  3. ssh <host> 'cd <deploy_dir> && git pull && strut <stack> rebuild --env <name>'"
+  echo ""
+}
+
+# cmd_ship [options] (reads CMD_*)
+cmd_ship() {
+  local stack="$CMD_STACK"
+  local env_file="$CMD_ENV_FILE"
+  local env_name="$CMD_ENV_NAME"
+
+  # Parse flags
+  local commit_msg=""
+  local skip_commit=false
+  local skip_push=false
+  local no_cache=false
+  local dry_run="${DRY_RUN:-false}"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --message|-m) commit_msg="$2"; shift 2 ;;
+      --no-commit) skip_commit=true; shift ;;
+      --no-push) skip_push=true; shift ;;
+      --no-cache) no_cache=true; shift ;;
+      --dry-run) dry_run=true; shift ;;
+      *) shift ;;
+    esac
+  done
+
+  # Default commit message
+  [ -z "$commit_msg" ] && commit_msg="update $stack"
+
+  # Resolve connection info (from env file or topology)
+  validate_env_file "$env_file" VPS_HOST
+  local vps_host="${VPS_HOST:-}"
+  local vps_user="${VPS_USER:-ubuntu}"
+  local vps_ssh_key="${VPS_SSH_KEY:-}"
+  local vps_port="${VPS_PORT:-22}"
+  local deploy_dir="${VPS_DEPLOY_DIR:-/home/$vps_user/strut}"
+  local branch="${DEFAULT_BRANCH:-main}"
+
+  local ssh_opts
+  ssh_opts=$(build_ssh_opts -p "$vps_port" -k "$vps_ssh_key" --batch)
+
+  # Build remote rebuild command
+  local remote_rebuild="strut $stack rebuild --env $env_name"
+  [ "$no_cache" = "true" ] && remote_rebuild="$remote_rebuild --no-cache"
+
+  print_banner "Ship"
+  log "Stack: $stack | Env: $env_name | Target: $vps_user@$vps_host"
+  echo ""
+
+  # ── Dry-run ──────────────────────────────────────────────────────────────
+  if [ "$dry_run" = "true" ]; then
+    echo -e "${YELLOW}[DRY-RUN] Execution plan for ship:${NC}"
+    if [ "$skip_commit" != "true" ]; then
+      run_cmd "Stage and commit" git commit -am "$commit_msg"
+    fi
+    if [ "$skip_push" != "true" ]; then
+      run_cmd "Push to origin/$branch" git push origin "$branch"
+    fi
+    run_cmd "Pull on remote" ssh $ssh_opts "$vps_user@$vps_host" "cd $deploy_dir && git pull origin $branch"
+    run_cmd "Rebuild on remote" ssh $ssh_opts "$vps_user@$vps_host" "cd $deploy_dir && $remote_rebuild"
+    echo ""
+    echo -e "${YELLOW}[DRY-RUN] No changes made.${NC}"
+    return 0
+  fi
+
+  # ── Step 1: Commit ───────────────────────────────────────────────────────
+  if [ "$skip_commit" != "true" ]; then
+    log "[1/3] Committing changes..."
+    if git diff --quiet && git diff --cached --quiet; then
+      log "  Working tree clean — skipping commit"
+    else
+      git add -A
+      git commit -m "$commit_msg" || fail "Commit failed"
+      ok "Committed: $commit_msg"
+    fi
+  else
+    log "[1/3] Skipping commit (--no-commit)"
+  fi
+
+  # ── Step 2: Push ─────────────────────────────────────────────────────────
+  if [ "$skip_push" != "true" ]; then
+    log "[2/3] Pushing to origin/$branch..."
+    git push origin "$branch" || fail "Push failed"
+    ok "Pushed to origin/$branch"
+  else
+    log "[2/3] Skipping push (--no-push)"
+  fi
+
+  # ── Step 3: Remote rebuild ──────────────────────────────────────────────
+  log "[3/3] Rebuilding on $vps_host..."
+  # shellcheck disable=SC2029
+  ssh $ssh_opts "$vps_user@$vps_host" "
+    set -e
+    cd '$deploy_dir'
+    git pull origin '$branch'
+    $remote_rebuild
+  " || fail "Remote rebuild failed"
+
+  echo ""
+  ok "Shipped! $stack deployed to $vps_host"
+}

--- a/strut
+++ b/strut
@@ -136,6 +136,7 @@ source "$LIB/cmd_volumes.sh"
 source "$LIB/cmd_keys.sh"
 source "$LIB/cmd_remote.sh"
 source "$LIB/cmd_remote_init.sh"
+source "$LIB/cmd_ship.sh"
 source "$LIB/cmd_init.sh"
 source "$LIB/cmd_stop.sh"
 source "$LIB/cmd_skills.sh"
@@ -211,6 +212,7 @@ usage() {
   echo "  release  [--env <name>] [--services <profile>]                 Full VPS release (update + migrate + deploy)"
   echo "  deploy   [--env <name>] [--services <profile>] [--pull-only]  Deploy stack"
   echo "  rebuild  [--env <name>] [--no-cache] [--pull]                  Build images + deploy"
+  echo "  ship     [--env <name>] [-m <msg>] [--no-commit]               Commit, push, rebuild on remote"
   echo "  stop     [--env <name>] [--services <profile>] [--volumes]   Stop running containers"
   echo "  diff     [--env <name>] [--json]                              Preview pending changes vs VPS"
   echo "  lock     <status|release> [--env <name>] [--force]            Inspect/manage deploy locks"
@@ -558,6 +560,15 @@ case "${1:-}" in
     audit_list
     exit 0
     ;;
+  audit:diff)
+    VPS_HOST="${2:-}"
+    VPS_USER="${3:-ubuntu}"
+    SSH_KEY="${4:-}"
+    SSH_PORT="${5:-}"
+    [ -n "$VPS_HOST" ] || { usage; fail "Usage: strut audit:diff <vps-host> [vps-user] [ssh-key] [ssh-port]"; }
+    audit_diff "$VPS_HOST" "$VPS_USER" "$SSH_KEY" "$SSH_PORT"
+    exit 0
+    ;;
   audit:generate)
     # audit:generate <stack-name> --from <audit-dir>
     STACK_NAME="${2:-}"
@@ -688,6 +699,7 @@ if [ "$FLAGS_HELP" = "true" ]; then
   case "$COMMAND" in
     deploy)   _usage_deploy ;;
     rebuild)  _usage_rebuild ;;
+    ship)     _usage_ship ;;
     stop)     _usage_stop ;;
     health)   _usage_health ;;
     logs)     _usage_logs ;;
@@ -716,6 +728,7 @@ case "$COMMAND" in
   release)             cmd_release "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   deploy)              cmd_deploy "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   rebuild)             cmd_rebuild "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
+  ship)                cmd_ship "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   stop)                cmd_stop "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   health)              cmd_health ;;
   logs)                cmd_logs "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;


### PR DESCRIPTION
## Summary

Two new commands for the daily workflow:

### `strut <stack> ship` (#116)

The "edit locally, deploy remotely" workflow in one command:

```bash
strut hub ship --env prod                    # commit, push, rebuild on remote
strut hub ship --env prod -m 'fix layout'    # custom commit message
strut hub ship --env prod --no-commit        # just push + remote rebuild
```

Steps: `git commit -am` → `git push` → SSH → `git pull` → `strut rebuild`

### `strut audit:diff` (#115)

Compare current VPS state against the last audit:

```bash
strut audit:diff compass.local gfargo 22 ~/.ssh/id_rsa
```

Shows new/removed containers, changed images, and disk usage delta.

## Testing

```bash
bats tests/test_cmd_deploy.bats  # 12 tests, 0 failures
shellcheck -s bash lib/cmd_ship.sh lib/audit.sh strut  # clean
```

Closes #115, Closes #116
