### PR TITLE
feat(doctor,config): working_dir deep probe + stack-aware env resolution

### DIFF
--- a/lib/cmd_doctor.sh
+++ b/lib/cmd_doctor.sh
@@ -338,6 +338,8 @@ ss -tlnH 2>/dev/null | awk '{print $4}' | awk -F: '{print $NF}' | sort -u | tr '
 echo ""
 echo "=== sudo ==="
 sudo -n true 2>/dev/null && echo "sudo: PASSWORDLESS" || echo "sudo: NEEDS_PASSWORD"
+echo "=== workingdir ==="
+docker ps -q 2>/dev/null | head -5 | xargs -r docker inspect --format '{{ index .Config.Labels "com.docker.compose.project.working_dir" }}' 2>/dev/null | sort -u | grep -v '^$' || echo "workingdir: EMPTY"
 REMOTE
 ); then
     _doc_fail "$label" "remote probe failed (timeout or SSH error)" ""
@@ -426,6 +428,29 @@ REMOTE
     _doc_pass "$label / sudo" "passwordless sudo works"
   else
     _doc_warn "$label / sudo" "sudo requires a password (some strut ops will fail)" "Add '$vps_user ALL=(ALL) NOPASSWD:ALL' to /etc/sudoers.d/"
+  fi
+
+  # ── workingdir ── (compose working_dir label from running containers)
+  local workingdir_lines
+  workingdir_lines=$(echo "$out" | awk '/^=== workingdir ===/{flag=1; next} /^===/{flag=0} flag')
+  if [[ "$workingdir_lines" == *"EMPTY"* ]] || [ -z "$workingdir_lines" ]; then
+    _doc_pass "$label / workingdir" "no running containers (skip)"
+  else
+    local expected_prefix
+    expected_prefix="$(resolve_deploy_dir)/stacks"
+    local mismatch_found=false
+    while IFS= read -r wdir; do
+      [ -z "$wdir" ] && continue
+      if [[ "$wdir" != "$expected_prefix"* ]]; then
+        _doc_warn "$label / workingdir" \
+          "container working_dir '$wdir' outside expected prefix '$expected_prefix'" \
+          "Check VPS_DEPLOY_DIR or re-deploy from the correct checkout"
+        mismatch_found=true
+      fi
+    done <<< "$workingdir_lines"
+    if ! $mismatch_found; then
+      _doc_pass "$label / workingdir" "all containers under $expected_prefix"
+    fi
   fi
 }
 

