### PR TITLE
fix(demos): render GIFs from strut() shims (clean, no stray errors)

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -69,23 +69,30 @@ Output ../output/gif/my-demo.gif    # GIF output
 # or: Screenshot ../output/png/my-still.png   # PNG still
 
 # ── Hidden setup (not recorded) ───────────────────────────
+# Source a per-tape shim that defines a fake strut() printing canned
+# output, so typed commands never run real strut (no infra, no errors).
 Hide
 Type `export PS1="~/project $ "` Enter
+Type "source shims/my-demo.sh" Enter
 Type "clear" Enter
 Show
 
 # ── The scene ─────────────────────────────────────────────
+# Type only the real-looking command — the shim prints the output.
 Sleep 800ms
-Type "strut my-app deploy --env prod"
-Sleep 300ms
-Enter
-# ... simulated output via printf ...
+Type "strut my-app deploy --env prod" Enter
+Sleep 3000ms
 ```
+
+Each tape has a matching `shims/<name>.sh` that defines `strut()` to
+dispatch on the command and `printf` the intended output (with `sleep`s
+for staged reveal). See `shims/hero-deploy.sh` for the canonical example.
 
 ### Key conventions
 
 - **Output paths** are relative to the tape file: `../output/gif/` and `../output/png/`
-- **Simulated output** uses `printf` with ANSI codes (no live VPS needed)
+- **Output comes from a shim** (`shims/<name>.sh`), never the real CLI — no live VPS, no stray errors, no visible `printf` lines
+- **Embedded quotes** in a typed command (e.g. `-m 'msg'`) need a backtick Type: `` Type `strut ... -m 'msg'` `` then `Enter` on the next line
 - **Gold accent** for success: `\\033[1;33m✓ text\\033[0m`
 - **Red** for errors/warnings: `\\033[1;31m✗ text\\033[0m`
 - **Green dots** for status: `\\033[32m●\\033[0m`
@@ -154,21 +161,25 @@ Set FontSize 16    # smaller font → smaller canvas (VHS auto-sizes)
 
 ### Current output sizes
 
-| File | Raw | Optimized | Duration |
-|------|-----|-----------|----------|
-| hero-deploy.gif | ~1.1 MB | ~1.0 MB | ~15s |
-| backup-restore.gif | ~670 KB | ~627 KB | ~12s |
-| drift-detect.gif | ~514 KB | ~484 KB | ~11s |
-| health-status.png | — | 304 KB | (still) |
+| File | Optimized | Notes |
+|------|-----------|-------|
+| hero-deploy.gif | ~132 KB | init → scaffold → deploy |
+| ship.gif | ~32 KB | commit → push → rebuild |
+| local-dev.gif | ~120 KB | start → sync-db → logs |
+| rollback.gif | ~76 KB | failed health → rollback |
+| drift-detect.gif | ~96 KB | detect → fix |
+| backup-restore.gif | ~100 KB | backup → verify |
+| health-status.png | ~88 KB | (still) |
 
-These are already web-viable. For aggressive reduction, trim Sleep durations
-and increase TypingSpeed first.
+Sizes dropped sharply after moving to shims (no error output or visible
+`printf` frames). For aggressive reduction, trim Sleep durations and increase
+TypingSpeed first.
 
 ## Design Decisions
 
 - **Deterministic**: tapes pin timing, theme, cursor blink, and prompt
 - **Brand-aligned**: Catppuccin Mocha maps well to our Charcoal/Bone/Gold palette
-- **No real infra**: tapes simulate strut output via printf — no SSH, no Docker, no VPS
+- **No real infra**: a hidden per-tape `strut()` shim prints canned output — no SSH, no Docker, no VPS, and no stray errors from real commands
 - **Web-ready**: all GIFs are losslessly optimized as a pipeline step
 - **Regenerable**: run `./bin/record.sh` anytime to rebuild all assets from source
 
@@ -193,15 +204,17 @@ Full DSL: https://github.com/charmbracelet/vhs
 
 ## Troubleshooting
 
-**"command not found: strut"** in the tape output  
-Expected — tapes use `printf` to simulate output rather than running real strut commands. The `Type "strut ..."` line types the command visually; the `printf` on the next line fakes the output.
+**Real strut errors in the GIF (e.g. "Project already initialized", "Env file not found")**  
+The tape's `strut()` shim didn't load, so the typed command ran the *real* strut against the fixture. Ensure the Hide block sources the shim (`Type "source shims/<name>.sh" Enter`) and that a matching `shims/<name>.sh` exists and defines `strut()` for that command.
 
-**GIF shows the printf commands being typed**  
-Make sure the `printf` lines execute after `Enter` (the command prompt runs them). The viewer sees: typed command → output appears.
+**GIF shows `printf` commands being typed**  
+That's the old pattern. Move the output into the shim's `strut()` function so the scene types only the real command.
+
+**`recording failed: failed to type key -`**  
+The typed command has embedded quotes (e.g. `-m 'msg'`) that broke VHS's `Type "..."` parsing. Use a backtick Type instead: `` Type `strut ... -m 'msg'` `` with `Enter` on the next line.
 
 **Screenshot is empty / shows loading state**  
-Increase the `Sleep` before `Screenshot`. The terminal needs time to render output.
+Increase the `Sleep` before `Screenshot`. The terminal needs time to render output. Also ensure the trailing `Sleep` after a command is ≥ the shim's total internal `sleep` time, or the recording ends before the output finishes.
 
 **Artifacts in tapes/ directory (stacks/, strut.conf)**  
-These are created when VHS actually executes typed strut commands during recording.
-They're gitignored via `bin/tapes/.gitignore`.
+`bin/tapes/` intentionally contains a fixture project (`strut.conf`, `stacks/my-app/`). Generated runtime artifacts are gitignored via `bin/tapes/.gitignore`.

--- a/bin/tapes/backup-restore.tape
+++ b/bin/tapes/backup-restore.tape
@@ -1,7 +1,6 @@
-# backup-restore.tape — Database backup and restore workflow
-# Used for: Feature section, docs illustration
-#
-# Story: Show reliable backup creation and verification in one beat.
+# backup-restore.tape — Database backup and verification
+# Story: Create a backup → verify its integrity.
+# Output driven by hidden shim (shims/backup-restore.sh).
 
 Set Shell "bash"
 Set FontSize 20
@@ -13,42 +12,14 @@ Set WindowBar Colorful
 
 Output ../output/gif/backup-restore.gif
 
-# ── Hidden setup ──────────────────────────────────────────────────────────────
 Hide
 Type `export PS1="~/project $ "` Enter
+Type "source shims/backup-restore.sh" Enter
 Type "clear" Enter
 Show
 
-# ── Scene: Backup ─────────────────────────────────────────────────────────────
 Sleep 800ms
-Type "strut my-app backup postgres --env prod"
-Sleep 300ms
-Enter
-Sleep 500ms
-Type "printf '→ Connecting to VPS (prod)...\n'"
-Enter
-Sleep 600ms
-Type "printf '→ Dumping postgres (my-app-db)...\n'"
-Enter
-Sleep 1200ms
-Type "printf '✓ Backup: my-app-postgres-20260614-120000.sql.gz (24MB)\n'"
-Enter
-Sleep 400ms
-Type "printf '✓ Uploaded to offsite: s3://backups/my-app/\n'"
-Enter
-Sleep 2500ms
-
-# ── Scene: Verify ─────────────────────────────────────────────────────────────
-Type "strut my-app backup verify --env prod"
-Sleep 300ms
-Enter
-Sleep 400ms
-Type "printf '→ Verifying latest backup integrity...\n'"
-Enter
-Sleep 800ms
-Type "printf '  ✓ Checksum: valid\n  ✓ Tables: 47/47 present\n  ✓ Row counts: within 1%% of live\n'"
-Enter
-Sleep 400ms
-Type "printf '\\033[1;33m✓ Backup verified\\033[0m\n'"
-Enter
+Type "strut my-app backup postgres --env prod" Enter
+Sleep 3200ms
+Type "strut my-app backup verify --env prod" Enter
 Sleep 3000ms

--- a/bin/tapes/drift-detect.tape
+++ b/bin/tapes/drift-detect.tape
@@ -1,7 +1,6 @@
 # drift-detect.tape — Configuration drift detection
-# Used for: Feature section, drift detection docs
-#
-# Story: Run drift detection → find a mismatch → auto-fix it.
+# Story: Detect a mismatch → auto-fix it.
+# Output driven by hidden shim (shims/drift-detect.sh).
 
 Set Shell "bash"
 Set FontSize 20
@@ -13,45 +12,14 @@ Set WindowBar Colorful
 
 Output ../output/gif/drift-detect.gif
 
-# ── Hidden setup ──────────────────────────────────────────────────────────────
 Hide
 Type `export PS1="~/project $ "` Enter
+Type "source shims/drift-detect.sh" Enter
 Type "clear" Enter
 Show
 
-# ── Scene: Detect drift ───────────────────────────────────────────────────────
 Sleep 800ms
-Type "strut my-app drift detect --env prod"
-Sleep 300ms
-Enter
-Sleep 500ms
-Type "printf '→ Comparing local vs remote config...\n'"
-Enter
-Sleep 1000ms
-Type "printf '\\033[1;31m✗ Drift detected (2 files)\\033[0m\n'"
-Enter
-Sleep 400ms
-Type "printf '  docker-compose.yml  +2 lines (port mapping added remotely)\n'"
-Enter
-Sleep 300ms
-Type "printf '  .env.prod           1 var changed (DB_POOL_SIZE: 10→25)\n'"
-Enter
-Sleep 2500ms
-
-# ── Scene: Auto-fix ───────────────────────────────────────────────────────────
-Type "strut my-app drift fix --env prod"
-Sleep 300ms
-Enter
-Sleep 400ms
-Type "printf '→ Syncing local config to VPS...\n'"
-Enter
-Sleep 800ms
-Type "printf '  ✓ docker-compose.yml restored\n'"
-Enter
-Sleep 300ms
-Type "printf '  ✓ .env.prod restored\n'"
-Enter
-Sleep 400ms
-Type "printf '\\033[1;33m✓ Drift resolved — 2 files synced\\033[0m\n'"
-Enter
+Type "strut my-app drift detect --env prod" Enter
+Sleep 3000ms
+Type "strut my-app drift fix --env prod" Enter
 Sleep 3000ms

--- a/bin/tapes/health-status.tape
+++ b/bin/tapes/health-status.tape
@@ -1,7 +1,6 @@
-# health-status.tape — Health check and status overview
-# Used for: Marketing still (PNG), README badge area
-#
+# health-status.tape — Health check overview (still PNG)
 # Story: Quick health check showing all services green.
+# Output driven by hidden shim (shims/health-status.sh).
 
 Set Shell "bash"
 Set FontSize 20
@@ -11,42 +10,13 @@ Set CursorBlink false
 Set TypingSpeed 40ms
 Set WindowBar Colorful
 
-# ── Hidden setup ──────────────────────────────────────────────────────────────
 Hide
 Type `export PS1="~/project $ "` Enter
+Type "source shims/health-status.sh" Enter
 Type "clear" Enter
 Show
 
-# ── Scene: Health check ───────────────────────────────────────────────────────
 Sleep 800ms
-Type "strut my-app health --env prod"
-Sleep 300ms
-Enter
-Sleep 600ms
-Type "printf '\n'"
-Enter
-Type "printf '  Service          Status     Uptime\n'"
-Enter
-Type "printf '  ─────────────────────────────────────\n'"
-Enter
-Type "printf '  \\033[32m●\\033[0m api             healthy    14d 6h\n'"
-Enter
-Sleep 200ms
-Type "printf '  \\033[32m●\\033[0m worker          healthy    14d 6h\n'"
-Enter
-Sleep 200ms
-Type "printf '  \\033[32m●\\033[0m postgres        healthy    14d 6h\n'"
-Enter
-Sleep 200ms
-Type "printf '  \\033[32m●\\033[0m redis           healthy    14d 6h\n'"
-Enter
-Sleep 200ms
-Type "printf '  \\033[32m●\\033[0m nginx           healthy    14d 6h\n'"
-Enter
-Sleep 400ms
-Type "printf '\n  \\033[1;33m✓ 5/5 services healthy\\033[0m\n'"
-Enter
-Sleep 2000ms
-
-# Capture a still for use as a PNG screenshot
+Type "strut my-app health --env prod" Enter
+Sleep 2500ms
 Screenshot ../output/png/health-status.png

--- a/bin/tapes/hero-deploy.tape
+++ b/bin/tapes/hero-deploy.tape
@@ -2,6 +2,9 @@
 # Used for: README hero GIF, marketing site header
 #
 # Story: Show the full "zero to deployed" flow in one tight scene.
+#
+# Output is driven by a hidden strut() shim (shims/hero-deploy.sh) so the
+# recording shows clean, deterministic output — no real infra, no stray errors.
 
 Set Shell "bash"
 Set FontSize 20
@@ -13,51 +16,18 @@ Set WindowBar Colorful
 
 Output ../output/gif/hero-deploy.gif
 
-# ── Hidden setup ──────────────────────────────────────────────────────────────
+# ── Hidden setup: prompt + strut output shim ──────────────────────────────────
 Hide
 Type `export PS1="~/project $ "` Enter
+Type "source shims/hero-deploy.sh" Enter
 Type "clear" Enter
 Show
 
-# ── Scene: Init ───────────────────────────────────────────────────────────────
+# ── Scene: Init → Scaffold → Deploy ───────────────────────────────────────────
 Sleep 800ms
-Type "strut init --registry ghcr --org acme"
-Sleep 300ms
-Enter
-Sleep 400ms
-Type "printf '✓ Created strut.conf\n✓ Created stacks/ directory\n✓ Registry: ghcr.io/acme\n'"
-Enter
+Type "strut init --registry ghcr --org acme" Enter
 Sleep 2000ms
-
-# ── Scene: Scaffold ───────────────────────────────────────────────────────────
-Type "strut scaffold my-app"
-Sleep 300ms
-Enter
-Sleep 400ms
-Type "printf '✓ stacks/my-app/docker-compose.yml\n✓ stacks/my-app/services.conf\n✓ stacks/my-app/.env.template\n'"
-Enter
+Type "strut scaffold my-app" Enter
 Sleep 2000ms
-
-# ── Scene: Deploy ─────────────────────────────────────────────────────────────
-Type "strut my-app release --env prod"
-Sleep 300ms
-Enter
-Sleep 500ms
-Type "printf '→ Syncing repository on VPS...\n'"
-Enter
-Sleep 600ms
-Type "printf '→ Running migrations...\n'"
-Enter
-Sleep 800ms
-Type "printf '→ Deploying containers...\n'"
-Enter
-Sleep 600ms
-Type "printf '\\033[1;33m✓ my-app deployed successfully\\033[0m\n'"
-Enter
-Sleep 400ms
-Type "printf '→ Health check: 3/3 services healthy\n'"
-Enter
-Sleep 300ms
-Type "printf '\\033[1;33m✓ Done in 12s\\033[0m\n'"
-Enter
+Type "strut my-app release --env prod" Enter
 Sleep 3000ms

--- a/bin/tapes/local-dev.tape
+++ b/bin/tapes/local-dev.tape
@@ -1,7 +1,6 @@
 # local-dev.tape — Local development workflow
-# Used for: Feature section, local dev docs
-#
-# Story: Start local → sync prod DB → tail logs. The full dev loop.
+# Story: Start local → sync prod DB → tail logs.
+# Output driven by hidden shim (shims/local-dev.sh).
 
 Set Shell "bash"
 Set FontSize 20
@@ -15,60 +14,14 @@ Output ../output/gif/local-dev.gif
 
 Hide
 Type `export PS1="~/project $ "` Enter
+Type "source shims/local-dev.sh" Enter
 Type "clear" Enter
 Show
 
-# ── Start local ───────────────────────────────────────────────────────────────
 Sleep 600ms
-Type "strut my-app local start"
-Sleep 200ms
-Enter
-Sleep 400ms
-Type@0ms "printf '→ Starting containers (docker compose up -d)...\n'"
-Enter
-Sleep 800ms
-Type@0ms "printf '  ✓ api         running  :3000\n'"
-Enter
-Sleep 150ms
-Type@0ms "printf '  ✓ postgres    running  :5432\n'"
-Enter
-Sleep 150ms
-Type@0ms "printf '  ✓ redis       running  :6379\n'"
-Enter
-Sleep 300ms
-Type@0ms "printf '\\033[1;33m✓ Local stack ready\\033[0m\n'"
-Enter
-Sleep 1500ms
-
-# ── Sync DB from prod ─────────────────────────────────────────────────────────
-Type "strut my-app local sync-db --from prod postgres"
-Sleep 200ms
-Enter
-Sleep 400ms
-Type@0ms "printf '→ Pulling latest backup from prod...\n'"
-Enter
-Sleep 600ms
-Type@0ms "printf '→ Restoring into local postgres...\n'"
-Enter
-Sleep 800ms
-Type@0ms "printf '\\033[1;33m✓ Synced 47 tables (24MB)\\033[0m\n'"
-Enter
-Sleep 1500ms
-
-# ── Tail logs ─────────────────────────────────────────────────────────────────
-Type "strut my-app local logs"
-Sleep 200ms
-Enter
-Sleep 400ms
-Type@0ms "printf '\\033[90m[api]\\033[0m      Server listening on :3000\n'"
-Enter
-Sleep 200ms
-Type@0ms "printf '\\033[90m[api]\\033[0m      Connected to postgres (47 tables)\n'"
-Enter
-Sleep 200ms
-Type@0ms "printf '\\033[90m[api]\\033[0m      Redis cache warm\n'"
-Enter
-Sleep 200ms
-Type@0ms "printf '\\033[90m[postgres]\\033[0m Ready to accept connections\n'"
-Enter
-Sleep 1500ms
+Type "strut my-app local start" Enter
+Sleep 2200ms
+Type "strut my-app local sync-db --from prod postgres" Enter
+Sleep 2200ms
+Type "strut my-app local logs" Enter
+Sleep 2500ms

--- a/bin/tapes/rollback.tape
+++ b/bin/tapes/rollback.tape
@@ -1,7 +1,6 @@
 # rollback.tape — Instant recovery from a bad deploy
-# Used for: Safety messaging, "what if it breaks?" section
-#
-# Story: Deploy goes wrong → health check fails → rollback → instant recovery.
+# Story: Health check fails → rollback → instant recovery.
+# Output driven by hidden shim (shims/rollback.sh).
 
 Set Shell "bash"
 Set FontSize 20
@@ -15,42 +14,12 @@ Output ../output/gif/rollback.gif
 
 Hide
 Type `export PS1="~/project $ "` Enter
+Type "source shims/rollback.sh" Enter
 Type "clear" Enter
 Show
 
-# ── Failed deploy ─────────────────────────────────────────────────────────────
 Sleep 600ms
-Type "strut my-app health --env prod"
-Sleep 200ms
-Enter
-Sleep 500ms
-Type@0ms "printf '  \\033[32m●\\033[0m postgres   healthy\n'"
-Enter
-Sleep 150ms
-Type@0ms "printf '  \\033[32m●\\033[0m redis      healthy\n'"
-Enter
-Sleep 150ms
-Type@0ms "printf '  \\033[31m●\\033[0m api        unhealthy (502)\n'"
-Enter
-Sleep 300ms
-Type@0ms "printf '\\033[1;31m✗ 1/3 services failing\\033[0m\n'"
-Enter
-Sleep 2000ms
-
-# ── Rollback ──────────────────────────────────────────────────────────────────
-Type "strut my-app rollback --env prod"
-Sleep 200ms
-Enter
-Sleep 400ms
-Type@0ms "printf '→ Rolling back to previous release (v2.3.1)...\n'"
-Enter
-Sleep 800ms
-Type@0ms "printf '→ Restoring containers...\n'"
-Enter
-Sleep 600ms
-Type@0ms "printf '→ Health check: 3/3 healthy\n'"
-Enter
-Sleep 300ms
-Type@0ms "printf '\\033[1;33m✓ Rolled back in 4s\\033[0m\n'"
-Enter
+Type "strut my-app health --env prod" Enter
 Sleep 2500ms
+Type "strut my-app rollback --env prod" Enter
+Sleep 3000ms

--- a/bin/tapes/shims/backup-restore.sh
+++ b/bin/tapes/shims/backup-restore.sh
@@ -1,0 +1,16 @@
+# Canned strut output for the backup-restore demo.
+strut() {
+  case "$3" in
+    postgres)
+      printf '→ Connecting to VPS (prod)...\n';        sleep 0.6
+      printf '→ Dumping postgres (my-app-db)...\n';     sleep 1.2
+      printf '✓ Backup: my-app-postgres-20260614-120000.sql.gz (24MB)\n'; sleep 0.4
+      printf '✓ Uploaded to offsite: s3://backups/my-app/\n' ;;
+    verify)
+      printf '→ Verifying latest backup integrity...\n'; sleep 0.8
+      printf '  ✓ Checksum: valid\n'
+      printf '  ✓ Tables: 47/47 present\n'
+      printf '  ✓ Row counts: within 1%% of live\n';    sleep 0.4
+      printf '\033[1;33m✓ Backup verified\033[0m\n' ;;
+  esac
+}

--- a/bin/tapes/shims/drift-detect.sh
+++ b/bin/tapes/shims/drift-detect.sh
@@ -1,0 +1,15 @@
+# Canned strut output for the drift-detect demo.
+strut() {
+  case "$3" in
+    detect)
+      printf '→ Comparing local vs remote config...\n'; sleep 1.0
+      printf '\033[1;31m✗ Drift detected (2 files)\033[0m\n'; sleep 0.4
+      printf '  docker-compose.yml  +2 lines (port mapping added remotely)\n'; sleep 0.3
+      printf '  .env.prod           1 var changed (DB_POOL_SIZE: 10→25)\n' ;;
+    fix)
+      printf '→ Syncing local config to VPS...\n';  sleep 0.8
+      printf '  ✓ docker-compose.yml restored\n';   sleep 0.3
+      printf '  ✓ .env.prod restored\n';            sleep 0.4
+      printf '\033[1;33m✓ Drift resolved — 2 files synced\033[0m\n' ;;
+  esac
+}

--- a/bin/tapes/shims/health-status.sh
+++ b/bin/tapes/shims/health-status.sh
@@ -1,0 +1,15 @@
+# Canned strut output for the health-status still.
+strut() {
+  case "$2" in
+    health)
+      printf '\n'
+      printf '  Service          Status     Uptime\n'
+      printf '  ─────────────────────────────────────\n'
+      printf '  \033[32m●\033[0m api             healthy    14d 6h\n'; sleep 0.2
+      printf '  \033[32m●\033[0m worker          healthy    14d 6h\n'; sleep 0.2
+      printf '  \033[32m●\033[0m postgres        healthy    14d 6h\n'; sleep 0.2
+      printf '  \033[32m●\033[0m redis           healthy    14d 6h\n'; sleep 0.2
+      printf '  \033[32m●\033[0m nginx           healthy    14d 6h\n'; sleep 0.4
+      printf '\n  \033[1;33m✓ 5/5 services healthy\033[0m\n' ;;
+  esac
+}

--- a/bin/tapes/shims/hero-deploy.sh
+++ b/bin/tapes/shims/hero-deploy.sh
@@ -1,0 +1,23 @@
+# Canned strut output for the hero-deploy demo (no real execution).
+strut() {
+  case "$1" in
+    init)
+      printf '\033[32m✓\033[0m Created strut.conf\n'
+      printf '\033[32m✓\033[0m Created stacks/ directory\n'
+      printf '\033[32m✓\033[0m Registry: ghcr.io/acme\n' ;;
+    scaffold)
+      printf '\033[32m✓\033[0m stacks/my-app/docker-compose.yml\n'
+      printf '\033[32m✓\033[0m stacks/my-app/services.conf\n'
+      printf '\033[32m✓\033[0m stacks/my-app/.env.template\n' ;;
+    *)
+      case "$2" in
+        release)
+          printf '→ Syncing repository on VPS...\n';      sleep 0.6
+          printf '→ Running migrations...\n';              sleep 0.8
+          printf '→ Deploying containers...\n';            sleep 0.6
+          printf '\033[1;33m✓ my-app deployed successfully\033[0m\n'; sleep 0.4
+          printf '→ Health check: 3/3 services healthy\n'; sleep 0.3
+          printf '\033[1;33m✓ Done in 12s\033[0m\n' ;;
+      esac ;;
+  esac
+}

--- a/bin/tapes/shims/local-dev.sh
+++ b/bin/tapes/shims/local-dev.sh
@@ -1,0 +1,20 @@
+# Canned strut output for the local-dev demo.
+strut() {
+  case "$3" in
+    start)
+      printf '→ Starting containers (docker compose up -d)...\n'; sleep 0.8
+      printf '  ✓ api         running  :3000\n';       sleep 0.15
+      printf '  ✓ postgres    running  :5432\n';       sleep 0.15
+      printf '  ✓ redis       running  :6379\n';       sleep 0.3
+      printf '\033[1;33m✓ Local stack ready\033[0m\n' ;;
+    sync-db)
+      printf '→ Pulling latest backup from prod...\n'; sleep 0.6
+      printf '→ Restoring into local postgres...\n';   sleep 0.8
+      printf '\033[1;33m✓ Synced 47 tables (24MB)\033[0m\n' ;;
+    logs)
+      printf '\033[90m[api]\033[0m      Server listening on :3000\n';        sleep 0.2
+      printf '\033[90m[api]\033[0m      Connected to postgres (47 tables)\n'; sleep 0.2
+      printf '\033[90m[api]\033[0m      Redis cache warm\n';                  sleep 0.2
+      printf '\033[90m[postgres]\033[0m Ready to accept connections\n' ;;
+  esac
+}

--- a/bin/tapes/shims/rollback.sh
+++ b/bin/tapes/shims/rollback.sh
@@ -1,0 +1,15 @@
+# Canned strut output for the rollback demo.
+strut() {
+  case "$2" in
+    health)
+      printf '  \033[32m●\033[0m postgres   healthy\n';         sleep 0.15
+      printf '  \033[32m●\033[0m redis      healthy\n';         sleep 0.15
+      printf '  \033[31m●\033[0m api        unhealthy (502)\n'; sleep 0.3
+      printf '\033[1;31m✗ 1/3 services failing\033[0m\n' ;;
+    rollback)
+      printf '→ Rolling back to previous release (v2.3.1)...\n'; sleep 0.8
+      printf '→ Restoring containers...\n';                      sleep 0.6
+      printf '→ Health check: 3/3 healthy\n';                    sleep 0.3
+      printf '\033[1;33m✓ Rolled back in 4s\033[0m\n' ;;
+  esac
+}

--- a/bin/tapes/shims/ship.sh
+++ b/bin/tapes/shims/ship.sh
@@ -1,0 +1,13 @@
+# Canned strut output for the ship demo.
+strut() {
+  case "$2" in
+    ship)
+      printf '→ Committing changes...\n';            sleep 0.5
+      printf '  [main 4a2f1c8] fix auth timeout\n';   sleep 0.3
+      printf '→ Pushing to origin/main...\n';         sleep 0.6
+      printf '→ Rebuilding on VPS (prod)...\n';       sleep 1.0
+      printf '→ Pulling latest images...\n';          sleep 0.8
+      printf '→ Restarting containers...\n';          sleep 0.6
+      printf '\033[1;33m✓ Shipped in 18s\033[0m\n' ;;
+  esac
+}

--- a/bin/tapes/ship.tape
+++ b/bin/tapes/ship.tape
@@ -1,7 +1,6 @@
 # ship.tape — One command to production
-# Used for: Hero alternative, "ship it" messaging
-#
 # Story: Commit, push, and rebuild on remote in one shot.
+# Output driven by hidden shim (shims/ship.sh) — no real infra, no stray errors.
 
 Set Shell "bash"
 Set FontSize 20
@@ -15,32 +14,11 @@ Output ../output/gif/ship.gif
 
 Hide
 Type `export PS1="~/project $ "` Enter
+Type "source shims/ship.sh" Enter
 Type "clear" Enter
 Show
 
 Sleep 600ms
-Type "strut my-app ship -m 'fix auth timeout' --env prod"
-Sleep 200ms
+Type `strut my-app ship -m 'fix auth timeout' --env prod`
 Enter
-Sleep 400ms
-Type@0ms "printf '→ Committing changes...\n'"
-Enter
-Sleep 500ms
-Type@0ms "printf '  [main 4a2f1c8] fix auth timeout\n'"
-Enter
-Sleep 300ms
-Type@0ms "printf '→ Pushing to origin/main...\n'"
-Enter
-Sleep 600ms
-Type@0ms "printf '→ Rebuilding on VPS (prod)...\n'"
-Enter
-Sleep 1000ms
-Type@0ms "printf '→ Pulling latest images...\n'"
-Enter
-Sleep 800ms
-Type@0ms "printf '→ Restarting containers...\n'"
-Enter
-Sleep 600ms
-Type@0ms "printf '\\033[1;33m✓ Shipped in 18s\\033[0m\n'"
-Enter
-Sleep 2500ms
+Sleep 5000ms


### PR DESCRIPTION
## Problem
The demo tapes typed a real `strut …` command **and pressed Enter**, so VHS executed it against the `bin/tapes/` fixture. With no VPS/Docker, strut correctly errored ("Project already initialized", "Env file not found", "Unknown command: 'ship'"), and those errors were baked into the marketing GIFs alongside the `printf` fakes — plus the `printf` lines themselves were visible. **Not strut bugs — a recording-setup bug.**

## Fix
Each tape now sources a per-tape `shims/<name>.sh` that defines a fake `strut()` printing canned, staged output. Scenes type only the real-looking command; nothing real runs.

- 7 new shims under `bin/tapes/shims/`
- all 7 tapes rewritten to source their shim
- `ship` uses a backtick `Type` (embedded quotes in `-m 'fix auth timeout'` broke VHS's quoted Type)
- `bin/README.md` updated (shim pattern + troubleshooting)

## Result
Clean recordings, zero stray errors, and much smaller GIFs: hero 593K→132K, local-dev 975K→120K, rollback 352K→76K, ship →32K. Verified frame-by-frame. (GIFs live in `.www` and were synced there separately.)