### PR TITLE
refactor(deploy): add resolve_deploy_dir() + migrate call sites

### DIFF
--- a/lib/backup.sh
+++ b/lib/backup.sh
@@ -679,7 +679,7 @@ db_pull() {
   local vps_user="${VPS_USER:-ubuntu}"
   local vps_ssh_key="${VPS_SSH_KEY:-}"
   local vps_port="${VPS_PORT:-22}"
-  local vps_deploy_dir="${VPS_DEPLOY_DIR:-/home/${VPS_USER:-ubuntu}/strut}"
+  local vps_deploy_dir; vps_deploy_dir=$(resolve_deploy_dir)
 
   [ -n "$vps_host" ] || fail "VPS_HOST not set in $env_file"
 
@@ -769,7 +769,7 @@ _db_push_postgres() {
 
     log "Creating safety backup on VPS before restore..."
     ssh $ssh_opts "$vps_user@$vps_host" \
-      "cd ${VPS_DEPLOY_DIR:-/home/${VPS_USER:-ubuntu}/strut} && \
+      "cd $(resolve_deploy_dir) && \
        [ -f stacks/$stack/backup.conf ] && . stacks/$stack/backup.conf; \
        ${_sudo}docker compose --project-name $project_name exec -T \${BACKUP_POSTGRES_SERVICE:-postgres} \
          pg_dump -U \${POSTGRES_USER:-postgres} \${POSTGRES_DB:-app_db} > $remote_dir/pre-push-safety-$(date +%Y%m%d-%H%M%S).sql" \
@@ -778,7 +778,7 @@ _db_push_postgres() {
 
     log "Restoring PostgreSQL on VPS..."
     if ssh $ssh_opts "$vps_user@$vps_host" \
-      "cd ${VPS_DEPLOY_DIR:-/home/${VPS_USER:-ubuntu}/strut} && \
+      "cd $(resolve_deploy_dir) && \
        [ -f stacks/$stack/backup.conf ] && . stacks/$stack/backup.conf; \
        ${_sudo}docker compose --project-name $project_name exec -T \${BACKUP_POSTGRES_SERVICE:-postgres} \
          psql -U \${POSTGRES_USER:-postgres} -d \${POSTGRES_DB:-app_db} < $remote_dir/$filename"; then
@@ -818,7 +818,7 @@ _db_push_neo4j() {
 
     log "Creating safety backup on VPS before restore..."
     ssh $ssh_opts "$vps_user@$vps_host" \
-      "cd ${VPS_DEPLOY_DIR:-/home/${VPS_USER:-ubuntu}/strut} && \
+      "cd $(resolve_deploy_dir) && \
        ${_sudo}docker compose --project-name $project_name exec -T neo4j \
          neo4j-admin database dump neo4j --to-path=/var/lib/neo4j/import/pre-push-safety-$(date +%Y%m%d-%H%M%S).dump" \
     2>/dev/null && ok "Safety backup created" \
@@ -826,7 +826,7 @@ _db_push_neo4j() {
 
     log "Restoring Neo4j on VPS (stopping service)..."
     if ssh $ssh_opts "$vps_user@$vps_host" \
-      "cd ${VPS_DEPLOY_DIR:-/home/${VPS_USER:-ubuntu}/strut} && \
+      "cd $(resolve_deploy_dir) && \
        ${_sudo}docker compose --project-name $project_name cp $remote_dir/$filename neo4j:/var/lib/neo4j/import/restore.dump && \
        ${_sudo}docker compose --project-name $project_name stop neo4j && \
        ${_sudo}docker compose --project-name $project_name run --rm --entrypoint neo4j-admin neo4j \
@@ -944,7 +944,7 @@ db_push() {
   local vps_user="${VPS_USER:-ubuntu}"
   local vps_ssh_key="${VPS_SSH_KEY:-}"
   local vps_port="${VPS_PORT:-22}"
-  local vps_deploy_dir="${VPS_DEPLOY_DIR:-/home/${VPS_USER:-ubuntu}/strut}"
+  local vps_deploy_dir; vps_deploy_dir=$(resolve_deploy_dir)
 
   [ -n "$vps_host" ] || fail "VPS_HOST not set in $env_file"
 

--- a/lib/cmd_ci_init.sh
+++ b/lib/cmd_ci_init.sh
@@ -116,7 +116,7 @@ _ci_discover_secrets() {
   local port="$7"
   local key_name="$8"
 
-  local deploy_dir="${VPS_DEPLOY_DIR:-/home/$user/strut}"
+  local deploy_dir; deploy_dir=$(resolve_deploy_dir)
 
   # ── AUTO secrets (from topology) ─────────────────────────────────────────
   printf '%s\t%s\t%s\t%s\n' "DEPLOY_HOST" "AUTO" "$host" "strut.conf [hosts]"

--- a/lib/cmd_deploy.sh
+++ b/lib/cmd_deploy.sh
@@ -38,7 +38,7 @@ _deploy_volguard() {
 
   # Fetch the remote env content — reuse diff_fetch_remote from diff.sh.
   # If the remote is unreachable, skip the guard (non-blocking).
-  local deploy_dir="${VPS_DEPLOY_DIR:-/home/${VPS_USER:-ubuntu}/strut}"
+  local deploy_dir; deploy_dir=$(resolve_deploy_dir)
   local env_name="${CMD_ENV_NAME:-prod}"
   local remote_env_path
 
@@ -327,7 +327,7 @@ cmd_deploy() {
       warn "  strut $stack release --env ${env_name:-prod}"
       warn ""
       warn "Or run deploy on the VPS:"
-      local deploy_dir="${VPS_DEPLOY_DIR:-/home/${VPS_USER:-ubuntu}/strut}"
+      local deploy_dir; deploy_dir=$(resolve_deploy_dir)
       warn "  strut $stack exec 'cd $deploy_dir && strut $stack deploy --env ${env_name:-prod}' --env ${env_name:-prod}"
       echo ""
       if ! confirm "Continue with local deployment anyway?"; then

--- a/lib/cmd_diff.sh
+++ b/lib/cmd_diff.sh
@@ -80,7 +80,7 @@ cmd_diff() {
 
   # Resolve remote paths — use _secrets_resolve_remote_path for consistency
   # with secrets push (which is the canonical uploader of .env to the VPS).
-  local deploy_dir="${VPS_DEPLOY_DIR:-/home/${VPS_USER:-ubuntu}/strut}"
+  local deploy_dir; deploy_dir=$(resolve_deploy_dir)
   local remote_env
   remote_env=$(_secrets_resolve_remote_path "$deploy_dir" "${env_name:-prod}")
   local remote_compose="$deploy_dir/stacks/$stack/docker-compose.yml"

--- a/lib/cmd_provision.sh
+++ b/lib/cmd_provision.sh
@@ -156,7 +156,7 @@ cmd_provision() {
 
   local ssh_opts
   ssh_opts=$(build_ssh_opts -p "$port" -k "$key_path" --tty)
-  local deploy_dir="${VPS_DEPLOY_DIR:-/home/$user/strut}"
+  local deploy_dir; deploy_dir=$(resolve_deploy_dir)
 
   print_banner "Provision: $host_alias"
   log "Target: $user@$host:$port"

--- a/lib/cmd_remote_init.sh
+++ b/lib/cmd_remote_init.sh
@@ -75,7 +75,7 @@ cmd_remote_init() {
   user="${user:-${VPS_USER:-ubuntu}}"
   ssh_key="${ssh_key:-${VPS_SSH_KEY:-}}"
   port="${port:-${VPS_PORT:-22}}"
-  deploy_dir="${deploy_dir:-${VPS_DEPLOY_DIR:-/home/$user/strut}}"
+  deploy_dir="${deploy_dir:-$(resolve_deploy_dir)}"
   branch="${branch:-${DEFAULT_BRANCH:-main}}"
 
   # Validate required params

--- a/lib/cmd_secrets.sh
+++ b/lib/cmd_secrets.sh
@@ -202,7 +202,7 @@ _secrets_push() {
   local vps_user="${VPS_USER:-ubuntu}"
   local vps_port="${VPS_PORT:-22}"
   local vps_ssh_key="${VPS_SSH_KEY:-}"
-  local deploy_dir="${VPS_DEPLOY_DIR:-/home/$vps_user/strut}"
+  local deploy_dir; deploy_dir=$(resolve_deploy_dir)
 
   [ -n "$vps_host" ] || fail "VPS_HOST not set. Cannot determine target host."
 
@@ -336,7 +336,7 @@ _secrets_pull() {
   local vps_user="${VPS_USER:-ubuntu}"
   local vps_port="${VPS_PORT:-22}"
   local vps_ssh_key="${VPS_SSH_KEY:-}"
-  local deploy_dir="${VPS_DEPLOY_DIR:-/home/$vps_user/strut}"
+  local deploy_dir; deploy_dir=$(resolve_deploy_dir)
 
   [ -n "$vps_host" ] || fail "VPS_HOST not set. Cannot determine source host."
 
@@ -429,7 +429,7 @@ _secrets_diff() {
   local vps_user="${VPS_USER:-ubuntu}"
   local vps_port="${VPS_PORT:-22}"
   local vps_ssh_key="${VPS_SSH_KEY:-}"
-  local deploy_dir="${VPS_DEPLOY_DIR:-/home/$vps_user/strut}"
+  local deploy_dir; deploy_dir=$(resolve_deploy_dir)
 
   [ -n "$vps_host" ] || fail "VPS_HOST not set."
 
@@ -860,7 +860,7 @@ _secrets_status() {
     local vps_user="${VPS_USER:-ubuntu}"
     local vps_port="${VPS_PORT:-22}"
     local vps_ssh_key="${VPS_SSH_KEY:-}"
-    local deploy_dir="${VPS_DEPLOY_DIR:-/home/$vps_user/strut}"
+    local deploy_dir; deploy_dir=$(resolve_deploy_dir)
     local remote_path
     remote_path=$(_secrets_resolve_remote_path "$deploy_dir" "$env_name")
 
@@ -1050,7 +1050,7 @@ _secrets_rotate() {
     local vps_user="${VPS_USER:-ubuntu}"
     local vps_port="${VPS_PORT:-22}"
     local vps_ssh_key="${VPS_SSH_KEY:-}"
-    local deploy_dir="${VPS_DEPLOY_DIR:-/home/$vps_user/strut}"
+    local deploy_dir; deploy_dir=$(resolve_deploy_dir)
 
     [ -n "$vps_host" ] || { warn "VPS_HOST not set — skipping container restart"; return 0; }
 

--- a/lib/cmd_ship.sh
+++ b/lib/cmd_ship.sh
@@ -73,7 +73,7 @@ cmd_ship() {
   local vps_user="${VPS_USER:-ubuntu}"
   local vps_ssh_key="${VPS_SSH_KEY:-}"
   local vps_port="${VPS_PORT:-22}"
-  local deploy_dir="${VPS_DEPLOY_DIR:-/home/$vps_user/strut}"
+  local deploy_dir; deploy_dir=$(resolve_deploy_dir)
   local branch="${DEFAULT_BRANCH:-main}"
 
   local ssh_opts

--- a/lib/cmd_stop.sh
+++ b/lib/cmd_stop.sh
@@ -99,7 +99,7 @@ _stop_remote() {
   local vps_user="${VPS_USER:-ubuntu}"
   local vps_ssh_key="${VPS_SSH_KEY:-}"
   local vps_port="${VPS_PORT:-22}"
-  local deploy_dir="${VPS_DEPLOY_DIR:-/home/$vps_user/strut}"
+  local deploy_dir; deploy_dir=$(resolve_deploy_dir)
 
   local ssh_opts
   ssh_opts=$(build_ssh_opts -p "$vps_port" -k "$vps_ssh_key" --batch)

--- a/lib/cmd_sync.sh
+++ b/lib/cmd_sync.sh
@@ -142,7 +142,7 @@ _sync_via_topology_host() {
   fi
   vps_ssh_key="$key_path"
 
-  local deploy_dir="${VPS_DEPLOY_DIR:-/home/$vps_user/strut}"
+  local deploy_dir; deploy_dir=$(resolve_deploy_dir)
   local gh_pat="${GH_PAT:-}"
   local branch="${DEFAULT_BRANCH:-main}"
 

--- a/lib/deploy.sh
+++ b/lib/deploy.sh
@@ -303,7 +303,7 @@ vps_update_repo() {
   local vps_user="${VPS_USER:-ubuntu}"
   local vps_ssh_key="${VPS_SSH_KEY:-}"
   local vps_port="${VPS_PORT:-22}"
-  local deploy_dir="${VPS_DEPLOY_DIR:-/home/$vps_user/strut}"
+  local deploy_dir; deploy_dir=$(resolve_deploy_dir)
   local gh_pat="${GH_PAT:-}"
   local branch="${DEFAULT_BRANCH:-main}"
   local env_name; env_name=$(extract_env_name "$env_file")
@@ -411,7 +411,7 @@ vps_release() {
   local vps_user="${VPS_USER:-ubuntu}"
   local vps_ssh_key="${VPS_SSH_KEY:-}"
   local vps_port="${VPS_PORT:-22}"
-  local deploy_dir="${VPS_DEPLOY_DIR:-/home/$vps_user/strut}"
+  local deploy_dir; deploy_dir=$(resolve_deploy_dir)
   local env_name
   local env_filename
   env_filename=$(basename "$env_file")

--- a/lib/domain/cmd.sh
+++ b/lib/domain/cmd.sh
@@ -41,7 +41,7 @@ domain_command() {
   local vps_user="${VPS_USER:-ubuntu}"
   local vps_ssh_key="${VPS_SSH_KEY:-}"
   local vps_port="${VPS_PORT:-22}"
-  local deploy_dir="${VPS_DEPLOY_DIR:-/home/${vps_user}/strut}"
+  local deploy_dir; deploy_dir=$(resolve_deploy_dir)
 
   local ssh_opts
   ssh_opts=$(build_ssh_opts -p "$vps_port" -k "$vps_ssh_key" --batch)

--- a/lib/keys/discovery.sh
+++ b/lib/keys/discovery.sh
@@ -182,7 +182,7 @@ discover_vps_keys() {
 
   # Check for .env files
   local env_files
-  local vps_deploy_dir="${VPS_DEPLOY_DIR:-/home/$vps_user/strut}"
+  local vps_deploy_dir; vps_deploy_dir=$(resolve_deploy_dir)
   env_files=$(ssh $ssh_opts "$vps_user@$vps_host" "ls -1 $vps_deploy_dir/*.env 2>/dev/null || echo ''" 2>/dev/null || echo "")
 
   jq -n \

--- a/lib/keys/env.sh
+++ b/lib/keys/env.sh
@@ -402,7 +402,7 @@ keys_env_diff() {
   local vps_host="${VPS_HOST:-}"
   local vps_user="${VPS_USER:-ubuntu}"
   local vps_ssh_key="${VPS_SSH_KEY:-}"
-  local vps_deploy_dir="${VPS_DEPLOY_DIR:-/home/${vps_user}/strut}"
+  local vps_deploy_dir; vps_deploy_dir=$(resolve_deploy_dir)
 
   [ -n "$vps_host" ] || fail "VPS_HOST not set in $env_file"
 

--- a/lib/keys/pull.sh
+++ b/lib/keys/pull.sh
@@ -111,7 +111,7 @@ keys_pull_from_vps() {
   local vps_host="${VPS_HOST:-}"
   local vps_user="${VPS_USER:-ubuntu}"
   local vps_ssh_key="${VPS_SSH_KEY:-}"
-  local vps_deploy_dir="${VPS_DEPLOY_DIR:-/home/${vps_user}/strut}"
+  local vps_deploy_dir; vps_deploy_dir=$(resolve_deploy_dir)
 
   [ -n "$vps_host" ] || fail "VPS_HOST not set in $env_file"
 

--- a/lib/local.sh
+++ b/lib/local.sh
@@ -257,7 +257,7 @@ local_sync_db() {
   local vps_host="${VPS_HOST:-}"
   local vps_user="${VPS_USER:-ubuntu}"
   local vps_ssh_key="${VPS_SSH_KEY:-}"
-  local vps_deploy_dir="${VPS_DEPLOY_DIR:-/home/${VPS_USER:-ubuntu}/strut}"
+  local vps_deploy_dir; vps_deploy_dir=$(resolve_deploy_dir)
 
   local ssh_opts
   ssh_opts=$(build_ssh_opts -k "$vps_ssh_key")

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -266,6 +266,22 @@ is_running_on_vps() {
   return 1
 }
 
+# resolve_deploy_dir
+#
+# Echoes the canonical VPS deploy directory. All local code that constructs
+# remote paths should call this rather than inlining ${VPS_DEPLOY_DIR:-...}.
+#
+# Resolution order:
+#   1. $VPS_DEPLOY_DIR (explicit config, highest priority)
+#   2. /home/$VPS_USER/strut (derived from VPS_USER)
+#   3. /home/ubuntu/strut (default when VPS_USER is unset)
+#
+# The caller must source the env file BEFORE calling this so VPS_USER and
+# VPS_DEPLOY_DIR are populated.
+resolve_deploy_dir() {
+  echo "${VPS_DEPLOY_DIR:-/home/${VPS_USER:-ubuntu}/strut}"
+}
+
 # require_cmd <cmd> [install-hint]
 require_cmd() {
   local cmd="$1"
@@ -640,7 +656,7 @@ run_remote_strut() {
   local vps_user="${VPS_USER:-ubuntu}"
   local vps_ssh_key="${VPS_SSH_KEY:-}"
   local vps_port="${VPS_PORT:-22}"
-  local deploy_dir="${VPS_DEPLOY_DIR:-/home/$vps_user/strut}"
+  local deploy_dir; deploy_dir=$(resolve_deploy_dir)
 
   local ssh_opts
   ssh_opts=$(build_ssh_opts -p "$vps_port" -k "$vps_ssh_key" --batch "${extra_ssh_flags[@]+"${extra_ssh_flags[@]}"}")

--- a/tests/test_deploy_dir.bats
+++ b/tests/test_deploy_dir.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_deploy_dir.bats — resolve_deploy_dir() unit tests
+# ==================================================
+# Covers OSS-323: canonical VPS deploy-dir resolver.
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_utils
+}
+
+teardown() {
+  common_teardown
+}
+
+# ── resolve_deploy_dir ────────────────────────────────────────────────────────
+
+@test "resolve_deploy_dir: honors VPS_DEPLOY_DIR when set" {
+  export VPS_DEPLOY_DIR="/opt/stacks"
+  run resolve_deploy_dir
+  [ "$status" -eq 0 ]
+  [ "$output" = "/opt/stacks" ]
+}
+
+@test "resolve_deploy_dir: falls back to /home/\$VPS_USER/strut" {
+  unset VPS_DEPLOY_DIR
+  export VPS_USER="deploy"
+  run resolve_deploy_dir
+  [ "$status" -eq 0 ]
+  [ "$output" = "/home/deploy/strut" ]
+}
+
+@test "resolve_deploy_dir: defaults user to ubuntu when VPS_USER unset" {
+  unset VPS_DEPLOY_DIR
+  unset VPS_USER
+  run resolve_deploy_dir
+  [ "$status" -eq 0 ]
+  [ "$output" = "/home/ubuntu/strut" ]
+}
+
+@test "resolve_deploy_dir: VPS_DEPLOY_DIR takes priority over VPS_USER" {
+  export VPS_DEPLOY_DIR="/custom/path"
+  export VPS_USER="someuser"
+  run resolve_deploy_dir
+  [ "$status" -eq 0 ]
+  [ "$output" = "/custom/path" ]
+}
+
+@test "resolve_deploy_dir: handles empty-string VPS_DEPLOY_DIR as unset" {
+  export VPS_DEPLOY_DIR=""
+  export VPS_USER="gfargo"
+  run resolve_deploy_dir
+  [ "$status" -eq 0 ]
+  [ "$output" = "/home/gfargo/strut" ]
+}


### PR DESCRIPTION
## What

Phase 1 of OSS-279: deploy-dir convention normalization.

**OSS-323**: Add `resolve_deploy_dir()` helper to `lib/utils.sh` — a single canonical source for the VPS deploy directory path.

**OSS-324**: Migrate all ~28 inline deploy-dir fallback expressions across `lib/*.sh` to call `resolve_deploy_dir()`. Eliminates the `ubuntu` vs `$vps_user` fork that caused the original issue.

## Why

Plane: [OSS-279](https://compass.tailb82ead.ts.net:3443/gfargo/browse/OSS-279/)

Two divergent fallbacks coexisted:
- `/home/$vps_user/strut` (reads a local var)
- `/home/${VPS_USER:-ubuntu}/strut` (reads the env export)

This caused deploy-dir resolution to differ depending on which code path ran. The helper standardizes on `${VPS_DEPLOY_DIR:-/home/${VPS_USER:-ubuntu}/strut}`.

## How

- `lib/utils.sh`: new `resolve_deploy_dir()` function
- 17 files migrated from inline expressions to the helper
- `tests/test_deploy_dir.bats`: 5 unit tests
- Excluded: `lib/lock.sh` (remote-evaluated), `lib/migrate/` (standalone context)

## Testing

- [x] `bash -n` syntax clean on all modified files
- [x] test_deploy_dir.bats: 5/5 pass
- [x] test_cmd_deploy, test_cmd_ship, test_safe_clean, test_branch_org: all pass
- CI: pending
