### PR TITLE
feat: add `strut <stack> init-secrets` command

### DIFF
--- a/lib/cmd_init_secrets.sh
+++ b/lib/cmd_init_secrets.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+# ==================================================
+# cmd_init_secrets.sh — Generate .env from template with auto-secrets
+# ==================================================
+# Usage: strut <stack> init-secrets [--env <name>] [--force] [--dry-run]
+#
+# Reads stacks/<stack>/.env.template, detects placeholder values and
+# generation hints, auto-generates secrets, and writes the output to
+# the appropriate .env file. Safe to re-run — never overwrites existing
+# values unless --force is passed.
+# ==================================================
+# Requires: lib/utils.sh sourced first
+
+set -euo pipefail
+
+# ── Secret generation helpers ─────────────────────────────────────────────────
+
+# _secrets_generate_hex <bytes>
+# Generate a random hex string of the specified byte length.
+_secrets_generate_hex() {
+  local bytes="${1:-32}"
+  openssl rand -hex "$bytes" 2>/dev/null || head -c "$bytes" /dev/urandom | od -A n -t x1 | tr -d ' \n' | head -c "$((bytes * 2))"
+}
+
+# _secrets_generate_base64 <bytes>
+# Generate a random base64 string of the specified byte length.
+_secrets_generate_base64() {
+  local bytes="${1:-32}"
+  openssl rand -base64 "$bytes" 2>/dev/null | tr -d '\n' | head -c "$((bytes * 4 / 3))"
+}
+
+# _secrets_is_placeholder <value>
+# Returns 0 if the value looks like a placeholder that should be replaced.
+_secrets_is_placeholder() {
+  local val="$1"
+  # Empty values are placeholders
+  [ -z "$val" ] && return 0
+  # Common placeholder patterns
+  case "$val" in
+    change-me*|changeme*|CHANGEME*|Change-Me*) return 0 ;;
+    your.*|your-*|YOUR_*|YOUR-*) return 0 ;;
+    xxxx*|XXXX*|xxx*|XXX*) return 0 ;;
+    ghp_xxx*) return 0 ;;
+    replace-*|REPLACE_*|replace_*) return 0 ;;
+    todo*|TODO*|fixme*|FIXME*) return 0 ;;
+    example*|EXAMPLE*) return 0 ;;
+    placeholder*|PLACEHOLDER*) return 0 ;;
+  esac
+  return 1
+}
+
+# _secrets_detect_type <key> <value> <comment>
+# Detects what kind of secret to generate based on key name, value, and comment.
+# Outputs: hex:<bytes> | base64:<bytes> | password:<length> | skip | keep
+_secrets_detect_type() {
+  local key="$1" value="$2" comment="${3:-}"
+
+  # Check for explicit generation hint in comment
+  # e.g. "# Generate with: openssl rand -hex 32"
+  if [[ "$comment" =~ openssl[[:space:]]+rand[[:space:]]+-hex[[:space:]]+([0-9]+) ]]; then
+    echo "hex:${BASH_REMATCH[1]}"
+    return
+  fi
+  if [[ "$comment" =~ openssl[[:space:]]+rand[[:space:]]+-base64[[:space:]]+([0-9]+) ]]; then
+    echo "base64:${BASH_REMATCH[1]}"
+    return
+  fi
+
+  # If value is not a placeholder, keep it as-is
+  if ! _secrets_is_placeholder "$value"; then
+    echo "keep"
+    return
+  fi
+
+  # Auto-detect based on key name
+  local key_lower
+  key_lower=$(echo "$key" | tr '[:upper:]' '[:lower:]')
+
+  case "$key_lower" in
+    *secret*|*jwt*)
+      echo "hex:32"
+      ;;
+    *password*|*passwd*|*pass)
+      echo "hex:16"
+      ;;
+    *salt*)
+      echo "hex:16"
+      ;;
+    *key*|*token*)
+      # Only auto-generate for generic keys, not API keys that need external values
+      if [[ "$key_lower" == *api_key* ]] || [[ "$key_lower" == *api_secret* ]]; then
+        echo "skip"
+      else
+        echo "hex:24"
+      fi
+      ;;
+    *encryption*)
+      echo "hex:32"
+      ;;
+    *)
+      echo "skip"
+      ;;
+  esac
+}
+
+# _secrets_process_template <template_file> [existing_env_file]
+# Processes a template file and outputs generated key=value lines.
+# If existing_env_file is provided, preserves existing values.
+# Output: one line per variable: KEY=VALUE (generated or preserved)
+_secrets_process_template() {
+  local template="$1"
+  local existing="${2:-}"
+  local force="${3:-false}"
+
+  # Load existing values into an associative array
+  declare -A existing_values=()
+  if [ -n "$existing" ] && [ -f "$existing" ]; then
+    while IFS= read -r line; do
+      [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+      if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
+        existing_values["${BASH_REMATCH[1]}"]="${BASH_REMATCH[2]}"
+      fi
+    done < "$existing"
+  fi
+
+  local prev_comment=""
+  local generated_count=0
+  local skipped_count=0
+  local preserved_count=0
+
+  while IFS= read -r line; do
+    # Track comments (they may contain generation hints)
+    if [[ "$line" =~ ^[[:space:]]*# ]]; then
+      prev_comment="$line"
+      echo "$line"
+      continue
+    fi
+
+    # Pass through empty lines
+    if [ -z "$line" ]; then
+      prev_comment=""
+      echo ""
+      continue
+    fi
+
+    # Parse KEY=VALUE
+    if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
+      local key="${BASH_REMATCH[1]}"
+      local value="${BASH_REMATCH[2]}"
+
+      # If value exists in the current env file and we're not forcing, preserve it
+      if [ "$force" != "true" ] && [ -n "${existing_values[$key]+x}" ]; then
+        local existing_val="${existing_values[$key]}"
+        if [ -n "$existing_val" ] && ! _secrets_is_placeholder "$existing_val"; then
+          echo "${key}=${existing_val}"
+          preserved_count=$((preserved_count + 1))
+          prev_comment=""
+          continue
+        fi
+      fi
+
+      # Detect what to generate
+      local gen_type
+      gen_type=$(_secrets_detect_type "$key" "$value" "$prev_comment")
+
+      case "$gen_type" in
+        hex:*)
+          local bytes="${gen_type#hex:}"
+          local new_val
+          new_val=$(_secrets_generate_hex "$bytes")
+          echo "${key}=${new_val}"
+          generated_count=$((generated_count + 1))
+          ;;
+        base64:*)
+          local bytes="${gen_type#base64:}"
+          local new_val
+          new_val=$(_secrets_generate_base64 "$bytes")
+          echo "${key}=${new_val}"
+          generated_count=$((generated_count + 1))
+          ;;
+        password:*)
+          local length="${gen_type#password:}"
+          local new_val
+          new_val=$(_secrets_generate_hex "$((length / 2))")
+          echo "${key}=${new_val}"
+          generated_count=$((generated_count + 1))
+          ;;
+        keep)
+          echo "${key}=${value}"
+          skipped_count=$((skipped_count + 1))
+          ;;
+        skip)
+          # Leave the placeholder — user must fill this manually
+          echo "${key}=${value}"
+          skipped_count=$((skipped_count + 1))
+          ;;
+      esac
+      prev_comment=""
+    else
+      # Pass through anything else
+      echo "$line"
+      prev_comment=""
+    fi
+  done < "$template"
+
+  # Output counts to stderr for the caller to pick up
+  echo "GENERATED=$generated_count" >&2
+  echo "SKIPPED=$skipped_count" >&2
+  echo "PRESERVED=$preserved_count" >&2
+}
+
+# ── Command handler ───────────────────────────────────────────────────────────
+
+_usage_init_secrets() {
+  echo "Usage: strut <stack> init-secrets [--env <name>] [--force] [--dry-run]"
+  echo ""
+  echo "Generate a populated .env file from the stack's .env.template."
+  echo "Auto-generates secrets for PASSWORD, SECRET, SALT, TOKEN, and KEY variables."
+  echo "Respects generation hints in comments (e.g. '# openssl rand -hex 32')."
+  echo ""
+  echo "Options:"
+  echo "  --env <name>   Target environment name (default: prod)"
+  echo "  --force        Overwrite existing values (default: preserve)"
+  echo "  --dry-run      Print generated env to stdout without writing"
+  echo ""
+  echo "Safety:"
+  echo "  - Never overwrites existing non-placeholder values (unless --force)"
+  echo "  - Safe to re-run — only fills in missing/placeholder values"
+  echo "  - Variables that need manual input (API keys, domains) are left as-is"
+  echo ""
+  echo "Examples:"
+  echo "  strut langfuse init-secrets --env prod"
+  echo "  strut my-app init-secrets --dry-run"
+  echo "  strut my-app init-secrets --env staging --force"
+}
+
+cmd_init_secrets() {
+  local stack="$CMD_STACK"
+  local stack_dir="$CMD_STACK_DIR"
+  local env_name="${CMD_ENV_NAME:-prod}"
+  local dry_run="${DRY_RUN:-false}"
+  local force=false
+
+  # Parse command-specific flags
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --force) force=true; shift ;;
+      *) shift ;;
+    esac
+  done
+
+  local template="$stack_dir/.env.template"
+  if [ ! -f "$template" ]; then
+    fail "No .env.template found at: $template"
+    return 1
+  fi
+
+  # Determine output path
+  local output_file="$CLI_ROOT/.${env_name}.env"
+
+  log "Generating secrets for stack '$stack' (env: $env_name)"
+  log "Template: $template"
+  [ "$force" = "true" ] && warn "Force mode: existing values will be overwritten"
+
+  # Process template
+  local result
+  local counts
+  counts=$(mktemp)
+  result=$(_secrets_process_template "$template" "$output_file" "$force" 2>"$counts")
+
+  local generated skipped preserved
+  generated=$(grep "^GENERATED=" "$counts" | cut -d= -f2)
+  skipped=$(grep "^SKIPPED=" "$counts" | cut -d= -f2)
+  preserved=$(grep "^PRESERVED=" "$counts" | cut -d= -f2)
+  rm -f "$counts"
+
+  # Dry-run mode
+  if [ "$dry_run" = "true" ]; then
+    echo ""
+    echo -e "${YELLOW}[DRY-RUN] Generated env contents:${NC}"
+    echo "─────────────────────────────────────────"
+    echo "$result"
+    echo "─────────────────────────────────────────"
+    echo ""
+    log "Generated: ${generated:-0} secrets"
+    log "Skipped: ${skipped:-0} (need manual input)"
+    log "Preserved: ${preserved:-0} (existing values kept)"
+    echo ""
+    echo -e "${YELLOW}[DRY-RUN] No file written.${NC}"
+    return 0
+  fi
+
+  # Write output
+  echo "$result" > "$output_file"
+  ok "Env file written: $output_file"
+  echo ""
+  log "Generated: ${generated:-0} secrets"
+  log "Skipped: ${skipped:-0} (need manual input)"
+  log "Preserved: ${preserved:-0} (existing values kept)"
+
+  # Warn about remaining placeholders
+  local remaining_placeholders=0
+  while IFS= read -r line; do
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+    if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
+      local val="${BASH_REMATCH[2]}"
+      if _secrets_is_placeholder "$val"; then
+        remaining_placeholders=$((remaining_placeholders + 1))
+      fi
+    fi
+  done <<< "$result"
+
+  if [ "$remaining_placeholders" -gt 0 ]; then
+    echo ""
+    warn "$remaining_placeholders variable(s) still need manual input"
+    warn "Edit $output_file to fill in: API keys, domains, external service URLs"
+  fi
+}

