### PR TITLE
fix: macOS portability — sed -i and date -d without BSD fallbacks

### DIFF
--- a/lib/backup/schedule.sh
+++ b/lib/backup/schedule.sh
@@ -306,7 +306,7 @@ check_missed_backups() {
         # Check if backup is overdue (expected interval + 2 hours grace period)
         if [ $time_diff -gt $((expected_interval + two_hours)) ]; then
           warn "Missed backup detected for $service"
-          log "  Last backup: $(date -d "@$backup_time" 2>/dev/null || date -r "$backup_time" 2>/dev/null)"
+          log "  Last backup: $(date -d "@$backup_time" 2>/dev/null || date -r "$backup_time" 2>/dev/null || echo "unknown")"
           log "  Expected interval: $((expected_interval / 3600)) hours"
           log "  Time since last backup: $((time_diff / 3600)) hours"
 
@@ -345,11 +345,20 @@ get_next_backup_time() {
   # For daily backups (most common case)
   if [ "$day" = "*" ] && [ "$month" = "*" ] && [ "$weekday" = "*" ]; then
     local next_time
-    next_time=$(date -d "today $hour:$minute" +"%Y-%m-%d %H:%M" 2>/dev/null)
+    # GNU date: date -d "today HH:MM"; macOS: use current date with specified time
+    next_time=$(date -d "today $hour:$minute" +"%Y-%m-%d %H:%M" 2>/dev/null \
+      || date -j -f "%Y-%m-%d %H:%M" "$(date +%Y-%m-%d) $hour:$minute" +"%Y-%m-%d %H:%M" 2>/dev/null \
+      || echo "")
 
     # If time has passed today, show tomorrow
-    if [ "$(date +%s)" -gt "$(date -d "$next_time" +%s 2>/dev/null)" ]; then
-      next_time=$(date -d "tomorrow $hour:$minute" +"%Y-%m-%d %H:%M" 2>/dev/null)
+    local next_epoch
+    next_epoch=$(date -d "$next_time" +%s 2>/dev/null \
+      || date -j -f "%Y-%m-%d %H:%M" "$next_time" +%s 2>/dev/null \
+      || echo "0")
+    if [ "$(date +%s)" -gt "$next_epoch" ]; then
+      next_time=$(date -d "tomorrow $hour:$minute" +"%Y-%m-%d %H:%M" 2>/dev/null \
+        || date -j -v+1d -f "%Y-%m-%d %H:%M" "$(date +%Y-%m-%d) $hour:$minute" +"%Y-%m-%d %H:%M" 2>/dev/null \
+        || echo "")
     fi
 
     echo "$next_time"

--- a/lib/drift/autofix.sh
+++ b/lib/drift/autofix.sh
@@ -35,7 +35,7 @@ drift_autofix_enable() {
   if [ -f "$config_file" ]; then
     # Update existing config
     if grep -q "^DRIFT_AUTOFIX_ENABLED=" "$config_file"; then
-      sed -i "s|^DRIFT_AUTOFIX_ENABLED=.*|DRIFT_AUTOFIX_ENABLED=true|" "$config_file"
+      sed -i.bak "s|^DRIFT_AUTOFIX_ENABLED=.*|DRIFT_AUTOFIX_ENABLED=true|" "$config_file" && rm -f "$config_file.bak"
     else
       echo "DRIFT_AUTOFIX_ENABLED=true" >>"$config_file"
     fi
@@ -102,7 +102,7 @@ drift_autofix_disable() {
   # Update config file
   if [ -f "$config_file" ]; then
     if grep -q "^DRIFT_AUTOFIX_ENABLED=" "$config_file"; then
-      sed -i "s|^DRIFT_AUTOFIX_ENABLED=.*|DRIFT_AUTOFIX_ENABLED=false|" "$config_file"
+      sed -i.bak "s|^DRIFT_AUTOFIX_ENABLED=.*|DRIFT_AUTOFIX_ENABLED=false|" "$config_file" && rm -f "$config_file.bak"
     else
       echo "DRIFT_AUTOFIX_ENABLED=false" >>"$config_file"
     fi

--- a/lib/monitor.sh
+++ b/lib/monitor.sh
@@ -345,25 +345,25 @@ monitoring_alert_channel_add_email() {
 
   # Use sed to update or add variables
   if grep -q "^ALERT_EMAIL_TO=" "$env_file"; then
-    sed -i "s|^ALERT_EMAIL_TO=.*|ALERT_EMAIL_TO=$to_email|" "$env_file"
+    sed -i.bak "s|^ALERT_EMAIL_TO=.*|ALERT_EMAIL_TO=$to_email|" "$env_file" && rm -f "$env_file.bak"
   else
     echo "ALERT_EMAIL_TO=$to_email" >> "$env_file"
   fi
 
   if grep -q "^ALERT_EMAIL_FROM=" "$env_file"; then
-    sed -i "s|^ALERT_EMAIL_FROM=.*|ALERT_EMAIL_FROM=$from_email|" "$env_file"
+    sed -i.bak "s|^ALERT_EMAIL_FROM=.*|ALERT_EMAIL_FROM=$from_email|" "$env_file" && rm -f "$env_file.bak"
   else
     echo "ALERT_EMAIL_FROM=$from_email" >> "$env_file"
   fi
 
   if grep -q "^RESEND_API_KEY=" "$env_file"; then
-    sed -i "s|^RESEND_API_KEY=.*|RESEND_API_KEY=$api_key|" "$env_file"
+    sed -i.bak "s|^RESEND_API_KEY=.*|RESEND_API_KEY=$api_key|" "$env_file" && rm -f "$env_file.bak"
   else
     echo "RESEND_API_KEY=$api_key" >> "$env_file"
   fi
 
   if grep -q "^ALERT_EMAIL_ENABLED=" "$env_file"; then
-    sed -i "s|^ALERT_EMAIL_ENABLED=.*|ALERT_EMAIL_ENABLED=true|" "$env_file"
+    sed -i.bak "s|^ALERT_EMAIL_ENABLED=.*|ALERT_EMAIL_ENABLED=true|" "$env_file" && rm -f "$env_file.bak"
   else
     echo "ALERT_EMAIL_ENABLED=true" >> "$env_file"
   fi
@@ -419,13 +419,13 @@ monitoring_alert_channel_add_slack() {
 
   # Update .env file
   if grep -q "^SLACK_WEBHOOK_URL=" "$env_file"; then
-    sed -i "s|^SLACK_WEBHOOK_URL=.*|SLACK_WEBHOOK_URL=$webhook_url|" "$env_file"
+    sed -i.bak "s|^SLACK_WEBHOOK_URL=.*|SLACK_WEBHOOK_URL=$webhook_url|" "$env_file" && rm -f "$env_file.bak"
   else
     echo "SLACK_WEBHOOK_URL=$webhook_url" >> "$env_file"
   fi
 
   if grep -q "^ALERT_SLACK_ENABLED=" "$env_file"; then
-    sed -i "s|^ALERT_SLACK_ENABLED=.*|ALERT_SLACK_ENABLED=true|" "$env_file"
+    sed -i.bak "s|^ALERT_SLACK_ENABLED=.*|ALERT_SLACK_ENABLED=true|" "$env_file" && rm -f "$env_file.bak"
   else
     echo "ALERT_SLACK_ENABLED=true" >> "$env_file"
   fi
@@ -474,13 +474,13 @@ monitoring_alert_channel_add_webhook() {
 
   # Update .env file
   if grep -q "^ALERT_WEBHOOK_URL=" "$env_file"; then
-    sed -i "s|^ALERT_WEBHOOK_URL=.*|ALERT_WEBHOOK_URL=$webhook_url|" "$env_file"
+    sed -i.bak "s|^ALERT_WEBHOOK_URL=.*|ALERT_WEBHOOK_URL=$webhook_url|" "$env_file" && rm -f "$env_file.bak"
   else
     echo "ALERT_WEBHOOK_URL=$webhook_url" >> "$env_file"
   fi
 
   if grep -q "^ALERT_WEBHOOK_ENABLED=" "$env_file"; then
-    sed -i "s|^ALERT_WEBHOOK_ENABLED=.*|ALERT_WEBHOOK_ENABLED=true|" "$env_file"
+    sed -i.bak "s|^ALERT_WEBHOOK_ENABLED=.*|ALERT_WEBHOOK_ENABLED=true|" "$env_file" && rm -f "$env_file.bak"
   else
     echo "ALERT_WEBHOOK_ENABLED=true" >> "$env_file"
   fi
@@ -528,7 +528,7 @@ monitoring_alert_channel_test() {
     "description": "This is a test alert to verify your alert channel configuration. If you receive this, your alerts are working correctly!"
   },
   "startsAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "endsAt": "$(date -u -d '+5 minutes' +%Y-%m-%dT%H:%M:%SZ)"
+  "endsAt": "$(date -u -d '+5 minutes' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v+5M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
 }]
 EOF
 )


### PR DESCRIPTION
Fixes macOS portability: bare sed -i (GNU-only) and date -d (GNU-only) without BSD fallbacks in drift/autofix.sh, monitor.sh, backup/schedule.sh. Uses sed -i.bak + rm pattern and date -j -f fallbacks matching existing codebase conventions.