### PR TITLE
feat: STRUT_YES/--yes global + safer backup restore

### DIFF
--- a/lib/backup.sh
+++ b/lib/backup.sh
@@ -328,9 +328,11 @@ restore_neo4j() {
   # Get data volume
   local data_volume
   data_volume=$(docker inspect "$container_name" --format '{{range .Mounts}}{{if eq .Destination "/data"}}{{.Name}}{{end}}{{end}}')
+  [ -n "$data_volume" ] || fail "Could not resolve /data volume for container '$container_name' (container running? correct mount?)"
 
   local import_volume
   import_volume=$(docker inspect "$container_name" --format '{{range .Mounts}}{{if eq .Destination "/var/lib/neo4j/import"}}{{.Name}}{{end}}{{end}}')
+  [ -n "$import_volume" ] || fail "Could not resolve /var/lib/neo4j/import volume for container '$container_name'"
 
   # Run neo4j-admin load in temporary container - show output in real-time
   # Note: neo4j-admin database load expects the dump file to be named "neo4j.dump" in the from-path directory
@@ -417,6 +419,7 @@ restore_neo4j_from_targz() {
   # Get data volume
   local data_volume
   data_volume=$(docker inspect "$container_name" --format '{{range .Mounts}}{{if eq .Destination "/data"}}{{.Name}}{{end}}{{end}}')
+  [ -n "$data_volume" ] || fail "Could not resolve /data volume for container '$container_name' (container running? correct mount?) — aborting restore to avoid wiping the wrong volume"
 
   log "Clearing existing data..."
   docker run --rm \

--- a/lib/cmd_deploy.sh
+++ b/lib/cmd_deploy.sh
@@ -206,8 +206,7 @@ cmd_deploy() {
       local deploy_dir="${VPS_DEPLOY_DIR:-/home/${VPS_USER:-ubuntu}/strut}"
       warn "  strut $stack exec 'cd $deploy_dir && strut $stack deploy --env ${env_name:-prod}' --env ${env_name:-prod}"
       echo ""
-      read -p "Continue with local deployment anyway? (yes/no): " -r
-      if [[ ! $REPLY =~ ^[Yy][Ee][Ss]$ ]]; then
+      if ! confirm "Continue with local deployment anyway?"; then
         fail "Deployment cancelled by user"
       fi
     fi

--- a/lib/flags.sh
+++ b/lib/flags.sh
@@ -7,6 +7,7 @@
 #   --services <profile> | --services=<profile>
 #   --json
 #   --dry-run
+#   --yes | -y   (also honored via STRUT_YES=1)
 #   --help | -h
 #
 # Handler-specific flags are left in FLAGS_POSITIONAL for the caller
@@ -41,6 +42,7 @@ parse_common_flags() {
       --host)        FLAGS_HOST="${2:-}"; shift 2 ;;
       --json)        FLAGS_JSON="--json"; shift ;;
       --dry-run)     FLAGS_DRY_RUN="true"; shift ;;
+      --yes|-y)      STRUT_YES=1; export STRUT_YES; shift ;;
       --help|-h)     FLAGS_HELP="true"; shift ;;
       *)             FLAGS_POSITIONAL+=("$1"); shift ;;
     esac

