### PR TITLE
feat: add `strut <host> provision` command

### DIFF
--- a/lib/cmd_provision.sh
+++ b/lib/cmd_provision.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# ==================================================
+# cmd_provision.sh — One-time host bootstrap via provision scripts
+# ==================================================
+# Usage: strut <host> provision [--script <path>] [--verify] [--dry-run]
+#
+# Looks for scripts/provision-<host>.sh in the project, SCPs it to the
+# target host, and executes it via SSH with TTY allocation for sudo.
+# Optionally runs only the verification section with --verify.
+# ==================================================
+# Requires: lib/utils.sh, lib/topology.sh sourced first
+
+set -euo pipefail
+
+_usage_provision() {
+  echo "Usage: strut <host> provision [options]"
+  echo ""
+  echo "Run a one-time provision script on a remote host."
+  echo ""
+  echo "Options:"
+  echo "  --script <path>   Path to provision script (default: scripts/provision-<host>.sh)"
+  echo "  --verify          Run only the verification section of the script"
+  echo "  --dry-run         Show what would be done without executing"
+  echo ""
+  echo "Convention:"
+  echo "  Place provision scripts at: scripts/provision-<host-alias>.sh"
+  echo "  The script runs on the remote host with sudo access."
+  echo ""
+  echo "Examples:"
+  echo "  strut harbor provision                           # Run scripts/provision-harbor.sh"
+  echo "  strut harbor provision --verify                  # Run verification only"
+  echo "  strut harbor provision --script ./my-setup.sh    # Custom script"
+  echo "  strut harbor provision --dry-run                 # Preview"
+}
+
+# _provision_find_script <host_alias> [explicit_path]
+#
+# Resolves the provision script path. Checks:
+# 1. Explicit --script path (if provided)
+# 2. scripts/provision-<host>.sh
+# 3. infra/scripts/provision-<host>.sh
+#
+# Outputs the resolved path to stdout, returns 1 if not found.
+_provision_find_script() {
+  local host_alias="$1"
+  local explicit="${2:-}"
+  local project_root="${PROJECT_ROOT:-$CLI_ROOT}"
+
+  # Explicit path takes precedence
+  if [ -n "$explicit" ]; then
+    if [ -f "$explicit" ]; then
+      echo "$explicit"
+      return 0
+    else
+      return 1
+    fi
+  fi
+
+  # Convention-based lookup
+  local candidates=(
+    "$project_root/scripts/provision-${host_alias}.sh"
+    "$project_root/infra/scripts/provision-${host_alias}.sh"
+  )
+
+  for candidate in "${candidates[@]}"; do
+    if [ -f "$candidate" ]; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+# _provision_remote_marker <ssh_opts> <user> <host> <deploy_dir>
+#
+# Checks if the remote host has a .provisioned marker.
+# Returns 0 if provisioned, 1 if not.
+_provision_remote_marker() {
+  local ssh_opts="$1" user="$2" host="$3" deploy_dir="$4"
+  # shellcheck disable=SC2029
+  ssh $ssh_opts "$user@$host" "test -f '$deploy_dir/.provisioned'" 2>/dev/null
+}
+
+# cmd_provision [options]
+cmd_provision() {
+  local host_alias="${CMD_STACK:-}"
+  local dry_run="${DRY_RUN:-false}"
+  local verify_only=false
+  local script_path=""
+
+  # Parse command-specific flags
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --script) script_path="$2"; shift 2 ;;
+      --verify) verify_only=true; shift ;;
+      --dry-run) dry_run=true; shift ;;
+      *) shift ;;
+    esac
+  done
+
+  [ -n "$host_alias" ] || { fail "Host alias required. Usage: strut <host> provision"; return 1; }
+
+  # Resolve the provision script
+  local script
+  if ! script=$(_provision_find_script "$host_alias" "$script_path"); then
+    if [ -n "$script_path" ]; then
+      fail "Provision script not found: $script_path"
+    else
+      fail "No provision script found. Expected: scripts/provision-${host_alias}.sh"
+    fi
+    return 1
+  fi
+
+  log "Provision script: $script"
+
+  # Resolve host connection info from topology
+  source "${STRUT_HOME:-$CLI_ROOT}/lib/topology.sh"
+  topology_load
+
+  local user host port key_path
+  if topology_has_host "$host_alias" 2>/dev/null; then
+    # host_alias is actually a host in the topology — resolve directly
+    local host_spec="${_TOPO_HOSTS[$host_alias]:-}"
+    if [ -n "$host_spec" ]; then
+      local conn_part
+      conn_part="${host_spec%% *}"
+      key_path="${host_spec#* }"
+      [ "$key_path" = "$conn_part" ] && key_path=""
+
+      if [[ "$conn_part" == *@* ]]; then
+        user="${conn_part%%@*}"
+        local host_port="${conn_part#*@}"
+      else
+        user="ubuntu"
+        local host_port="$conn_part"
+      fi
+
+      if [[ "$host_port" == *:* ]]; then
+        host="${host_port%%:*}"
+        port="${host_port#*:}"
+      else
+        host="$host_port"
+        port="22"
+      fi
+    fi
+  else
+    # Fall back to env vars
+    host="${VPS_HOST:-}"
+    user="${VPS_USER:-ubuntu}"
+    port="${VPS_PORT:-22}"
+    key_path="${VPS_SSH_KEY:-}"
+  fi
+
+  [ -n "$host" ] || { fail "Cannot resolve host for '$host_alias'. Add to [hosts] in strut.conf or set VPS_HOST."; return 1; }
+
+  local ssh_opts
+  ssh_opts=$(build_ssh_opts -p "$port" -k "$key_path" --tty)
+  local deploy_dir="${VPS_DEPLOY_DIR:-/home/$user/strut}"
+
+  print_banner "Provision: $host_alias"
+  log "Target: $user@$host:$port"
+  log "Script: $script"
+  [ "$verify_only" = "true" ] && log "Mode: verification only"
+  echo ""
+
+  # ── Dry-run ──────────────────────────────────────────────────────────────
+  if [ "$dry_run" = "true" ]; then
+    echo -e "${YELLOW}[DRY-RUN] Execution plan:${NC}"
+    run_cmd "Test SSH connectivity" ssh $ssh_opts "$user@$host" "echo ok"
+    run_cmd "Check if already provisioned" ssh $ssh_opts "$user@$host" "test -f $deploy_dir/.provisioned"
+    run_cmd "SCP provision script to host" scp $ssh_opts "$script" "$user@$host:/tmp/provision-${host_alias}.sh"
+    if [ "$verify_only" = "true" ]; then
+      run_cmd "Run verification section" ssh $ssh_opts "$user@$host" "sudo bash /tmp/provision-${host_alias}.sh --verify"
+    else
+      run_cmd "Execute provision script" ssh $ssh_opts "$user@$host" "sudo bash /tmp/provision-${host_alias}.sh"
+      run_cmd "Create provisioned marker" ssh $ssh_opts "$user@$host" "mkdir -p $deploy_dir && echo provisioned > $deploy_dir/.provisioned"
+    fi
+    run_cmd "Clean up remote script" ssh $ssh_opts "$user@$host" "rm -f /tmp/provision-${host_alias}.sh"
+    echo ""
+    echo -e "${YELLOW}[DRY-RUN] No changes made.${NC}"
+    return 0
+  fi
+
+  # ── Check if already provisioned ────────────────────────────────────────
+  if _provision_remote_marker "$ssh_opts" "$user" "$host" "$deploy_dir"; then
+    if [ "$verify_only" = "true" ]; then
+      log "Host already provisioned — running verification..."
+    else
+      warn "Host '$host_alias' appears already provisioned ($deploy_dir/.provisioned exists)"
+      warn "Use --verify to re-run verification, or delete the marker to re-provision"
+      return 0
+    fi
+  fi
+
+  # ── Execute ─────────────────────────────────────────────────────────────
+  log "Copying provision script to $host..."
+  local remote_script="/tmp/provision-${host_alias}.sh"
+  scp $ssh_opts "$script" "$user@$host:$remote_script" || fail "Failed to copy script"
+  ok "Script uploaded"
+
+  log "Executing provision script..."
+  local ssh_cmd="sudo bash $remote_script"
+  [ "$verify_only" = "true" ] && ssh_cmd="sudo bash $remote_script --verify"
+
+  # shellcheck disable=SC2029
+  if ssh $ssh_opts "$user@$host" "$ssh_cmd"; then
+    ok "Provision script completed successfully"
+
+    # Mark as provisioned (only on full provision, not verify)
+    if [ "$verify_only" != "true" ]; then
+      # shellcheck disable=SC2029
+      ssh $ssh_opts "$user@$host" "mkdir -p '$deploy_dir' && date -u +%Y-%m-%dT%H:%M:%SZ > '$deploy_dir/.provisioned'" || true
+      ok "Host marked as provisioned"
+    fi
+  else
+    local rc=$?
+    error "Provision script failed (exit $rc)"
+    return "$rc"
+  fi
+
+  # Clean up
+  # shellcheck disable=SC2029
+  ssh $ssh_opts "$user@$host" "rm -f '$remote_script'" 2>/dev/null || true
+
+  echo ""
+  ok "Provisioning complete for $host_alias ($host)"
+}