--- a/strut
+++ b/strut
@@ -137,6 +137,7 @@ source "$LIB/cmd_keys.sh"
 source "$LIB/cmd_remote.sh"
 source "$LIB/cmd_remote_init.sh"
 source "$LIB/cmd_ship.sh"
+source "$LIB/cmd_init_secrets.sh"
 source "$LIB/cmd_init.sh"
 source "$LIB/cmd_stop.sh"
 source "$LIB/cmd_skills.sh"
@@ -260,6 +261,7 @@ usage() {
   echo "  group      list|show|add|remove | <name> <command>             Stack groups (coordinated multi-stack ops)"
   echo "  scaffold <new-stack-name> [--recipe <name>]                    New stack (optionally from a recipe)"
   echo "  scaffold list [--json]                                         List available scaffold recipes"
+  echo "  init-secrets [--env <name>] [--force] [--dry-run]              Generate .env from template with auto-secrets"
   echo "  init     [--registry <type>] [--org <name>]                    Initialize new project"
   echo "  upgrade                                                        Upgrade strut to latest version"
   echo "  skills   [list|install] [--format kiro|claude|cursor|generic|all]  AI agent context"
@@ -705,6 +707,7 @@ if [ "$FLAGS_HELP" = "true" ]; then
     deploy)   _usage_deploy ;;
     rebuild)  _usage_rebuild ;;
     ship)     _usage_ship ;;
