### PR TITLE
fix(completions): complete group names from INI section headers

### DIFF
--- a/completions/bash.sh
+++ b/completions/bash.sh
@@ -58,7 +58,8 @@ _strut_groups() {
   local root
   root=$(_strut_find_project_root) || return 0
   [ -f "$root/groups.conf" ] || return 0
-  awk -F'=' '/^[a-zA-Z_][a-zA-Z0-9_-]*=/{print $1}' "$root/groups.conf" 2>/dev/null
+  # Group names are INI section headers: [group-name]
+  awk -F'[][]' '/^[[:space:]]*#/{next} /^[[:space:]]*\[[^]]+\][[:space:]]*$/{print $2}' "$root/groups.conf" 2>/dev/null
 }
 
 _strut_completions() {

--- a/completions/fish.fish
+++ b/completions/fish.fish
@@ -43,7 +43,8 @@ end
 function __strut_groups
     set -l root (__strut_project_root); or return 0
     test -f "$root/groups.conf"; or return 0
-    awk -F'=' '/^[a-zA-Z_][a-zA-Z0-9_-]*=/{print $1}' "$root/groups.conf" 2>/dev/null
+    # Group names are INI section headers: [group-name]
+    awk -F'[][]' '/^[[:space:]]*#/{next} /^[[:space:]]*\[[^]]+\][[:space:]]*$/{print $2}' "$root/groups.conf" 2>/dev/null
 end
 
 # Position helpers — fish gives us the whole tokenized command

--- a/completions/zsh.sh
+++ b/completions/zsh.sh
@@ -43,7 +43,8 @@ _strut_groups() {
   local root
   root=$(_strut_find_project_root) || return 0
   [ -f "$root/groups.conf" ] || return 0
-  awk -F'=' '/^[a-zA-Z_][a-zA-Z0-9_-]*=/{print $1}' "$root/groups.conf" 2>/dev/null
+  # Group names are INI section headers: [group-name]
+  awk -F'[][]' '/^[[:space:]]*#/{next} /^[[:space:]]*\[[^]]+\][[:space:]]*$/{print $2}' "$root/groups.conf" 2>/dev/null
 }
 
 _strut() {


### PR DESCRIPTION
Group-name tab completion parsed `name=value` lines, but `groups.conf` uses INI section headers (`[group-name]`) — so `strut group <TAB>` never completed any real group names.

This matches the same bracket-section parsing `groups_list` uses in `lib/groups.sh`, applied to the bash, zsh, and fish completion scripts.

Discovered during a docs/wiki accuracy audit: `Shell-Completions.md` documents that `strut group <TAB>` completes group names from `groups.conf` — this fix makes that claim true (rather than walking the doc back).

Verified: awk extracts `[name]` section headers and skips comment lines; shellcheck clean.