### PR TITLE
feat: --host flag for per-host deploy targeting

### DIFF
--- a/lib/flags.sh
+++ b/lib/flags.sh
@@ -28,6 +28,7 @@ parse_common_flags() {
   FLAGS_JSON=""
   FLAGS_DRY_RUN=""
   FLAGS_HELP=""
+  FLAGS_HOST=""
   FLAGS_POSITIONAL=()
 
   while [[ $# -gt 0 ]]; do
@@ -36,6 +37,8 @@ parse_common_flags() {
       --env)         FLAGS_ENV_NAME="${2:-}"; shift 2 ;;
       --services=*)  FLAGS_SERVICES="${1#*=}"; shift ;;
       --services)    FLAGS_SERVICES="${2:-}"; shift 2 ;;
+      --host=*)      FLAGS_HOST="${1#*=}"; shift ;;
+      --host)        FLAGS_HOST="${2:-}"; shift 2 ;;
       --json)        FLAGS_JSON="--json"; shift ;;
       --dry-run)     FLAGS_DRY_RUN="true"; shift ;;
       --help|-h)     FLAGS_HELP="true"; shift ;;

--- a/lib/topology.sh
+++ b/lib/topology.sh
@@ -172,3 +172,57 @@ topology_apply_to_env() {
   [ -z "${VPS_PORT:-}" ] && export VPS_PORT="$port"
   [ -z "${VPS_SSH_KEY:-}" ] && [ -n "$key_path" ] && export VPS_SSH_KEY="$key_path"
 }
+
+# topology_apply_host_override <stack> <host_alias> <stack_dir>
+#
+# When --host is specified, overrides the topology target for this stack
+# and sources per-host env overrides from stacks/<stack>/.<host>.env if present.
+#
+# This enables deploying the same stack to multiple hosts with different
+# env vars (e.g., different ports, hostnames) per host.
+topology_apply_host_override() {
+  local stack="$1"
+  local host_alias="$2"
+  local stack_dir="$3"
+  topology_load
+
+  local host_spec="${_TOPO_HOSTS[$host_alias]:-}"
+  if [ -z "$host_spec" ]; then
+    fail "Unknown host alias: '$host_alias'. Check [hosts] in strut.conf."
+    return 1
+  fi
+
+  # Parse host spec and force-set VPS_* vars (override everything)
+  local conn_part key_path
+  conn_part="${host_spec%% *}"
+  key_path="${host_spec#* }"
+  [ "$key_path" = "$conn_part" ] && key_path=""
+
+  local user host port
+  if [[ "$conn_part" == *@* ]]; then
+    user="${conn_part%%@*}"
+    local host_port="${conn_part#*@}"
+  else
+    user="ubuntu"
+    local host_port="$conn_part"
+  fi
+
+  if [[ "$host_port" == *:* ]]; then
+    host="${host_port%%:*}"
+    port="${host_port#*:}"
+  else
+    host="$host_port"
+    port="22"
+  fi
+
+  export VPS_HOST="$host"
+  export VPS_USER="$user"
+  export VPS_PORT="$port"
+  [ -n "$key_path" ] && export VPS_SSH_KEY="$key_path"
+
+  # Source per-host env override if it exists
+  local host_env="$stack_dir/.$host_alias.env"
+  if [ -f "$host_env" ]; then
+    set -a; source "$host_env"; set +a
+  fi
+}

--- a/strut
+++ b/strut
@@ -684,7 +684,12 @@ export CMD_JSON="$JSON_FLAG"
 if [ -f "$ENV_FILE" ]; then
   set -a; source "$ENV_FILE" 2>/dev/null; set +a
 fi
-topology_apply_to_env "$STACK"
+if [ -n "$FLAGS_HOST" ]; then
+  # --host flag overrides topology target and applies per-host env
+  topology_apply_host_override "$STACK" "$FLAGS_HOST" "$STACK_DIR"
+else
+  topology_apply_to_env "$STACK"
+fi
 
 # Error context for fail/warn/error messages. Formats as
 # "stack/env/command" when all three are known, else falls back.


### PR DESCRIPTION
Adds global --host flag to target a specific host from the topology. Sources per-host env overrides from stacks/<stack>/.<host>.env. Closes #114