--- a/strut
+++ b/strut
@@ -136,6 +136,7 @@ source "$LIB/cmd_volumes.sh"
 source "$LIB/cmd_keys.sh"
 source "$LIB/cmd_remote.sh"
 source "$LIB/cmd_remote_init.sh"
+source "$LIB/cmd_provision.sh"
 source "$LIB/cmd_ship.sh"
 source "$LIB/cmd_init.sh"
 source "$LIB/cmd_stop.sh"
@@ -722,6 +723,7 @@ if [ "$FLAGS_HELP" = "true" ]; then
     rollback) _usage_rollback ;;
     diff)     _usage_diff ;;
     remote:init) _usage_remote_init ;;
+    provision) _usage_provision ;;
     lock)     _usage_lock ;;
     *)        usage ;;
   esac
@@ -749,6 +751,7 @@ case "$COMMAND" in
   shell)               cmd_shell ;;
   exec)                cmd_exec "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   remote:init)         cmd_remote_init "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
+  provision)           cmd_provision "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   status)              cmd_status ;;
   prune)               cmd_prune "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   volumes)             cmd_volumes "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;

--- a/tests/test_provision.bats
+++ b/tests/test_provision.bats
@@ -1,0 +1,185 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_provision.bats — Tests for lib/cmd_provision.sh
+# ==================================================
+# Run:  bats tests/test_provision.bats
+# Covers: _provision_find_script, _usage_provision, cmd_provision dry-run
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_utils
+
+  # Override output helpers
+  fail() { echo "FAIL: $1" >&2; return 1; }
+  ok()   { echo "OK: $*"; }
+  warn() { echo "WARN: $*" >&2; }
+  log()  { echo "LOG: $*"; }
+  error() { echo "ERROR: $*" >&2; }
+  print_banner() { echo "BANNER: $*"; }
+  run_cmd() { echo "RUN: $*"; }
+  export -f fail ok warn log error print_banner run_cmd
+
+  # Stub build_ssh_opts
+  build_ssh_opts() { echo "-o StrictHostKeyChecking=no"; }
+  export -f build_ssh_opts
+
+  source "$CLI_ROOT/lib/cmd_provision.sh"
+
+  export CLI_ROOT="$TEST_TMP"
+  export PROJECT_ROOT="$TEST_TMP"
+}
+
+teardown() { common_teardown; }
+
+# ── _usage_provision ──────────────────────────────────────────────────────────
+
+@test "_usage_provision: prints usage information" {
+  run _usage_provision
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage:"* ]]
+  [[ "$output" == *"--script"* ]]
+  [[ "$output" == *"--verify"* ]]
+  [[ "$output" == *"--dry-run"* ]]
+}
+
+@test "_usage_provision: includes examples" {
+  run _usage_provision
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Examples:"* ]]
+  [[ "$output" == *"provision"* ]]
+}
+
+# ── _provision_find_script ────────────────────────────────────────────────────
+
+@test "_provision_find_script: finds scripts/provision-<host>.sh" {
+  mkdir -p "$TEST_TMP/scripts"
+  touch "$TEST_TMP/scripts/provision-harbor.sh"
+
+  result=$(_provision_find_script "harbor")
+  [ "$result" = "$TEST_TMP/scripts/provision-harbor.sh" ]
+}
+
+@test "_provision_find_script: finds infra/scripts/provision-<host>.sh" {
+  mkdir -p "$TEST_TMP/infra/scripts"
+  touch "$TEST_TMP/infra/scripts/provision-compass.sh"
+
+  result=$(_provision_find_script "compass")
+  [ "$result" = "$TEST_TMP/infra/scripts/provision-compass.sh" ]
+}
+
+@test "_provision_find_script: prefers scripts/ over infra/scripts/" {
+  mkdir -p "$TEST_TMP/scripts" "$TEST_TMP/infra/scripts"
+  touch "$TEST_TMP/scripts/provision-node1.sh"
+  touch "$TEST_TMP/infra/scripts/provision-node1.sh"
+
+  result=$(_provision_find_script "node1")
+  [ "$result" = "$TEST_TMP/scripts/provision-node1.sh" ]
+}
+
+@test "_provision_find_script: uses explicit path when provided" {
+  mkdir -p "$TEST_TMP/custom"
+  touch "$TEST_TMP/custom/my-script.sh"
+
+  result=$(_provision_find_script "harbor" "$TEST_TMP/custom/my-script.sh")
+  [ "$result" = "$TEST_TMP/custom/my-script.sh" ]
+}
+
+@test "_provision_find_script: returns 1 when explicit path doesn't exist" {
+  run _provision_find_script "harbor" "/nonexistent/script.sh"
+  [ "$status" -eq 1 ]
+}
+
+@test "_provision_find_script: returns 1 when no script found" {
+  run _provision_find_script "unknown-host"
+  [ "$status" -eq 1 ]
+}
+
+# ── cmd_provision dry-run ─────────────────────────────────────────────────────
+
+@test "cmd_provision: dry-run shows execution plan" {
+  mkdir -p "$TEST_TMP/scripts"
+  echo "#!/bin/bash" > "$TEST_TMP/scripts/provision-harbor.sh"
+
+  # Stub topology
+  source "$CLI_ROOT/lib/topology.sh" 2>/dev/null || true
+  topology_load() { :; }
+  topology_has_host() { return 1; }
+  export -f topology_load topology_has_host
+  export VPS_HOST="10.0.0.1"
+  export VPS_USER="deploy"
+  export VPS_PORT="22"
+
+  export CMD_STACK="harbor"
+  export DRY_RUN=false
+
+  run cmd_provision --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY-RUN"* ]]
+  [[ "$output" == *"No changes made"* ]]
+  [[ "$output" == *"SSH connectivity"* ]] || [[ "$output" == *"ssh"* ]]
+  [[ "$output" == *"provision"* ]]
+}
+
+@test "cmd_provision: dry-run with --verify shows verify mode" {
+  mkdir -p "$TEST_TMP/scripts"
+  echo "#!/bin/bash" > "$TEST_TMP/scripts/provision-harbor.sh"
+
+  topology_load() { :; }
+  topology_has_host() { return 1; }
+  export -f topology_load topology_has_host
+  export VPS_HOST="10.0.0.1"
+  export VPS_USER="deploy"
+
+  export CMD_STACK="harbor"
+  export DRY_RUN=false
+
+  run cmd_provision --verify --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--verify"* ]]
+}
+
+@test "cmd_provision: fails when no host alias provided" {
+  export CMD_STACK=""
+
+  fail() { echo "FAIL: $1" >&2; exit 1; }
+  export -f fail
+
+  run cmd_provision --dry-run
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Host alias required"* ]]
+}
+
+@test "cmd_provision: fails when no provision script found" {
+  export CMD_STACK="unknown-host"
+
+  fail() { echo "FAIL: $1" >&2; exit 1; }
+  export -f fail
+
+  topology_load() { :; }
+  topology_has_host() { return 1; }
+  export -f topology_load topology_has_host
+  export VPS_HOST="10.0.0.1"
+
+  run cmd_provision --dry-run
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"No provision script found"* ]] || [[ "$output" == *"provision-unknown-host.sh"* ]]
+}
+
+@test "cmd_provision: fails when host cannot be resolved" {
+  mkdir -p "$TEST_TMP/scripts"
+  echo "#!/bin/bash" > "$TEST_TMP/scripts/provision-orphan.sh"
+
+  export CMD_STACK="orphan"
+  unset VPS_HOST
+
+  topology_load() { :; }
+  topology_has_host() { return 1; }
+  export -f topology_load topology_has_host
+
+  fail() { echo "FAIL: $1" >&2; exit 1; }
+  export -f fail
+
+  run cmd_provision --dry-run
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Cannot resolve host"* ]]
+}


### PR DESCRIPTION
## Summary

Adds `strut <host> provision [--script <path>] [--verify] [--dry-run]` for one-time host bootstrapping.

Closes #120

## How it works

1. Looks for `scripts/provision-<host>.sh` (convention-based)
2. SCPs the script to the target host
3. Executes via SSH with TTY allocation (for sudo prompts)
4. Creates a `.provisioned` marker on success
5. Subsequent runs detect the marker and skip (unless `--verify`)

## Script Discovery

Checks in order:
1. Explicit `--script <path>` if provided
2. `scripts/provision-<host-alias>.sh`
3. `infra/scripts/provision-<host-alias>.sh`

## Host Resolution

Resolves from:
1. `[hosts]` section in `strut.conf` (topology)
2. `VPS_HOST` / `VPS_USER` / `VPS_PORT` env vars

## Testing

13 tests:
```bash
bats tests/test_provision.bats   # 13 tests, 0 failures
shellcheck lib/cmd_provision.sh  # clean
```