--- a/lib/github-token.sh
+++ b/lib/github-token.sh
@@ -230,8 +230,7 @@ github_setup_token_permissions() {
       echo ""
       echo "This allows the wizard to create fine-grained tokens automatically."
       echo ""
-      read -p "Run this command now? (yes/no): " -r
-      if [[ $REPLY =~ ^[Yy][Ee][Ss]$ ]]; then
+      if confirm "Run this command now?"; then
         gh auth refresh -s admin:personal_access_token
 
         if github_check_token_permissions | grep -q "has_permissions"; then

--- a/lib/keys/pull.sh
+++ b/lib/keys/pull.sh
@@ -187,8 +187,7 @@ keys_pull_from_vps() {
   # Check if target file exists
   if [ -f "$target_file" ] && ! $force; then
     warn "Target file already exists: $target_file"
-    read -p "Overwrite? (yes/no): " -r
-    if [[ ! $REPLY =~ ^[Yy][Ee][Ss]$ ]]; then
+    if ! confirm "Overwrite?"; then
       fail "Cancelled by user"
     fi
   fi
@@ -339,8 +338,7 @@ keys_pull_from_containers() {
   # Check if target file exists
   if [ -f "$target_file" ] && ! $force; then
     warn "Target file already exists: $target_file"
-    read -p "Overwrite? (yes/no): " -r
-    if [[ ! $REPLY =~ ^[Yy][Ee][Ss]$ ]]; then
+    if ! confirm "Overwrite?"; then
       fail "Cancelled by user"
     fi
   fi
@@ -432,8 +430,7 @@ keys_pull_from_env_file() {
   # Check if target file exists
   if [ -f "$target_file" ] && ! $force; then
     warn "Target file already exists: $target_file"
-    read -p "Overwrite? (yes/no): " -r
-    if [[ ! $REPLY =~ ^[Yy][Ee][Ss]$ ]]; then
+    if ! confirm "Overwrite?"; then
       fail "Cancelled by user"
     fi
   fi

--- a/lib/monitor.sh
+++ b/lib/monitor.sh
@@ -87,7 +87,11 @@ monitoring_deploy() {
       warn "  - ALERT_EMAIL_TO"
       warn "  - ALERT_EMAIL_FROM"
       echo
-      read -p "Press Enter after configuring .env to continue..."
+      if [ "${STRUT_YES:-}" = "1" ] || [ ! -t 0 ]; then
+        warn "Non-interactive: proceeding without confirmation (edit .env before deploying)"
+      else
+        read -p "Press Enter after configuring .env to continue..." -r
+      fi
     else
       fail ".env.template not found"
     fi
@@ -163,8 +167,7 @@ monitoring_add_target() {
   # Check if target file already exists
   if [ -f "$target_file" ]; then
     warn "Target file already exists: $target_file"
-    read -p "Overwrite? (y/N): " confirm
-    if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
+    if ! confirm "Overwrite?"; then
       log "Aborted"
       return 0
     fi
@@ -327,18 +330,10 @@ monitoring_alert_channel_add_email() {
     esac
   done
 
-  # Prompt for missing values
-  if [ -z "$to_email" ]; then
-    read -p "Alert recipient email: " to_email
-  fi
-
-  if [ -z "$from_email" ]; then
-    read -p "Alert sender email (or onboarding@resend.dev): " from_email
-  fi
-
-  if [ -z "$api_key" ]; then
-    read -p "Resend API key: " api_key
-  fi
+  # Prompt for missing values (or fail loudly when non-interactive)
+  [ -z "$to_email" ]   && read_or_fail to_email   "Alert recipient email: "
+  [ -z "$from_email" ] && read_or_fail from_email "Alert sender email (or onboarding@resend.dev): "
+  [ -z "$api_key" ]    && read_or_fail api_key    "Resend API key: " --secret
 
   # Update .env file
   log "Updating .env file..."
@@ -413,9 +408,7 @@ monitoring_alert_channel_add_slack() {
     esac
   done
 
-  if [ -z "$webhook_url" ]; then
-    read -p "Slack webhook URL: " webhook_url
-  fi
+  [ -z "$webhook_url" ] && read_or_fail webhook_url "Slack webhook URL: "
 
   # Update .env file
   if grep -q "^SLACK_WEBHOOK_URL=" "$env_file"; then
@@ -468,9 +461,7 @@ monitoring_alert_channel_add_webhook() {
     esac
   done
 
-  if [ -z "$webhook_url" ]; then
-    read -p "Webhook URL: " webhook_url
-  fi
+  [ -z "$webhook_url" ] && read_or_fail webhook_url "Webhook URL: "
 
   # Update .env file
   if grep -q "^ALERT_WEBHOOK_URL=" "$env_file"; then

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -274,10 +274,47 @@ require_cmd() {
 }
 
 # confirm <prompt> — returns 0 if user types y/yes, 1 otherwise
+#
+# Auto-yes paths (never blocks the caller):
+#   STRUT_YES=1  — set by --yes/-y or environment; returns 0 without prompting
+#   stdin not a TTY — returns 1 without prompting (fail-safe; caller sees "no")
+#
+# The stdin-TTY check prevents CI hangs when a script pipes into strut. Callers
+# that need "yes" in that case must set STRUT_YES=1 explicitly.
 confirm() {
   local prompt="${1:-Continue?}"
+  if [ "${STRUT_YES:-}" = "1" ] || [ "${STRUT_YES:-}" = "true" ]; then
+    log "$prompt [auto-yes: STRUT_YES=1]"
+    return 0
+  fi
+  if [ ! -t 0 ]; then
+    warn "$prompt — declining (no TTY; set STRUT_YES=1 to auto-approve)"
+    return 1
+  fi
+  local answer
   read -r -p "$(echo -e "${YELLOW}${prompt}${NC} [y/N] ")" answer
   [[ "$answer" =~ ^[Yy](es)?$ ]]
+}
+
+# read_or_fail <var_name> <prompt> [--secret]
+#
+# Prompt for a value interactively, or fail with a clear error when
+# non-interactive. Use this instead of a bare `read -p` for values (URLs,
+# tokens, emails) that don't have a boolean answer. Callers should first
+# check for a value from a --flag, and only call read_or_fail as a fallback.
+#
+#   --secret  — do not echo characters as they're typed (read -s)
+read_or_fail() {
+  local var_name="$1"
+  local prompt="$2"
+  local secret_flag=""
+  [ "${3:-}" = "--secret" ] && secret_flag="-s"
+  if [ ! -t 0 ]; then
+    fail "$prompt — no value provided and stdin is not a TTY (set the flag or run interactively)"
+  fi
+  # shellcheck disable=SC2229  # intentional: assign into var named by $var_name
+  read -r $secret_flag -p "$prompt" "$var_name"
+  [ -n "$secret_flag" ] && echo  # newline after silent read
 }
 
 # ── SSH helpers ───────────────────────────────────────────────────────────────

--- a/strut
+++ b/strut
@@ -298,6 +298,8 @@ usage() {
   echo "  --services <prof>  Service profile (messaging|ui|full)"
   echo "  --json             JSON output (where supported)"
   echo "  --dry-run          Preview destructive operations without executing"
+  echo "  --yes, -y          Auto-approve confirmation prompts (safe in CI)"
+  echo "                     (also honored via STRUT_YES=1)"
   echo "  --no-tui           Disable interactive TUI when called with no args"
   echo "                     (also honored via STRUT_NO_TUI=1)"
   echo ""
@@ -682,7 +684,7 @@ fi
 shift 2  # consume stack and command; remaining args are command-specific
 
 # ── Parse universal options ───────────────────────────────────────────────────
-# Only --env, --services, --json, and --dry-run are parsed globally.
+# Only --env, --services, --json, --dry-run, and --yes are parsed globally.
 # All other flags and positional args are passed through to command handlers.
 parse_common_flags "$@"
 ENV_NAME="$FLAGS_ENV_NAME"

--- a/tests/test_confirm.bats
+++ b/tests/test_confirm.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# ==================================================
+# test_confirm.bats — confirm() + read_or_fail() + --yes wiring
+# ==================================================
+# Property: interactive prompts never hang non-interactive callers.
+#   1. STRUT_YES=1 → confirm returns 0 without reading stdin
+#   2. Non-TTY stdin → confirm returns 1 (declines) without hanging
+#   3. read_or_fail → fails loudly (exit 1) when no TTY and no value
+#   4. --yes / -y flag → parse_common_flags sets STRUT_YES=1
+
+setup() {
+  CLI_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  export CLI_ROOT
+  # shellcheck disable=SC1091
+  source "$CLI_ROOT/lib/utils.sh"
+  # shellcheck disable=SC1091
+  source "$CLI_ROOT/lib/flags.sh"
+}
+
+# ── confirm(): STRUT_YES bypasses the read ──────────────────────────────
+@test "confirm returns 0 immediately when STRUT_YES=1 (no read)" {
+  STRUT_YES=1 run bash -c '
+    source "'"$CLI_ROOT"'/lib/utils.sh"
+    # No stdin piped and no timeout — if confirm reads, this test hangs.
+    confirm "Do the thing?" </dev/null
+  '
+  [ "$status" -eq 0 ]
+}
+
+@test "confirm returns 0 immediately when STRUT_YES=true (word form)" {
+  STRUT_YES=true run bash -c '
+    source "'"$CLI_ROOT"'/lib/utils.sh"
+    confirm "Do the thing?" </dev/null
+  '
+  [ "$status" -eq 0 ]
+}
+
+# ── confirm(): non-TTY stdin auto-declines (fail-safe) ──────────────────
+@test "confirm returns 1 without hanging when stdin is not a TTY" {
+  run bash -c '
+    source "'"$CLI_ROOT"'/lib/utils.sh"
+    # Redirect stdin from /dev/null — non-TTY, no data. Without the fix
+    # this would either hang forever or read empty and return 1 randomly.
+    confirm "Continue?" </dev/null
+  '
+  [ "$status" -eq 1 ]
+  # Should print a warning explaining why
+  [[ "$output" == *"no TTY"* ]] || [[ "$output" == *"STRUT_YES"* ]]
+}
+
+# ── read_or_fail(): fails hard when non-interactive and no value ────────
+@test "read_or_fail exits non-zero when non-interactive and no value provided" {
+  run bash -c '
+    source "'"$CLI_ROOT"'/lib/utils.sh"
+    read_or_fail my_value "Enter value: " </dev/null
+    echo "should not reach here"
+  '
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"should not reach here"* ]]
+}
+
+# ── flags: --yes and -y set STRUT_YES=1 ─────────────────────────────────
+@test "parse_common_flags: --yes exports STRUT_YES=1" {
+  unset STRUT_YES
+  parse_common_flags --yes deploy --env prod
+  [ "${STRUT_YES:-}" = "1" ]
+}
+
+@test "parse_common_flags: -y exports STRUT_YES=1" {
+  unset STRUT_YES
+  parse_common_flags -y deploy --env prod
+  [ "${STRUT_YES:-}" = "1" ]
+}
+
+@test "parse_common_flags: --yes leaves other args in FLAGS_POSITIONAL" {
+  unset STRUT_YES
+  parse_common_flags deploy --env prod --yes some-service
+  [ "${STRUT_YES:-}" = "1" ]
+  [ "${FLAGS_ENV_NAME}" = "prod" ]
+  [ "${#FLAGS_POSITIONAL[@]}" -eq 2 ]
+  [ "${FLAGS_POSITIONAL[0]}" = "deploy" ]
+  [ "${FLAGS_POSITIONAL[1]}" = "some-service" ]
+}


### PR DESCRIPTION
Two closely-related safety fixes discovered during the roadmap audit.

## 1. `STRUT_YES` / `--yes` — closes the CI-hang class

Interactive `read -p` prompts scattered across the code (monitor, cmd_deploy fallback, github-token, keys/pull) had **no non-interactive path** — any strut invocation under CI or with stdin redirected would hang forever.

- `lib/utils.sh` — `confirm()` honors `STRUT_YES=1` (auto-yes) and non-TTY stdin (auto-decline with a clear warning). New `read_or_fail()` helper for value-reads that fails loudly instead of hanging.
- `lib/flags.sh` — `--yes` / `-y` global flag exports `STRUT_YES=1`.
- `strut` — usage documents the new flag.
- 6 raw `read -p` sites in monitor.sh converted (`Overwrite?`, `Press Enter`, and 4 value-reads for email/api-key/webhook-url).
- 3 identical `Overwrite?` prompts in `keys/pull.sh` converted to `confirm()`.
- `github-token.sh` and `cmd_deploy.sh`'s local-fallback prompt converted.

7 new tests in `tests/test_confirm.bats` cover: STRUT_YES bypasses read; non-TTY declines without hanging; read_or_fail exits when non-interactive; `--yes` and `-y` both wire correctly.

## 2. `backup.sh` — guard against empty volume resolution (data safety)

Neo4j restore (line ~330) and generic tar.gz restore (line ~420) both did:

```bash
data_volume=$(docker inspect "$container_name" --format '{{...}}')
docker run --rm -v "$data_volume:/data" alpine sh -c 'rm -rf /data/*'
```

If the container wasn't running or lacked the `/data` mount, `docker inspect` returned empty, docker created an **anonymous volume**, and `rm -rf /data/*` wiped that (not the intended one). Added `[ -n "$data_volume" ] || fail ...` before every destructive volume operation.

## Tests
- 7 new bats: all pass.
- Full `bats tests/` suite: **1398/1398** (no regressions).