### PR TITLE
feat: `secrets hydrate` — populate .env from a secret manager (#144)

### DIFF
--- a/.kiro/steering/stack-management.md
+++ b/.kiro/steering/stack-management.md
@@ -111,7 +111,8 @@ strut <stack> shell --env prod                # Interactive SSH
 strut <stack> exec "docker ps" --env prod     # Single command
 
 # Secrets / Env file management
-strut <stack> init-secrets --env prod         # Generate .env from template
+strut <stack> init-secrets --env prod         # Generate .env from template (random values)
+strut <stack> secrets hydrate --env prod      # Build .env from template via a secret manager
 strut <stack> secrets push --env prod         # Upload .env to VPS
 strut <stack> secrets pull --env prod         # Download .env from VPS
 strut <stack> secrets diff --env prod         # Compare local vs remote keys

--- a/lib/cmd_secrets.sh
+++ b/lib/cmd_secrets.sh
@@ -21,6 +21,7 @@ _usage_secrets() {
   echo "Sync environment files between local and VPS."
   echo ""
   echo "Subcommands:"
+  echo "  hydrate    Build local .env from a template, resolving secret references"
   echo "  push       Upload local .env to VPS (SCP, mode 600)"
   echo "  pull       Download .env from VPS to local"
   echo "  diff       Show differences between local and remote .env"
@@ -29,9 +30,16 @@ _usage_secrets() {
   echo "Options:"
   echo "  --env <name>   Environment name (default: prod)"
   echo "  --dry-run      Preview without executing"
-  echo "  --force        Overwrite remote file without confirmation"
+  echo "  --force        Overwrite local/remote file without confirmation"
+  echo ""
+  echo "Secret references (in a .env template, resolved by 'hydrate'):"
+  echo "  KEY=vault://<item>     Vaultwarden/Bitwarden item (via 'bw')"
+  echo "  KEY=exec://<command>   Stdout of a command"
+  echo "  KEY=file://<path>      Contents of a file (e.g. /run/secrets/x)"
+  echo "  KEY=plain-value        Literal — copied as-is"
   echo ""
   echo "Examples:"
+  echo "  strut my-app secrets hydrate --env prod      # template -> .prod.env"
   echo "  strut my-app secrets push --env prod"
   echo "  strut my-app secrets pull --env prod"
   echo "  strut my-app secrets diff --env prod"
@@ -479,6 +487,133 @@ _secrets_validate() {
   fi
 }
 
+# _secrets_hydrate (reads CMD_*)
+# Materialise the local .<env>.env from a template, resolving any
+# <provider>://<ref> references through the configured secret source(s).
+# Literal values pass through unchanged. Looks up the template stack-level
+# first, then project-level, preferring an env-specific name over .env.template.
+_secrets_hydrate() {
+  local stack="$CMD_STACK"
+  local stack_dir="$CMD_STACK_DIR"
+  local env_name="${CMD_ENV_NAME:-prod}"
+  local dry_run="${DRY_RUN:-false}"
+  local force=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --force) force=true; shift ;;
+      *) shift ;;
+    esac
+  done
+
+  # Resolve the template.
+  local template="" cand
+  for cand in \
+    "$stack_dir/.${env_name}.env.template" \
+    "$CLI_ROOT/.${env_name}.env.template" \
+    "$stack_dir/.env.template" \
+    "$CLI_ROOT/.env.template"; do
+    if [ -f "$cand" ]; then template="$cand"; break; fi
+  done
+  if [ -z "$template" ]; then
+    fail "No env template found for '$env_name' (looked for stacks/$stack/.${env_name}.env.template or .env.template)"
+    return 1
+  fi
+
+  # Output is written next to the template, matching the stack-first then
+  # project-level search order that _secrets_resolve_local_env (and therefore
+  # `secrets push`) uses to find it.
+  local out_file
+  out_file="$(dirname "$template")/.${env_name}.env"
+
+  print_banner "Secrets Hydrate"
+  log "Stack: $stack | Env: $env_name"
+  log "Template: $template"
+  log "Output: $out_file"
+  echo ""
+
+  # Pass 1 — scan the template. Collect the referenced provider schemes and,
+  # for --dry-run, report each mapping and return before touching credentials
+  # or disk (preview must work without unlocking the providers).
+  local schemes_seen=() value scheme key ref_count=0
+  while IFS= read -r line || [ -n "$line" ]; do
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+    [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]] || continue
+    key="${BASH_REMATCH[1]}"; value="${BASH_REMATCH[2]}"
+    if scheme=$(secrets_reference_scheme "$value"); then
+      ref_count=$((ref_count + 1))
+      [ "$dry_run" = "true" ] && log "  $key  <-  ${scheme}://$(secrets_reference_target "$value")"
+      case " ${schemes_seen[*]-} " in
+        *" $scheme "*) ;;
+        *) schemes_seen+=("$scheme") ;;
+      esac
+    fi
+  done < "$template"
+
+  if [ "$dry_run" = "true" ]; then
+    echo ""
+    log "[DRY-RUN] $ref_count reference(s) would be resolved; literals copied as-is."
+    echo -e "${YELLOW}[DRY-RUN] No file written.${NC}"
+    return 0
+  fi
+
+  if [ -f "$out_file" ] && [ "$force" != "true" ]; then
+    warn "Output already exists: $out_file"
+    warn "Use --force to overwrite."
+    return 1
+  fi
+
+  # Pre-flight every referenced provider before writing anything, so a missing
+  # tool or session aborts with no half-written secret file.
+  local s
+  for s in ${schemes_seen[@]+"${schemes_seen[@]}"}; do
+    secrets_provider_available "$s" || return 1
+  done
+
+  # Pass 2 — resolve into a 600-mode temp file in the destination directory,
+  # then rename into place (atomic, same filesystem, never transits /tmp).
+  local resolved_count=0 literal_count=0 rv
+  local tmp_out
+  tmp_out=$(mktemp "$(dirname "$out_file")/.hydrate.XXXXXX") || { fail "Could not create temp file"; return 1; }
+  chmod 600 "$tmp_out"
+  trap 'rm -f "$tmp_out"' RETURN
+  while IFS= read -r line || [ -n "$line" ]; do
+    if [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]]; then
+      printf '%s\n' "$line" >> "$tmp_out"
+      continue
+    fi
+    if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
+      key="${BASH_REMATCH[1]}"; value="${BASH_REMATCH[2]}"
+      if scheme=$(secrets_reference_scheme "$value"); then
+        if ! rv=$(secrets_resolve_reference "$value"); then
+          fail "Failed to resolve $key from ${scheme}://$(secrets_reference_target "$value")"
+          return 1
+        fi
+        # .env values are single-line (docker compose env_file can't represent
+        # a newline); a multi-line secret means the wrong target — fail loudly
+        # rather than emit a corrupt file. Mount multi-line secrets as files.
+        if [[ "$rv" == *$'\n'* ]]; then
+          fail "$key resolved to a multi-line value, which a .env file can't hold — mount it as a file (e.g. a Docker/compose secret) instead"
+          return 1
+        fi
+        printf '%s=%s\n' "$key" "$rv" >> "$tmp_out"
+        resolved_count=$((resolved_count + 1))
+      else
+        printf '%s\n' "$line" >> "$tmp_out"
+        literal_count=$((literal_count + 1))
+      fi
+    else
+      printf '%s\n' "$line" >> "$tmp_out"
+    fi
+  done < "$template"
+
+  mv "$tmp_out" "$out_file"
+  trap - RETURN
+  chmod 600 "$out_file"
+  echo ""
+  ok "Hydrated $out_file ($resolved_count resolved, $literal_count literal)"
+}
+
 # ── Dispatch ──────────────────────────────────────────────────────────────────
 
 cmd_secrets() {
@@ -486,6 +621,7 @@ cmd_secrets() {
   shift 2>/dev/null || true
 
   case "$subcmd" in
+    hydrate)  _secrets_hydrate "$@" ;;
     push)     _secrets_push "$@" ;;
     pull)     _secrets_pull "$@" ;;
     diff)     _secrets_diff "$@" ;;

