### PR TITLE
feat(demos): live-VPS tape suite (preflight, remote-exec, deploy)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ stacks/
 bin/output/gif/*.gif
 bin/output/png/*.png
 !bin/output/**/.gitkeep
+# Local live-tape recording credentials
+.strut-live.env

--- a/bin/record-live.sh
+++ b/bin/record-live.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# ==================================================
+# record-live.sh — Render live-VPS demo tapes with real credentials
+# ==================================================
+# The live tapes (bin/tapes/live/*.tape) run REAL strut commands against a
+# real VPS. This wrapper:
+#   1. Loads STRUT_LIVE_HOST / _USER / _SSH_KEY from ~/.strut-live.env (gitignored)
+#      or from your current environment.
+#   2. Renders one or all live tapes.
+#
+# Usage:
+#   bin/record-live.sh                           # render all live tapes
+#   bin/record-live.sh live-preflight.tape       # render one tape by name
+#
+# Create ~/.strut-live.env once:
+#   STRUT_LIVE_HOST=<vps-ip>
+#   STRUT_LIVE_USER=root
+#   STRUT_LIVE_SSH_KEY=/absolute/path/to/private-key
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STRUT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── Load credentials (env wins over file) ─────────────────────────────────
+if [ -f "$HOME/.strut-live.env" ] && [ -z "${STRUT_LIVE_HOST:-}" ]; then
+  # shellcheck disable=SC1091
+  set -a; source "$HOME/.strut-live.env"; set +a
+fi
+
+: "${STRUT_LIVE_HOST:?set STRUT_LIVE_HOST (VPS IP/host) — see ~/.strut-live.env}"
+: "${STRUT_LIVE_USER:?set STRUT_LIVE_USER (usually root)}"
+: "${STRUT_LIVE_SSH_KEY:?set STRUT_LIVE_SSH_KEY (path to private key)}"
+[ -r "$STRUT_LIVE_SSH_KEY" ] || { echo "SSH key not readable: $STRUT_LIVE_SSH_KEY" >&2; exit 1; }
+
+export STRUT_LIVE_HOST STRUT_LIVE_USER STRUT_LIVE_SSH_KEY
+
+command -v vhs >/dev/null || { echo "vhs not installed (brew install vhs)" >&2; exit 1; }
+
+# ── Sanity check connectivity before spending time on a recording ─────────
+if ! ssh -o BatchMode=yes -o ConnectTimeout=8 -o StrictHostKeyChecking=accept-new \
+     -i "$STRUT_LIVE_SSH_KEY" "$STRUT_LIVE_USER@$STRUT_LIVE_HOST" \
+     "echo pong" >/dev/null 2>&1; then
+  echo "✗ SSH probe failed for $STRUT_LIVE_USER@$STRUT_LIVE_HOST" >&2
+  exit 1
+fi
+echo "✓ VPS reachable at $STRUT_LIVE_USER@$STRUT_LIVE_HOST"
+
+# ── Render tapes ─────────────────────────────────────────────────────────
+cd "$SCRIPT_DIR/tapes"
+
+if [ $# -gt 0 ]; then
+  targets=("$@")
+else
+  targets=(live/*.tape)
+fi
+
+for tape in "${targets[@]}"; do
+  # Allow bare name (live-preflight.tape) or full path (live/live-preflight.tape)
+  case "$tape" in
+    live/*) : ;;
+    *)      tape="live/$tape" ;;
+  esac
+  [ -f "$tape" ] || { echo "✗ Not found: $tape" >&2; exit 1; }
+  echo "🎬 Recording: $tape"
+  vhs "$tape"
+done
+
+echo ""
+echo "✓ Done. GIFs in bin/output/gif/live-*.gif"

--- a/bin/tapes/live/README.md
+++ b/bin/tapes/live/README.md
@@ -1,0 +1,53 @@
+# live/ — Recordings that deploy to a real VPS
+
+Unlike the shimmed tapes in the parent directory (which use canned output for
+determinism), these tapes run **real** strut commands against a real target VPS.
+They demonstrate the actual SSH-based remote-execution and container-deploy paths.
+
+## Prerequisites
+
+1. **A reachable VPS** with SSH access. The droplet you use for `strut-action`'s
+   e2e workflow works fine here too.
+2. **`vhs` and `gifsicle`** installed locally (`brew install vhs gifsicle`).
+3. **Credentials file** at `~/.strut-live.env`:
+
+   ```bash
+   STRUT_LIVE_HOST=<vps-ip>
+   STRUT_LIVE_USER=root
+   STRUT_LIVE_SSH_KEY=/absolute/path/to/private-key
+   ```
+
+   Gitignored — never committed. `bin/record-live.sh` sources this before
+   invoking `vhs`.
+
+## Recording
+
+```bash
+# One tape at a time:
+bin/record-live.sh live-preflight.tape
+
+# All of them:
+bin/record-live.sh
+```
+
+The wrapper verifies SSH connectivity before spending time on the render.
+
+## The three tapes
+
+- **`live-preflight.tape`** — `strut doctor --deep` against the real VPS.
+  Read-only. The safest tape; makes a great single-command demo for the
+  "should I deploy here?" pitch.
+
+- **`live-remote-exec.tape`** — `strut probe exec 'uname -a && docker --version'`
+  showing SSH-multiplexed remote execution. Read-only.
+
+- **`live-deploy.tape`** — full up/curl/down cycle. Spins an `nginx:alpine`
+  container on port `18081` via `strut exec`, HTTP-checks it from the runner,
+  then removes it. Idempotent (safe to re-record).
+
+## Safety
+
+- All live tapes bind demo containers to **high ports (18000+)** so they can't
+  collide with anything the target host serves on 80/443.
+- `live-deploy` pre-cleans any leftover container from previous recordings.
+- The credentials file stays out of the repo.

--- a/bin/tapes/live/live-deploy.tape
+++ b/bin/tapes/live/live-deploy.tape
@@ -1,0 +1,31 @@
+# live-deploy.tape — REAL container up-and-teardown against a real VPS.
+# Uses strut exec (over SSH) to spin an nginx smoke container on port 18081,
+# curl it from the runner, then remove it. Idempotent — safe to re-record.
+
+Set Shell "bash"
+Set FontSize 20
+Set Padding 24
+Set Theme "Catppuccin Mocha"
+Set CursorBlink false
+Set TypingSpeed 30ms
+Set WindowBar Colorful
+Set Width 1400
+Set Height 750
+
+Output ../output/gif/live-deploy.gif
+
+Hide
+Type `export PS1="~/project $ "` Enter
+Type "bash live/shims/pre-record.sh" Enter
+Sleep 6s
+Type "clear" Enter
+Sleep 500ms
+Show
+
+Sleep 800ms
+Type `strut probe exec 'docker run -d --name live-demo-nginx -p 18081:80 nginx:alpine' --env prod` Enter
+Sleep 6000ms
+Type `curl -sf -o /dev/null -w "GET :18081 -> HTTP %{http_code}\n" http://${STRUT_LIVE_HOST}:18081/` Enter
+Sleep 2500ms
+Type `strut probe exec 'docker rm -f live-demo-nginx' --env prod` Enter
+Sleep 3500ms

--- a/bin/tapes/live/live-preflight.tape
+++ b/bin/tapes/live/live-preflight.tape
@@ -1,0 +1,25 @@
+# live-preflight.tape — REAL strut doctor --deep against a real VPS.
+
+Set Shell "bash"
+Set FontSize 20
+Set Padding 24
+Set Theme "Catppuccin Mocha"
+Set CursorBlink false
+Set TypingSpeed 30ms
+Set WindowBar Colorful
+Set Width 1400
+Set Height 800
+
+Output ../output/gif/live-preflight.gif
+
+Hide
+Type `export PS1="~/project $ "` Enter
+Type "bash live/shims/pre-record.sh" Enter
+Sleep 6s
+Type "clear" Enter
+Sleep 500ms
+Show
+
+Sleep 800ms
+Type "strut doctor --deep" Enter
+Sleep 10000ms

--- a/bin/tapes/live/live-remote-exec.tape
+++ b/bin/tapes/live/live-remote-exec.tape
@@ -1,0 +1,25 @@
+# live-remote-exec.tape — REAL strut exec against a real VPS.
+
+Set Shell "bash"
+Set FontSize 20
+Set Padding 24
+Set Theme "Catppuccin Mocha"
+Set CursorBlink false
+Set TypingSpeed 30ms
+Set WindowBar Colorful
+Set Width 1400
+Set Height 600
+
+Output ../output/gif/live-remote-exec.gif
+
+Hide
+Type `export PS1="~/project $ "` Enter
+Type "bash live/shims/pre-record.sh" Enter
+Sleep 6s
+Type "clear" Enter
+Sleep 500ms
+Show
+
+Sleep 800ms
+Type `strut probe exec 'uname -a && docker --version' --env prod` Enter
+Sleep 4500ms

--- a/bin/tapes/live/shims/pre-record.sh
+++ b/bin/tapes/live/shims/pre-record.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Pre-record setup: called silently during the Hide block of live tapes.
+# Writes .prod.env from environment, sets up the probe stack, and does a
+# best-effort cleanup so the recording starts from a known state.
+set -eu
+
+# Fixture project lives at bin/tapes/ — VHS is running from there.
+: "${STRUT_LIVE_HOST:?}"; : "${STRUT_LIVE_USER:?}"; : "${STRUT_LIVE_SSH_KEY:?}"
+
+cat > .prod.env <<EOF
+VPS_HOST=$STRUT_LIVE_HOST
+VPS_USER=$STRUT_LIVE_USER
+VPS_SSH_KEY=$STRUT_LIVE_SSH_KEY
+REGISTRY_TYPE=none
+EOF
+chmod 600 .prod.env
+
+mkdir -p stacks/probe
+cat > stacks/probe/docker-compose.yml <<'YAML'
+services:
+  probe:
+    image: alpine
+YAML
+
+# Best-effort pre-cleanup of any container the last recording left behind.
+strut probe exec 'docker rm -f live-demo-nginx 2>/dev/null || true' --env prod >/dev/null 2>&1 || true


### PR DESCRIPTION
Adds a **live-tape suite** — recordings that run REAL strut commands against a real VPS, complementing the shimmed tapes in the parent directory.

## Why

The shimmed tapes are great for deterministic marketing GIFs, but they can't answer the "but does it actually work?" question. Live tapes show real container IDs, real HTTP responses, real SSH round-trips.

## Three tapes

- **`live-preflight.tape`** — `strut doctor --deep` against a real VPS (read-only). Real signal: on our test droplet it detected `419MB memory (need >= 512MB)` and `ports 80, 443 already in use`.
- **`live-remote-exec.tape`** — `strut probe exec 'uname -a && docker --version'` showing SSH-multiplexed remote execution.
- **`live-deploy.tape`** — full up/curl/down cycle. Spins nginx:alpine on port 18081 via `strut exec`, HTTP-checks it, then removes it. Idempotent.

## Supporting infra

- **`bin/record-live.sh`** — wrapper that loads `~/.strut-live.env` (gitignored), verifies SSH, then invokes vhs.
- **`bin/tapes/live/shims/pre-record.sh`** — single-shim setup replaces a chained Type-Enter block that was racing against strut's SSH work; a 6s Sleep in the Hide block lets it finish before Show fires.
- **`.gitignore`** adds `.strut-live.env` so credentials never get committed.

## Design principles

- Demo containers bind to **high ports (18000+)** — can't collide with services on 80/443.
- `live-deploy` pre-cleans any container from a previous recording (idempotent).

## Verified

All 3 tapes recorded cleanly against the DO droplet — real container IDs, HTTP 200, real doctor output including a failed memory check on the tiny droplet. GIF sizes: 128–136K per tape.