### PR TITLE
feat: first-run hooks for one-time stack initialization

### DIFF
--- a/lib/deploy.sh
+++ b/lib/deploy.sh
@@ -228,6 +228,8 @@ deploy_stack() {
   echo ""
 
   # Fire post_deploy lifecycle hook (non-fatal on failure)
+  # First, run one-time first-run hook if needed (after services are up)
+  fire_first_run_hook "$stack_dir" || warn "First-run hook failed — deploy continues"
   DEPLOY_STATUS="ok" fire_hook_or_warn post_deploy "$stack_dir"
 
   # Notification providers (Slack/Discord/webhook) subscribed to deploy.success

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -76,3 +76,68 @@ fire_hook_or_warn() {
   fi
   return 0
 }
+
+# ── First-run hooks ──────────────────────────────────────────────────────────
+
+# _first_run_marker_path <stack_dir>
+#
+# Returns the path to the .strut-initialized marker file.
+# For local deploys this is inside the stack dir. For remote deploys
+# the caller should resolve this path on the VPS.
+_first_run_marker_path() {
+  local stack_dir="$1"
+  echo "$stack_dir/.strut-initialized"
+}
+
+# first_run_needed <stack_dir>
+#
+# Returns 0 if a first-run hook exists AND the stack has not been initialized
+# (marker file is absent). Returns 1 otherwise (no hook or already initialized).
+first_run_needed() {
+  local stack_dir="$1"
+  local hooks_dir="$stack_dir/hooks"
+
+  # Check if a first-run hook exists
+  local hook_file=""
+  for candidate in "$hooks_dir/first_run.sh" "$hooks_dir/first-run.sh"; do
+    if [ -f "$candidate" ]; then
+      hook_file="$candidate"
+      break
+    fi
+  done
+  [ -z "$hook_file" ] && return 1
+
+  # Check if already initialized
+  local marker
+  marker=$(_first_run_marker_path "$stack_dir")
+  [ -f "$marker" ] && return 1
+
+  return 0
+}
+
+# fire_first_run_hook <stack_dir>
+#
+# Runs the first-run hook if it exists and the stack hasn't been initialized.
+# On success, creates the .strut-initialized marker with a timestamp.
+# Returns 0 if no hook needed, 0 on success, or non-zero on hook failure.
+fire_first_run_hook() {
+  local stack_dir="$1"
+
+  if ! first_run_needed "$stack_dir"; then
+    return 0
+  fi
+
+  log "First-run hook detected — running one-time initialization..."
+  if fire_hook first_run "$stack_dir"; then
+    local marker
+    marker=$(_first_run_marker_path "$stack_dir")
+    echo "initialized=$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$marker"
+    ok "First-run hook completed — stack initialized"
+    return 0
+  else
+    local rc=$?
+    error "First-run hook failed (exit $rc)"
+    warn "Stack NOT marked as initialized — hook will re-run on next deploy"
+    return "$rc"
+  fi
+}

--- a/tests/test_first_run_hooks.bats
+++ b/tests/test_first_run_hooks.bats
@@ -1,0 +1,185 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_first_run_hooks.bats — Tests for first-run hook lifecycle
+# ==================================================
+# Run:  bats tests/test_first_run_hooks.bats
+# Covers: first_run_needed, fire_first_run_hook, _first_run_marker_path
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_utils
+
+  # Override output helpers
+  fail() { echo "FAIL: $1" >&2; return 1; }
+  ok()   { echo "OK: $*"; }
+  warn() { echo "WARN: $*" >&2; }
+  log()  { echo "LOG: $*"; }
+  error() { echo "ERROR: $*" >&2; }
+  export -f fail ok warn log error
+
+  source "$CLI_ROOT/lib/hooks.sh"
+}
+
+teardown() { common_teardown; }
+
+# ── _first_run_marker_path ────────────────────────────────────────────────────
+
+@test "_first_run_marker_path: returns correct path" {
+  result=$(_first_run_marker_path "/opt/stacks/myapp")
+  [ "$result" = "/opt/stacks/myapp/.strut-initialized" ]
+}
+
+# ── first_run_needed ──────────────────────────────────────────────────────────
+
+@test "first_run_needed: returns 1 when no hook file exists" {
+  mkdir -p "$TEST_TMP/stack/hooks"
+  # No first_run.sh or first-run.sh
+  run first_run_needed "$TEST_TMP/stack"
+  [ "$status" -eq 1 ]
+}
+
+@test "first_run_needed: returns 1 when no hooks directory exists" {
+  mkdir -p "$TEST_TMP/stack"
+  run first_run_needed "$TEST_TMP/stack"
+  [ "$status" -eq 1 ]
+}
+
+@test "first_run_needed: returns 0 when hook exists and not initialized" {
+  mkdir -p "$TEST_TMP/stack/hooks"
+  cat > "$TEST_TMP/stack/hooks/first_run.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "init"
+EOF
+  chmod +x "$TEST_TMP/stack/hooks/first_run.sh"
+
+  first_run_needed "$TEST_TMP/stack"
+}
+
+@test "first_run_needed: returns 1 when already initialized" {
+  mkdir -p "$TEST_TMP/stack/hooks"
+  cat > "$TEST_TMP/stack/hooks/first_run.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "init"
+EOF
+  chmod +x "$TEST_TMP/stack/hooks/first_run.sh"
+
+  # Create marker
+  echo "initialized=2024-01-01T00:00:00Z" > "$TEST_TMP/stack/.strut-initialized"
+
+  run first_run_needed "$TEST_TMP/stack"
+  [ "$status" -eq 1 ]
+}
+
+@test "first_run_needed: supports dash-case hook name (first-run.sh)" {
+  mkdir -p "$TEST_TMP/stack/hooks"
+  cat > "$TEST_TMP/stack/hooks/first-run.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "init"
+EOF
+  chmod +x "$TEST_TMP/stack/hooks/first-run.sh"
+
+  first_run_needed "$TEST_TMP/stack"
+}
+
+# ── fire_first_run_hook ───────────────────────────────────────────────────────
+
+@test "fire_first_run_hook: no-op when no hook exists" {
+  mkdir -p "$TEST_TMP/stack"
+
+  run fire_first_run_hook "$TEST_TMP/stack"
+  [ "$status" -eq 0 ]
+  # No marker should be created
+  [ ! -f "$TEST_TMP/stack/.strut-initialized" ]
+}
+
+@test "fire_first_run_hook: no-op when already initialized" {
+  mkdir -p "$TEST_TMP/stack/hooks"
+  cat > "$TEST_TMP/stack/hooks/first_run.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "should not run"
+exit 1
+EOF
+  chmod +x "$TEST_TMP/stack/hooks/first_run.sh"
+  echo "initialized=2024-01-01T00:00:00Z" > "$TEST_TMP/stack/.strut-initialized"
+
+  run fire_first_run_hook "$TEST_TMP/stack"
+  [ "$status" -eq 0 ]
+  # Hook should not have run (it would fail if it did)
+  [[ "$output" != *"should not run"* ]]
+}
+
+@test "fire_first_run_hook: runs hook and creates marker on success" {
+  mkdir -p "$TEST_TMP/stack/hooks"
+  cat > "$TEST_TMP/stack/hooks/first_run.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "initializing stack"
+EOF
+  chmod +x "$TEST_TMP/stack/hooks/first_run.sh"
+
+  run fire_first_run_hook "$TEST_TMP/stack"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"First-run hook"* ]]
+  [[ "$output" == *"initialized"* ]]
+  # Marker should exist
+  [ -f "$TEST_TMP/stack/.strut-initialized" ]
+  # Marker should contain a timestamp
+  grep -q "initialized=" "$TEST_TMP/stack/.strut-initialized"
+}
+
+@test "fire_first_run_hook: does not create marker on hook failure" {
+  mkdir -p "$TEST_TMP/stack/hooks"
+  cat > "$TEST_TMP/stack/hooks/first_run.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "failing init"
+exit 1
+EOF
+  chmod +x "$TEST_TMP/stack/hooks/first_run.sh"
+
+  run fire_first_run_hook "$TEST_TMP/stack"
+  [ "$status" -ne 0 ]
+  # Marker should NOT be created
+  [ ! -f "$TEST_TMP/stack/.strut-initialized" ]
+  [[ "$output" == *"failed"* ]]
+}
+
+@test "fire_first_run_hook: subsequent call is no-op after success" {
+  mkdir -p "$TEST_TMP/stack/hooks"
+  cat > "$TEST_TMP/stack/hooks/first_run.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "first run"
+EOF
+  chmod +x "$TEST_TMP/stack/hooks/first_run.sh"
+
+  # First call — should run
+  fire_first_run_hook "$TEST_TMP/stack"
+  [ -f "$TEST_TMP/stack/.strut-initialized" ]
+
+  # Change hook to fail (to prove it's not re-run)
+  cat > "$TEST_TMP/stack/hooks/first_run.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "should not re-run"
+exit 1
+EOF
+
+  # Second call — should be a no-op
+  run fire_first_run_hook "$TEST_TMP/stack"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"should not re-run"* ]]
+}
+
+@test "fire_first_run_hook: hook receives stack environment" {
+  mkdir -p "$TEST_TMP/stack/hooks"
+  cat > "$TEST_TMP/stack/hooks/first_run.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "stack=${CMD_STACK:-unset}"
+echo "env=${CMD_ENV_NAME:-unset}"
+EOF
+  chmod +x "$TEST_TMP/stack/hooks/first_run.sh"
+
+  export CMD_STACK="my-stack"
+  export CMD_ENV_NAME="prod"
+
+  run fire_first_run_hook "$TEST_TMP/stack"
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TMP/stack/.strut-initialized" ]
+}


### PR DESCRIPTION
## Summary

Adds a `first_run` lifecycle hook that runs once on first deploy, then never again.

Closes #122

## How it works

1. Drop an executable `hooks/first_run.sh` (or `first-run.sh`) in your stack directory
2. On `strut <stack> deploy`, if no `.strut-initialized` marker exists, the hook runs after containers start
3. On success, a `.strut-initialized` marker is created with a timestamp
4. Subsequent deploys skip the hook entirely

## Use cases

- `docker compose run --rm synapse generate` (one-time key generation)
- Database seeding / initial migrations
- Admin user creation
- One-time configuration that only applies on first deploy

## API

- `first_run_needed <stack_dir>` — check if hook exists and stack isn't initialized
- `fire_first_run_hook <stack_dir>` — run the hook, create marker on success
- Hook receives all `CMD_*` environment variables

## Safety

- Hook failure does NOT create the marker → hook will retry on next deploy
- Integrated after containers start (services available) but before `post_deploy`
- Supports both snake_case (`first_run.sh`) and dash-case (`first-run.sh`)

## Testing

12 new tests:
```bash
bats tests/test_first_run_hooks.bats  # 12 tests, 0 failures
shellcheck lib/hooks.sh                # clean
```