--- a/lib/secrets_providers.sh
+++ b/lib/secrets_providers.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# ==================================================
+# secrets_providers.sh — Pluggable secret sources for `secrets hydrate`
+# ==================================================
+# Lets secret values live in an external manager (Vaultwarden/Bitwarden, the
+# stdout of a command, or a file) instead of plaintext on disk. A template
+# value written as "<scheme>://<ref>" is resolved at hydrate time; any other
+# value is copied through verbatim, so the default behaviour is unchanged.
+#
+# Reference syntax (in a .env template):
+#   KEY=vault://<item-name>     Vaultwarden / Bitwarden item, via the `bw` CLI
+#   KEY=exec://<command>        Stdout of a shell command (e.g. a cloud SM CLI)
+#   KEY=file://<path>           Contents of a file (e.g. /run/secrets/<x>)
+#   KEY=plain-value             Literal — copied as-is (default)
+#
+# Add a provider: define `secrets_provider__<scheme>()` taking the ref string
+# on $1 and printing the resolved value to stdout (and `fail`ing on error);
+# optionally a `secrets_provider__<scheme>_check()` that pre-flights tooling
+# and credentials. Then add <scheme> to SECRETS_PROVIDERS below.
+#
+# Requires: lib/utils.sh sourced first (fail/warn/log/ok)
+# Provides: secrets_reference_scheme, secrets_is_reference,
+#           secrets_reference_target, secrets_provider_available,
+#           secrets_resolve_reference
+# ==================================================
+
+set -euo pipefail
+
+# Registered provider schemes (space-separated). Only these schemes are treated
+# as references — a normal value like "postgres://..." stays literal.
+SECRETS_PROVIDERS="${SECRETS_PROVIDERS:-vault exec file}"
+
+# secrets_reference_scheme <value>
+# If <value> is "<scheme>://..." and <scheme> is registered, echo the scheme
+# and return 0. Otherwise echo nothing and return 1 (the value is literal).
+secrets_reference_scheme() {
+  local value="$1"
+  local scheme
+  if [[ "$value" =~ ^([a-z][a-z0-9+.-]*):// ]]; then
+    scheme="${BASH_REMATCH[1]}"
+    case " $SECRETS_PROVIDERS " in
+      *" $scheme "*) echo "$scheme"; return 0 ;;
+    esac
+  fi
+  return 1
+}
+
+# secrets_is_reference <value> — 0 if the value is a resolvable reference.
+secrets_is_reference() {
+  secrets_reference_scheme "$1" >/dev/null 2>&1
+}
+
+# secrets_reference_target <value> — the part after "<scheme>://".
+secrets_reference_target() {
+  local value="$1"
+  printf '%s' "${value#*://}"
+}
+
+# secrets_provider_available <scheme>
+# Returns 0 if the provider can run (tools present, creds configured). Runs the
+# provider's optional `_check` hook; providers without one are assumed ready.
+secrets_provider_available() {
+  local scheme="$1"
+  if declare -F "secrets_provider__${scheme}_check" >/dev/null 2>&1; then
+    "secrets_provider__${scheme}_check"
+    return $?
+  fi
+  return 0
+}
+
+# secrets_resolve_reference <value>
+# Resolve a "<scheme>://<ref>" reference to its value on stdout. A non-reference
+# value is echoed unchanged.
+secrets_resolve_reference() {
+  local value="$1"
+  local scheme target
+  if ! scheme=$(secrets_reference_scheme "$value"); then
+    printf '%s' "$value"
+    return 0
+  fi
+  target=$(secrets_reference_target "$value")
+  "secrets_provider__${scheme}" "$target"
+}
+
+# ── Providers ─────────────────────────────────────────────────────────────────
+
+# vault:// — Vaultwarden / Bitwarden item resolved via the `bw` CLI. The ref is
+# the item name or id; the password field is preferred, falling back to notes.
+secrets_provider__vault_check() {
+  if ! command -v bw >/dev/null 2>&1; then
+    fail "secrets: 'bw' (Bitwarden/Vaultwarden CLI) not found — install it to use vault:// references"
+    return 1
+  fi
+  if [ -z "${BW_SESSION:-}" ] && [ -z "${BW_CLIENTID:-}" ]; then
+    fail "secrets: no Vaultwarden session — run: export BW_SESSION=\"\$(bw unlock --raw)\" (or set BW_CLIENTID/BW_CLIENTSECRET)"
+    return 1
+  fi
+  return 0
+}
+
+secrets_provider__vault() {
+  local item="$1"
+  local val
+  if val=$(bw get password "$item" 2>/dev/null) && [ -n "$val" ]; then
+    printf '%s' "$val"
+    return 0
+  fi
+  if val=$(bw get notes "$item" 2>/dev/null) && [ -n "$val" ]; then
+    printf '%s' "$val"
+    return 0
+  fi
+  fail "secrets: vault item '$item' not found or empty"
+  return 1
+}
+
+# exec:// — value is the stdout of a command (trailing newlines trimmed by $()).
+# Note: the command runs with the caller's privileges and is visible in `ps`
+# while running. Templates are user-authored, so this is execution-by-consent;
+# don't hydrate a template you didn't write.
+secrets_provider__exec() {
+  local cmd="$1"
+  local out
+  if ! out=$(bash -c "$cmd"); then
+    fail "secrets: exec reference failed: $cmd"
+    return 1
+  fi
+  printf '%s' "$out"
+}
+
+# file:// — value is the contents of a file (trailing newlines trimmed by $()).
+secrets_provider__file() {
+  local path="$1"
+  if [ ! -f "$path" ]; then
+    fail "secrets: file reference not found: $path"
+    return 1
+  fi
+  printf '%s' "$(cat "$path")"
+}

--- a/strut
+++ b/strut
@@ -157,6 +157,7 @@ source "$LIB/cmd_cert.sh"
 
 source "$LIB/cmd_gateway.sh"
 source "$LIB/cmd_ship.sh"
+source "$LIB/secrets_providers.sh"
 source "$LIB/cmd_secrets.sh"
 source "$LIB/cmd_init_secrets.sh"
 source "$LIB/cmd_init.sh"

--- a/tests/test_secrets_providers.bats
+++ b/tests/test_secrets_providers.bats
@@ -1,0 +1,246 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_secrets_providers.bats — Tests for lib/secrets_providers.sh
+#                                      and `secrets hydrate`
+# ==================================================
+# Run:  bats tests/test_secrets_providers.bats
+# Covers: secrets_reference_scheme, secrets_is_reference,
+#         secrets_reference_target, secrets_provider_available,
+#         secrets_resolve_reference, exec/file/vault providers,
+#         _secrets_hydrate (template -> .env, dry-run, --force, fail-fast)
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_utils
+
+  # Override output helpers so they don't exit the runner.
+  fail()  { echo "FAIL: $1" >&2; return 1; }
+  ok()    { echo "OK: $*"; }
+  warn()  { echo "WARN: $*" >&2; }
+  log()   { echo "LOG: $*"; }
+  error() { echo "ERROR: $*" >&2; }
+  print_banner() { echo "== $* =="; }
+  export -f fail ok warn log error print_banner
+
+  export RED="" GREEN="" YELLOW="" BLUE="" NC=""
+
+  source "$CLI_ROOT/lib/secrets_providers.sh"
+  source "$CLI_ROOT/lib/cmd_secrets.sh"
+}
+
+teardown() { common_teardown; }
+
+# ── secrets_reference_scheme ──────────────────────────────────────────────────
+
+@test "secrets_reference_scheme: detects registered schemes" {
+  run secrets_reference_scheme "vault://myapp.db-password"
+  [ "$status" -eq 0 ]; [ "$output" = "vault" ]
+  run secrets_reference_scheme "exec://aws secretsmanager get x"
+  [ "$status" -eq 0 ]; [ "$output" = "exec" ]
+  run secrets_reference_scheme "file:///run/secrets/token"
+  [ "$status" -eq 0 ]; [ "$output" = "file" ]
+}
+
+@test "secrets_reference_scheme: literals and unknown schemes are not references" {
+  run secrets_reference_scheme "hunter2"
+  [ "$status" -ne 0 ]
+  # A normal connection string must NOT be mistaken for a reference.
+  run secrets_reference_scheme "postgres://user:pass@host:5432/db"
+  [ "$status" -ne 0 ]
+  run secrets_reference_scheme "https://example.com"
+  [ "$status" -ne 0 ]
+}
+
+@test "secrets_is_reference: boolean wrapper" {
+  secrets_is_reference "vault://x"
+  ! secrets_is_reference "plain"
+}
+
+@test "secrets_reference_target: strips the scheme prefix" {
+  run secrets_reference_target "vault://myapp.db-password"
+  [ "$output" = "myapp.db-password" ]
+  run secrets_reference_target "exec://cat /run/secrets/x"
+  [ "$output" = "cat /run/secrets/x" ]
+}
+
+# ── exec:// and file:// providers ─────────────────────────────────────────────
+
+@test "secrets_provider__exec: returns command stdout, trimmed" {
+  run secrets_provider__exec "printf 'super-secret\n'"
+  [ "$status" -eq 0 ]; [ "$output" = "super-secret" ]
+}
+
+@test "secrets_provider__exec: non-zero command fails" {
+  run secrets_provider__exec "exit 3"
+  [ "$status" -ne 0 ]
+}
+
+@test "secrets_provider__file: returns file contents, trimmed" {
+  printf 'file-secret\n' > "$TEST_TMP/s"
+  run secrets_provider__file "$TEST_TMP/s"
+  [ "$status" -eq 0 ]; [ "$output" = "file-secret" ]
+}
+
+@test "secrets_provider__file: missing file fails" {
+  run secrets_provider__file "$TEST_TMP/nope"
+  [ "$status" -ne 0 ]
+}
+
+# ── vault:// provider (with a fake `bw`) ──────────────────────────────────────
+
+@test "secrets_provider__vault: reads the password field via bw" {
+  bw() { [ "$1" = "get" ] && [ "$2" = "password" ] && echo "vw-password"; }
+  export -f bw
+  run secrets_provider__vault "myapp.db-password"
+  [ "$status" -eq 0 ]; [ "$output" = "vw-password" ]
+}
+
+@test "secrets_provider__vault: falls back to notes when no password" {
+  bw() {
+    [ "$1" = "get" ] && [ "$2" = "password" ] && return 1
+    [ "$1" = "get" ] && [ "$2" = "notes" ] && echo "vw-note-secret"
+  }
+  export -f bw
+  run secrets_provider__vault "myapp.token"
+  [ "$status" -eq 0 ]; [ "$output" = "vw-note-secret" ]
+}
+
+@test "secrets_provider__vault_check: fails without a session" {
+  bw() { :; }; export -f bw
+  unset BW_SESSION BW_CLIENTID
+  run secrets_provider__vault_check
+  [ "$status" -ne 0 ]
+}
+
+@test "secrets_provider__vault_check: passes with BW_SESSION + bw present" {
+  bw() { :; }; export -f bw
+  export BW_SESSION="fake"
+  run secrets_provider__vault_check
+  [ "$status" -eq 0 ]
+}
+
+# ── secrets_resolve_reference ─────────────────────────────────────────────────
+
+@test "secrets_resolve_reference: literal passes through unchanged" {
+  run secrets_resolve_reference "just-a-value"
+  [ "$status" -eq 0 ]; [ "$output" = "just-a-value" ]
+}
+
+@test "secrets_resolve_reference: dispatches to the right provider" {
+  printf 'abc\n' > "$TEST_TMP/v"
+  run secrets_resolve_reference "file://$TEST_TMP/v"
+  [ "$status" -eq 0 ]; [ "$output" = "abc" ]
+}
+
+# ── _secrets_hydrate (end to end) ─────────────────────────────────────────────
+
+_setup_stack() {
+  export CLI_ROOT_SAVE="$CLI_ROOT"
+  export CMD_STACK="myapp"
+  export CMD_STACK_DIR="$TEST_TMP/stacks/myapp"
+  export CMD_ENV_NAME="prod"
+  export DRY_RUN="false"
+  mkdir -p "$CMD_STACK_DIR"
+}
+
+@test "_secrets_hydrate: resolves references and copies literals" {
+  _setup_stack
+  printf 'file-val\n' > "$TEST_TMP/secret_file"
+  cat > "$CMD_STACK_DIR/.prod.env.template" <<EOF
+# connection (literal)
+VPS_HOST=1.2.3.4
+DATABASE_URL=postgres://u:p@h:5432/db
+# secrets (resolved)
+API_TOKEN=exec://printf 'tok-123'
+TLS_KEY=file://$TEST_TMP/secret_file
+EOF
+
+  run _secrets_hydrate
+  [ "$status" -eq 0 ]
+
+  local out="$CMD_STACK_DIR/.prod.env"
+  [ -f "$out" ]
+  grep -q '^VPS_HOST=1.2.3.4$' "$out"
+  grep -q '^DATABASE_URL=postgres://u:p@h:5432/db$' "$out"
+  grep -q '^API_TOKEN=tok-123$' "$out"
+  grep -q '^TLS_KEY=file-val$' "$out"
+  # comments preserved
+  grep -q '^# connection (literal)$' "$out"
+}
+
+@test "_secrets_hydrate: output file is mode 600" {
+  _setup_stack
+  printf 'API_TOKEN=exec://printf x\n' > "$CMD_STACK_DIR/.prod.env.template"
+  run _secrets_hydrate
+  [ "$status" -eq 0 ]
+  local perms
+  perms=$(stat -c '%a' "$CMD_STACK_DIR/.prod.env" 2>/dev/null || stat -f '%Lp' "$CMD_STACK_DIR/.prod.env")
+  [ "$perms" = "600" ]
+}
+
+@test "_secrets_hydrate: dry-run writes no file" {
+  _setup_stack
+  export DRY_RUN="true"
+  printf 'API_TOKEN=exec://printf x\n' > "$CMD_STACK_DIR/.prod.env.template"
+  run _secrets_hydrate
+  [ "$status" -eq 0 ]
+  [ ! -f "$CMD_STACK_DIR/.prod.env" ]
+}
+
+@test "_secrets_hydrate: dry-run previews without provider credentials" {
+  # A vault:// ref must be previewable even with no bw/session — dry-run must
+  # not pre-flight providers.
+  _setup_stack
+  export DRY_RUN="true"
+  bw() { return 1; }; export -f bw          # bw present but unusable
+  unset BW_SESSION BW_CLIENTID
+  printf 'DB_PASS=vault://my-app.db-password\n' > "$CMD_STACK_DIR/.prod.env.template"
+  run _secrets_hydrate
+  [ "$status" -eq 0 ]
+  [ ! -f "$CMD_STACK_DIR/.prod.env" ]
+}
+
+@test "_secrets_hydrate: rejects a multi-line secret, no file written" {
+  _setup_stack
+  printf -- '-----BEGIN KEY-----\nabc\n-----END KEY-----\n' > "$TEST_TMP/pem"
+  printf 'TLS_KEY=file://%s\n' "$TEST_TMP/pem" > "$CMD_STACK_DIR/.prod.env.template"
+  run _secrets_hydrate
+  [ "$status" -ne 0 ]
+  [ ! -f "$CMD_STACK_DIR/.prod.env" ]
+}
+
+@test "_secrets_hydrate: refuses to overwrite without --force" {
+  _setup_stack
+  printf 'API_TOKEN=exec://printf x\n' > "$CMD_STACK_DIR/.prod.env.template"
+  echo "OLD=1" > "$CMD_STACK_DIR/.prod.env"
+  run _secrets_hydrate
+  [ "$status" -ne 0 ]
+  grep -q '^OLD=1$' "$CMD_STACK_DIR/.prod.env"   # untouched
+}
+
+@test "_secrets_hydrate: --force overwrites" {
+  _setup_stack
+  printf 'API_TOKEN=exec://printf new\n' > "$CMD_STACK_DIR/.prod.env.template"
+  echo "OLD=1" > "$CMD_STACK_DIR/.prod.env"
+  run _secrets_hydrate --force
+  [ "$status" -eq 0 ]
+  grep -q '^API_TOKEN=new$' "$CMD_STACK_DIR/.prod.env"
+  ! grep -q '^OLD=1$' "$CMD_STACK_DIR/.prod.env"
+}
+
+@test "_secrets_hydrate: missing template fails cleanly" {
+  _setup_stack
+  run _secrets_hydrate
+  [ "$status" -ne 0 ]
+}
+
+@test "_secrets_hydrate: fail-fast leaves no partial file on bad reference" {
+  _setup_stack
+  cat > "$CMD_STACK_DIR/.prod.env.template" <<EOF
+GOOD=exec://printf ok
+BAD=file://$TEST_TMP/does-not-exist
+EOF
+  run _secrets_hydrate
+  [ "$status" -ne 0 ]
+  [ ! -f "$CMD_STACK_DIR/.prod.env" ]
+}