+    init-secrets) _usage_init_secrets ;;
     stop)     _usage_stop ;;
     health)   _usage_health ;;
     logs)     _usage_logs ;;
@@ -734,6 +737,7 @@ case "$COMMAND" in
   deploy)              cmd_deploy "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   rebuild)             cmd_rebuild "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   ship)                cmd_ship "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
+  init-secrets)        cmd_init_secrets "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   stop)                cmd_stop "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   health)              cmd_health ;;
   logs)                cmd_logs "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;

--- a/tests/test_init_secrets.bats
+++ b/tests/test_init_secrets.bats
@@ -1,0 +1,342 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_init_secrets.bats — Tests for lib/cmd_init_secrets.sh
+# ==================================================
+# Run:  bats tests/test_init_secrets.bats
+# Covers: _secrets_is_placeholder, _secrets_detect_type, _secrets_generate_hex,
+#         _secrets_process_template, cmd_init_secrets (dry-run)
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_utils
+
+  # Override output helpers
+  fail() { echo "FAIL: $1" >&2; return 1; }
+  ok()   { echo "OK: $*"; }
+  warn() { echo "WARN: $*" >&2; }
+  log()  { echo "LOG: $*"; }
+  error() { echo "ERROR: $*" >&2; }
+  export -f fail ok warn log error
+
+  # Color vars
+  export RED="" GREEN="" YELLOW="" BLUE="" NC=""
+
+  source "$CLI_ROOT/lib/cmd_init_secrets.sh"
+}
+
+teardown() { common_teardown; }
+
+# ── _secrets_is_placeholder ───────────────────────────────────────────────────
+
+@test "_secrets_is_placeholder: empty value is a placeholder" {
+  _secrets_is_placeholder ""
+}
+
+@test "_secrets_is_placeholder: change-me is a placeholder" {
+  _secrets_is_placeholder "change-me"
+  _secrets_is_placeholder "change-me-strong-password"
+  _secrets_is_placeholder "changeme"
+}
+
+@test "_secrets_is_placeholder: your.* is a placeholder" {
+  _secrets_is_placeholder "your.vps.ip.address"
+  _secrets_is_placeholder "your-domain.com"
+}
+
+@test "_secrets_is_placeholder: xxxx patterns are placeholders" {
+  _secrets_is_placeholder "xxxx"
+  _secrets_is_placeholder "ghp_xxxxxxxxxxxx"
+}
+
+@test "_secrets_is_placeholder: actual values are NOT placeholders" {
+  ! _secrets_is_placeholder "10.0.0.1"
+  ! _secrets_is_placeholder "ubuntu"
+  ! _secrets_is_placeholder "my-actual-value"
+  ! _secrets_is_placeholder "abc123def456"
+  ! _secrets_is_placeholder "postgres"
+  ! _secrets_is_placeholder "/home/ubuntu/strut"
+}
+
+@test "_secrets_is_placeholder: real passwords are NOT placeholders" {
+  ! _secrets_is_placeholder "a1b2c3d4e5f6g7h8"
+  ! _secrets_is_placeholder "supersecretvalue123"
+}
+
+# ── _secrets_detect_type ──────────────────────────────────────────────────────
+
+@test "_secrets_detect_type: detects hex hint from comment" {
+  result=$(_secrets_detect_type "NEXTAUTH_SECRET" "change-me" "# Generate with: openssl rand -hex 32")
+  [ "$result" = "hex:32" ]
+}
+
+@test "_secrets_detect_type: detects base64 hint from comment" {
+  result=$(_secrets_detect_type "ENCRYPTION_KEY" "" "# Generate with: openssl rand -base64 24")
+  [ "$result" = "base64:24" ]
+}
+
+@test "_secrets_detect_type: auto-detects password type from key name" {
+  result=$(_secrets_detect_type "POSTGRES_PASSWORD" "change-me" "")
+  [ "$result" = "hex:16" ]
+}
+
+@test "_secrets_detect_type: auto-detects secret type from key name" {
+  result=$(_secrets_detect_type "JWT_SECRET" "" "")
+  [ "$result" = "hex:32" ]
+
+  result=$(_secrets_detect_type "SESSION_SECRET" "change-me" "")
+  [ "$result" = "hex:32" ]
+}
+
+@test "_secrets_detect_type: auto-detects salt type from key name" {
+  result=$(_secrets_detect_type "PASSWORD_SALT" "change-me" "")
+  [ "$result" = "hex:16" ]
+}
+
+@test "_secrets_detect_type: skips API keys (need external values)" {
+  result=$(_secrets_detect_type "OPENAI_API_KEY" "change-me" "")
+  [ "$result" = "skip" ]
+}
+
+@test "_secrets_detect_type: keeps non-placeholder values" {
+  result=$(_secrets_detect_type "POSTGRES_DB" "app_db" "")
+  [ "$result" = "keep" ]
+
+  result=$(_secrets_detect_type "PORT" "8000" "")
+  [ "$result" = "keep" ]
+}
+
+@test "_secrets_detect_type: skips non-secret keys with placeholders" {
+  result=$(_secrets_detect_type "DOMAIN" "example.com" "")
+  [ "$result" = "skip" ]
+}
+
+# ── _secrets_generate_hex ─────────────────────────────────────────────────────
+
+@test "_secrets_generate_hex: generates correct length" {
+  result=$(_secrets_generate_hex 16)
+  # 16 bytes = 32 hex chars
+  [ ${#result} -eq 32 ]
+}
+
+@test "_secrets_generate_hex: generates different values each time" {
+  result1=$(_secrets_generate_hex 16)
+  result2=$(_secrets_generate_hex 16)
+  [ "$result1" != "$result2" ]
+}
+
+@test "_secrets_generate_hex: output is valid hex" {
+  result=$(_secrets_generate_hex 8)
+  [[ "$result" =~ ^[0-9a-f]+$ ]]
+}
+
+# ── _secrets_process_template ─────────────────────────────────────────────────
+
+@test "_secrets_process_template: generates secrets for password fields" {
+  cat > "$TEST_TMP/template" <<'EOF'
+POSTGRES_DB=app_db
+POSTGRES_PASSWORD=change-me
+API_SECRET_KEY=change-me-long-random-secret
+PORT=8000
+EOF
+
+  local output
+  output=$(_secrets_process_template "$TEST_TMP/template" "" "false" 2>/dev/null)
+
+  # POSTGRES_DB and PORT should be unchanged (not placeholders or real values)
+  echo "$output" | grep -q "^POSTGRES_DB=app_db$"
+  echo "$output" | grep -q "^PORT=8000$"
+
+  # POSTGRES_PASSWORD and API_SECRET_KEY should be generated (not change-me)
+  local pw
+  pw=$(echo "$output" | grep "^POSTGRES_PASSWORD=" | cut -d= -f2)
+  [ -n "$pw" ]
+  [ "$pw" != "change-me" ]
+  [[ "$pw" =~ ^[0-9a-f]+$ ]]
+}
+
+@test "_secrets_process_template: respects generation hints in comments" {
+  cat > "$TEST_TMP/template" <<'EOF'
+# Generate with: openssl rand -hex 32
+NEXTAUTH_SECRET=change-me
+EOF
+
+  local output
+  output=$(_secrets_process_template "$TEST_TMP/template" "" "false" 2>/dev/null)
+
+  local secret
+  secret=$(echo "$output" | grep "^NEXTAUTH_SECRET=" | cut -d= -f2)
+  # Should be 64 hex chars (32 bytes)
+  [ ${#secret} -eq 64 ]
+  [[ "$secret" =~ ^[0-9a-f]+$ ]]
+}
+
+@test "_secrets_process_template: preserves existing values" {
+  cat > "$TEST_TMP/template" <<'EOF'
+POSTGRES_PASSWORD=change-me
+JWT_SECRET=change-me
+EOF
+
+  cat > "$TEST_TMP/existing" <<'EOF'
+POSTGRES_PASSWORD=already-set-value
+JWT_SECRET=existing-jwt-secret
+EOF
+
+  local output
+  output=$(_secrets_process_template "$TEST_TMP/template" "$TEST_TMP/existing" "false" 2>/dev/null)
+
+  echo "$output" | grep -q "^POSTGRES_PASSWORD=already-set-value$"
+  echo "$output" | grep -q "^JWT_SECRET=existing-jwt-secret$"
+}
+
+@test "_secrets_process_template: force mode overwrites existing values" {
+  cat > "$TEST_TMP/template" <<'EOF'
+POSTGRES_PASSWORD=change-me
+EOF
+
+  cat > "$TEST_TMP/existing" <<'EOF'
+POSTGRES_PASSWORD=old-value
+EOF
+
+  local output
+  output=$(_secrets_process_template "$TEST_TMP/template" "$TEST_TMP/existing" "true" 2>/dev/null)
+
+  local pw
+  pw=$(echo "$output" | grep "^POSTGRES_PASSWORD=" | cut -d= -f2)
+  [ "$pw" != "old-value" ]
+  [ "$pw" != "change-me" ]
+}
+
+@test "_secrets_process_template: preserves comments and empty lines" {
+  cat > "$TEST_TMP/template" <<'EOF'
+# Database config
+POSTGRES_DB=mydb
+
+# Secrets
+POSTGRES_PASSWORD=change-me
+EOF
+
+  local output
+  output=$(_secrets_process_template "$TEST_TMP/template" "" "false" 2>/dev/null)
+
+  echo "$output" | grep -q "^# Database config$"
+  echo "$output" | grep -q "^# Secrets$"
+  echo "$output" | grep -q "^POSTGRES_DB=mydb$"
+}
+
+@test "_secrets_process_template: outputs generation counts to stderr" {
+  cat > "$TEST_TMP/template" <<'EOF'
+POSTGRES_DB=mydb
+POSTGRES_PASSWORD=change-me
+JWT_SECRET=change-me
+PORT=8000
+EOF
+
+  local counts
+  counts=$(_secrets_process_template "$TEST_TMP/template" "" "false" 2>&1 >/dev/null)
+
+  echo "$counts" | grep -q "GENERATED=2"
+  echo "$counts" | grep -q "SKIPPED=2"  # POSTGRES_DB=keep, PORT=keep → counted as skipped
+}
+
+# ── cmd_init_secrets ──────────────────────────────────────────────────────────
+
+@test "cmd_init_secrets: dry-run prints generated env without writing" {
+  local stack="test-stack"
+  mkdir -p "$TEST_TMP/stacks/$stack"
+  export CLI_ROOT="$TEST_TMP"
+
+  cat > "$TEST_TMP/stacks/$stack/.env.template" <<'EOF'
+POSTGRES_DB=app_db
+POSTGRES_PASSWORD=change-me
+PORT=3000
+EOF
+
+  export CMD_STACK="$stack"
+  export CMD_STACK_DIR="$TEST_TMP/stacks/$stack"
+  export CMD_ENV_NAME="prod"
+  export DRY_RUN=true
+
+  run cmd_init_secrets
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY-RUN"* ]]
+  [[ "$output" == *"POSTGRES_DB=app_db"* ]]
+  [[ "$output" == *"PORT=3000"* ]]
+  # Should have generated a secret for POSTGRES_PASSWORD
+  [[ "$output" != *"POSTGRES_PASSWORD=change-me"* ]]
+  # File should NOT exist
+  [ ! -f "$TEST_TMP/.prod.env" ]
+}
+
+@test "cmd_init_secrets: writes env file in normal mode" {
+  local stack="test-stack"
+  mkdir -p "$TEST_TMP/stacks/$stack"
+  export CLI_ROOT="$TEST_TMP"
+
+  cat > "$TEST_TMP/stacks/$stack/.env.template" <<'EOF'
+POSTGRES_PASSWORD=change-me
+PORT=3000
+EOF
+
+  export CMD_STACK="$stack"
+  export CMD_STACK_DIR="$TEST_TMP/stacks/$stack"
+  export CMD_ENV_NAME="prod"
+  export DRY_RUN=false
+
+  run cmd_init_secrets
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TMP/.prod.env" ]
+
+  # Verify contents
+  local pw
+  pw=$(grep "^POSTGRES_PASSWORD=" "$TEST_TMP/.prod.env" | cut -d= -f2)
+  [ -n "$pw" ]
+  [ "$pw" != "change-me" ]
+  grep -q "^PORT=3000$" "$TEST_TMP/.prod.env"
+}
+
+@test "cmd_init_secrets: fails when no template exists" {
+  local stack="test-stack"
+  mkdir -p "$TEST_TMP/stacks/$stack"
+  export CLI_ROOT="$TEST_TMP"
+
+  export CMD_STACK="$stack"
+  export CMD_STACK_DIR="$TEST_TMP/stacks/$stack"
+  export CMD_ENV_NAME="prod"
+  export DRY_RUN=false
+
+  # Use exit-based fail in run subshell
+  fail() { echo "FAIL: $1" >&2; exit 1; }
+  export -f fail
+
+  run cmd_init_secrets
+  [ "$status" -ne 0 ]
+  [[ "$output" == *".env.template"* ]]
+}
+
+@test "cmd_init_secrets: uses --env name for output file" {
+  local stack="test-stack"
+  mkdir -p "$TEST_TMP/stacks/$stack"
+  export CLI_ROOT="$TEST_TMP"
+
+  cat > "$TEST_TMP/stacks/$stack/.env.template" <<'EOF'
+APP_SECRET=change-me
+EOF
+
+  export CMD_STACK="$stack"
+  export CMD_STACK_DIR="$TEST_TMP/stacks/$stack"
+  export CMD_ENV_NAME="staging"
+  export DRY_RUN=false
+
+  run cmd_init_secrets
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TMP/.staging.env" ]
+}
+
+@test "_usage_init_secrets: prints usage information" {
+  run _usage_init_secrets
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage:"* ]]
+  [[ "$output" == *"--env"* ]]
+  [[ "$output" == *"--force"* ]]
+  [[ "$output" == *"--dry-run"* ]]
+}


### PR DESCRIPTION
## Summary

Adds `strut <stack> init-secrets [--env <name>] [--force] [--dry-run]` — generates a populated .env file from the stack's .env.template by auto-generating secrets.

Closes #119

## What it does

1. Reads `stacks/<stack>/.env.template`
2. Detects placeholder values (`change-me`, `xxxx`, `your.*`, empty)
3. Respects generation hints in comments (`# openssl rand -hex 32`)
4. Auto-detects secret type from key names (`*PASSWORD*` → 16 bytes hex, `*SECRET*` → 32 bytes hex)
5. Preserves existing non-placeholder values (safe to re-run)
6. Writes to `.<env>.env`

## Flags

- `--env <name>` — Target environment (default: prod)
- `--force` — Overwrite existing values
- `--dry-run` — Print to stdout without writing

## Testing

28 new tests covering:
- Placeholder detection (`_secrets_is_placeholder`)
- Type detection from key names and comments (`_secrets_detect_type`)
- Hex generation correctness (`_secrets_generate_hex`)
- Full template processing with preservation logic
- Command handler (dry-run, normal mode, error cases)

```bash
bats tests/test_init_secrets.bats  # 28 tests, 0 failures
shellcheck lib/cmd_init_secrets.sh  # clean
```