### PR TITLE
feat: configurable migration failure mode in release (--strict)

### DIFF
--- a/lib/cmd_deploy.sh
+++ b/lib/cmd_deploy.sh
@@ -114,11 +114,20 @@ _usage_rebuild() {
   echo ""
 }
 
-# cmd_release (no args — reads CMD_*)
+# cmd_release [--strict] (reads CMD_*)
 cmd_release() {
   local stack="$CMD_STACK"
   local env_file="$CMD_ENV_FILE"
   local services="$CMD_SERVICES"
+
+  # Parse release-specific flags
+  local args=("${CMD_ARGS[@]+"${CMD_ARGS[@]}"}")
+  for arg in "${args[@]+"${args[@]}"}"; do
+    case "$arg" in
+      --strict) export MIGRATION_FAILURE_MODE="halt" ;;
+    esac
+  done
+
   validate_env_file "$env_file" VPS_HOST
   vps_release "$stack" "$env_file" "$services"
 }

--- a/lib/deploy.sh
+++ b/lib/deploy.sh
@@ -428,19 +428,32 @@ vps_release() {
 
   # Step 2: Run Postgres migrations
   log "[2/6] Running Postgres migrations..."
+  local migration_mode="${MIGRATION_FAILURE_MODE:-warn}"
   # shellcheck disable=SC2029
-  ssh $ssh_opts "$vps_user@$vps_host" "
+  if ! ssh $ssh_opts "$vps_user@$vps_host" "
     cd '$deploy_dir'
     ./strut $stack migrate postgres --env $env_name
-  " || warn "Postgres migration failed or no migrations to apply"
+  "; then
+    if [ "$migration_mode" = "halt" ]; then
+      fail "Postgres migration failed — halting release (MIGRATION_FAILURE_MODE=halt)"
+    else
+      warn "Postgres migration failed or no migrations to apply"
+    fi
+  fi
 
   # Step 3: Run Neo4j migrations
   log "[3/6] Running Neo4j migrations..."
   # shellcheck disable=SC2029
-  ssh $ssh_opts "$vps_user@$vps_host" "
+  if ! ssh $ssh_opts "$vps_user@$vps_host" "
     cd '$deploy_dir'
     ./strut $stack migrate neo4j --env $env_name
-  " || warn "Neo4j migration failed or no migrations to apply"
+  "; then
+    if [ "$migration_mode" = "halt" ]; then
+      fail "Neo4j migration failed — halting release (MIGRATION_FAILURE_MODE=halt)"
+    else
+      warn "Neo4j migration failed or no migrations to apply"
+    fi
+  fi
 
   # Step 4: Pull latest images
   log "[4/6] Pulling latest container images..."

--- a/strut
+++ b/strut
@@ -234,7 +234,7 @@ usage() {
   echo ""
   echo "Commands:"
   echo "  update   [--env <name>]                                        Pull latest strut on VPS"
-  echo "  release  [--env <name>] [--services <profile>]                 Full VPS release (update + migrate + deploy)"
+  echo "  release  [--env <name>] [--services <profile>] [--strict]       Full VPS release (update + migrate + deploy)"
   echo "  deploy   [--env <name>] [--services <profile>] [--pull-only]  Deploy stack"
   echo "  rebuild  [--env <name>] [--no-cache] [--pull]                  Build images + deploy"
   echo "  ship     [--env <name>] [-m <msg>] [--no-commit]               Commit, push, rebuild on remote"


### PR DESCRIPTION
Closes #166

## Summary

`vps_release` now supports a configurable migration failure mode instead of always warning and continuing.

## Behavior

| Mode | Behavior | Set via |
|------|----------|---------|
| `warn` (default) | Log warning, continue release | Backward compatible default |
| `halt` | Abort release immediately | `--strict` flag or `MIGRATION_FAILURE_MODE=halt` |

## Usage

```bash
# Strict mode via CLI flag
strut my-app release --env prod --strict

# Or via config (strut.conf or .env file)
MIGRATION_FAILURE_MODE=halt
```

## Rationale

The default remains `warn` because:
- Many migration commands return non-zero for "nothing to do"
- Existing users expect the current behavior
- `--strict` is opt-in for teams that want safety guarantees

Strict mode is recommended for stacks where schema + code must be in sync (most production apps).

## Testing
- 52 utils tests pass
- shellcheck clean on modified files