--- a/strut
+++ b/strut
@@ -450,14 +450,30 @@ cmd_list() {
 
 # resolve_env_file <stack> [env_name]
 # Returns the path to the env file.
-# If env_name is empty, defaults to .env in CLI_ROOT.
+# Resolution order (stack-aware, since v0.29.0):
+#   1. stacks/<stack>/.<env>.env  (stack-level override)
+#   2. $CLI_ROOT/.<env>.env       (project-level)
+#   3. stacks/<stack>/.env        (stack-level default, no env name)
+#   4. $CLI_ROOT/.env             (project-level default)
 resolve_env_file() {
   local stack="$1"
   local env_name="${2:-}"
+  local stack_dir="$CLI_ROOT/stacks/$stack"
+
   if [ -n "$env_name" ]; then
-    echo "$CLI_ROOT/.$env_name.env"
+    # Stack-level env file takes priority
+    if [ -f "$stack_dir/.$env_name.env" ]; then
+      echo "$stack_dir/.$env_name.env"
+    else
+      echo "$CLI_ROOT/.$env_name.env"
+    fi
   else
-    echo "$CLI_ROOT/.env"
+    # No env name: prefer stack-level .env, fallback to project root
+    if [ -f "$stack_dir/.env" ]; then
+      echo "$stack_dir/.env"
+    else
+      echo "$CLI_ROOT/.env"
+    fi
   fi
 }
 

--- a/tests/test_cli_resolve.bats
+++ b/tests/test_cli_resolve.bats
@@ -55,6 +55,46 @@ _load_cli_functions() {
   [[ "$result" == *"/.jitsi-prod.env" ]]
 }
 
+# ── resolve_env_file: stack-aware (since v0.29.0) ────────────────────────────
+
+@test "resolve_env_file: prefers stack-level env when file exists" {
+  _load_cli_functions
+  mkdir -p "$CLI_ROOT/stacks/my-stack"
+  echo "VPS_HOST=test" > "$CLI_ROOT/stacks/my-stack/.prod.env"
+  result=$(resolve_env_file "my-stack" "prod")
+  [[ "$result" == *"/stacks/my-stack/.prod.env" ]]
+}
+
+@test "resolve_env_file: falls back to project-level when stack-level absent" {
+  _load_cli_functions
+  local tmp_root; tmp_root=$(mktemp -d)
+  CLI_ROOT="$tmp_root"
+  mkdir -p "$tmp_root/stacks/my-stack"
+  # No .prod.env in stack dir
+  result=$(resolve_env_file "my-stack" "prod")
+  [[ "$result" == "$tmp_root/.prod.env" ]]
+  rm -rf "$tmp_root"
+}
+
+@test "resolve_env_file: no env name prefers stack-level .env" {
+  _load_cli_functions
+  mkdir -p "$CLI_ROOT/stacks/my-stack"
+  echo "VPS_HOST=test" > "$CLI_ROOT/stacks/my-stack/.env"
+  result=$(resolve_env_file "my-stack" "")
+  [[ "$result" == *"/stacks/my-stack/.env" ]]
+}
+
+@test "resolve_env_file: no env name falls back to project .env" {
+  _load_cli_functions
+  local tmp_root; tmp_root=$(mktemp -d)
+  CLI_ROOT="$tmp_root"
+  mkdir -p "$tmp_root/stacks/my-stack"
+  # No .env in stack dir
+  result=$(resolve_env_file "my-stack" "")
+  [[ "$result" == "$tmp_root/.env" ]]
+  rm -rf "$tmp_root"
+}
+
 # ── resolve_compose_cmd ───────────────────────────────────────────────────────
 
 @test "resolve_compose_cmd: builds correct command with stack and env" {

--- a/tests/test_doctor.bats
+++ b/tests/test_doctor.bats
@@ -287,3 +287,85 @@ teardown() {
   [[ "$output" == *"--deep"* ]]
   [[ "$output" == *"preflight"* ]]
 }
+
+# ── workingdir deep probe (OSS-325) ──────────────────────────────────────────
+
+@test "_doc_check_vps_deep: workingdir match emits pass" {
+  # Stub the SSH output to simulate a matching working_dir
+  local deploy_dir; deploy_dir=$(resolve_deploy_dir)
+  local fake_out="=== docker ===
+Docker version 24.0.7, build abcdef
+=== compose ===
+2.24.0
+=== disk ===
+10000000
+=== mem ===
+2000000
+=== ports ===
+22,
+=== sudo ===
+sudo: PASSWORDLESS
+=== workingdir ===
+${deploy_dir}/stacks/my-app"
+
+  # Override timeout+ssh to return our fake output
+  timeout() { shift; shift; echo "$fake_out"; }
+  export -f timeout
+
+  run _doc_check_vps_deep "prod" "-o BatchMode=yes" "ubuntu" "host.example.com"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"workingdir"* ]]
+  [[ "$output" == *"pass"* ]] || [[ "$output" == *"✓"* ]] || [[ "$output" == *"all containers"* ]]
+}
+
+@test "_doc_check_vps_deep: workingdir mismatch emits warn" {
+  local fake_out="=== docker ===
+Docker version 24.0.7, build abcdef
+=== compose ===
+2.24.0
+=== disk ===
+10000000
+=== mem ===
+2000000
+=== ports ===
+22,
+=== sudo ===
+sudo: PASSWORDLESS
+=== workingdir ===
+/opt/stacks/my-app"
+
+  timeout() { shift; shift; echo "$fake_out"; }
+  export -f timeout
+
+  export VPS_DEPLOY_DIR=""
+  export VPS_USER="ubuntu"
+
+  run _doc_check_vps_deep "prod" "-o BatchMode=yes" "ubuntu" "host.example.com"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"workingdir"* ]]
+  [[ "$output" == *"/opt/stacks/my-app"* ]]
+}
+
+@test "_doc_check_vps_deep: workingdir empty (no containers) skips cleanly" {
+  local fake_out="=== docker ===
+Docker version 24.0.7, build abcdef
+=== compose ===
+2.24.0
+=== disk ===
+10000000
+=== mem ===
+2000000
+=== ports ===
+22,
+=== sudo ===
+sudo: PASSWORDLESS
+=== workingdir ===
+workingdir: EMPTY"
+
+  timeout() { shift; shift; echo "$fake_out"; }
+  export -f timeout
+
+  run _doc_check_vps_deep "prod" "-o BatchMode=yes" "ubuntu" "host.example.com"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no running containers"* ]]
+}


### PR DESCRIPTION
## What

Phase 2 of OSS-279: deploy-dir convention enforcement.

**OSS-325**: Wire working_dir mismatch probe into `doctor --deep`. Compares the compose `working_dir` label on running containers against `resolve_deploy_dir()/stacks/*`. Reports pass/warn/skip.

**OSS-326**: Make `resolve_env_file` stack-aware. Now checks `stacks/<stack>/.<env>.env` first (stack-level override), falling back to `$CLI_ROOT/.<env>.env`. Aligns with `_secrets_resolve_local_env`.

## Why

Plane: [OSS-279](https://compass.tailb82ead.ts.net:3443/gfargo/browse/OSS-279/)

## How

- `lib/cmd_doctor.sh`: added `=== workingdir ===` SSH probe section + parsing
- `strut`: rewrote `resolve_env_file` with stack-dir-first lookup
- `tests/test_doctor.bats`: 3 new tests (match/mismatch/empty)
- `tests/test_cli_resolve.bats`: 4 new tests for stack-aware resolution

## Testing

- [x] `bash -n` clean on all modified files
- [x] test_doctor.bats workingdir tests: 3/3 pass
- [x] test_cli_resolve.bats: 8/8 pass (4 existing + 4 new)
- CI: pending