### PR DESCRIPTION
Closes #144.

Adds a small pluggable secret-source layer plus a new `strut <stack> secrets hydrate` so a stack's `.env` can be populated from a secret manager instead of hand-pasted plaintext — the missing piece between `init-secrets` (generate) and `secrets push/pull` (sync).

## What it does

`secrets hydrate --env <name>` builds the `.env` from a template, resolving `<scheme>://<ref>` values and copying everything else through verbatim:

```bash
# stacks/my-app/.prod.env.template
VPS_HOST=10.0.0.5
DATABASE_URL=postgres://app:app@db:5432/db          # literal — passes through
POSTGRES_PASSWORD=vault://my-app.postgres-password  # Vaultwarden/Bitwarden via `bw`
STRIPE_KEY=exec://aws secretsmanager get-secret-value --secret-id my-app/stripe --query SecretString --output text
API_TOKEN=file:///run/secrets/my-app-token          # file contents
```

Then `secrets validate` / `push` / `release` as usual.

## Approach

- **New `lib/secrets_providers.sh`** — `vault`/`exec`/`file` providers behind a tiny contract. Adding one is a `secrets_provider__<scheme>()` function (+ optional `_check` pre-flight) and a line in `SECRETS_PROVIDERS`; `exec://` already covers any secret-manager CLI.
- **`_secrets_hydrate` in `lib/cmd_secrets.sh`** — mirrors the `init-secrets` template idiom; output lands where `_secrets_resolve_local_env` (and `secrets push`) already look.
- **Backward compatible** — only the three known schemes are treated as references, so `postgres://` / `https://` literals are untouched.

## Safety

- `--dry-run` previews the `KEY <- scheme://ref` mapping without unlocking any provider and without writing a file.
- Providers are pre-flighted before writing — a missing `bw`/session aborts with no half-written file.
- Output is written 0600 to a temp file **in the destination dir** and renamed atomically (never transits `/tmp`), with a cleanup trap.
- Resolved values are never printed (logs, dry-run, or errors).
- Single-line only — a multi-line value (which a `.env` / compose `env_file` can't represent) is rejected rather than written corrupt.

## Testing

- `tests/test_secrets_providers.bats` — 23 tests: providers (incl. a fake `bw`), and `hydrate` end-to-end (dry-run-without-creds, multi-line rejection, fail-fast/no-partial-file, overwrite guards, 0600 mode).
- `bats tests/` green; `shellcheck -s bash` clean. Updated `secrets` help + `.kiro` steering. A draft Secrets-Management wiki section is ready if you want it.

Happy to reshape — e.g. fold this into `secrets pull --from <provider>` instead of a dedicated `hydrate`, or trim the provider set — whatever fits your direction. Take whatever's useful.
