### PR TITLE
feat(deploy): warn on env divergence from host active .env

### DIFF
--- a/lib/cmd_deploy.sh
+++ b/lib/cmd_deploy.sh
@@ -205,6 +205,7 @@ cmd_rebuild() {
 
   # Guard: detect data-destructive env changes before rebuilding
   _deploy_volguard "$stack" "$env_file" "$confirm_data_move" || return 1
+  diff_warn_env_divergence "$stack" "$env_file" "${CMD_STACK_DIR:-$CLI_ROOT/stacks/$stack}"
 
   # Delegate to the standard deploy pipeline
   deploy_stack "$stack" "$env_file" "$services"
@@ -250,6 +251,7 @@ cmd_release() {
 
   # Guard: detect data-destructive env changes before releasing to VPS
   _deploy_volguard "$stack" "$env_file" "$confirm_data_move" || return 1
+  diff_warn_env_divergence "$stack" "$env_file" "${CMD_STACK_DIR:-$CLI_ROOT/stacks/$stack}"
 
   vps_release "$stack" "$env_file" "$services"
 }
@@ -343,6 +345,7 @@ cmd_deploy() {
 
   # Guard: detect data-destructive env changes before deploying
   _deploy_volguard "$stack" "$env_file" "$confirm_data_move" || return 1
+  diff_warn_env_divergence "$stack" "$env_file" "${CMD_STACK_DIR:-$CLI_ROOT/stacks/$stack}"
 
   case "$deploy_mode" in
     blue-green)

--- a/lib/diff.sh
+++ b/lib/diff.sh
@@ -475,3 +475,70 @@ _diff_render_destructive_text() {
     esac
   done <<< "$tsv"
 }
+
+# diff_warn_env_divergence <stack> <env_file> <stack_dir>
+#
+# Warns (non-fatal) when the resolved env file differs from the host's
+# active .env for volume-defining vars. This catches the "wrong file entirely"
+# case: e.g., deploying with .prod.env while the host actually runs from .env
+# with different INSTALL_DIR. The volguard handles same-file value changes;
+# this function handles the file-identity mismatch.
+#
+# Skips silently when:
+#   - No VPS_HOST (local-only stack)
+#   - Remote fetch fails (non-blocking)
+#   - The resolved file IS the stack .env (no divergence possible)
+#   - No volume-defining vars differ
+diff_warn_env_divergence() {
+  local stack="$1"
+  local env_file="$2"
+  local stack_dir="$3"
+
+  # Only meaningful when deploying to a remote VPS
+  local vps_host="${VPS_HOST:-}"
+  [ -n "$vps_host" ] || return 0
+
+  # If the resolved file is already the stack-level .env, there's no
+  # secondary file to diverge from.
+  local basename_env
+  basename_env=$(basename "$env_file")
+  [ "$basename_env" != ".env" ] || return 0
+
+  # Fetch the host's active stack-level .env (compose auto-load path)
+  local deploy_dir
+  deploy_dir=$(resolve_deploy_dir)
+  local remote_stack_env_path="$deploy_dir/stacks/$stack/.env"
+  local remote_stack_env
+  remote_stack_env=$(diff_fetch_remote "$remote_stack_env_path" 2>/dev/null) || return 0
+  [ -n "$remote_stack_env" ] || return 0
+
+  # Read the local resolved env content
+  [ -f "$env_file" ] || return 0
+  local local_env_content
+  local_env_content=$(cat "$env_file")
+
+  # Diff and check for volume-defining var differences
+  local env_diff
+  env_diff=$(diff_env_content "$local_env_content" "$remote_stack_env")
+  [ -n "$env_diff" ] || return 0
+
+  # Filter to volume-defining vars only
+  local vol_diff=""
+  local kind key rest
+  while IFS=$'\x1f' read -r kind key rest; do
+    [ -z "$kind" ] && continue
+    if _diff_is_volume_heuristic_var "$key"; then
+      vol_diff="${vol_diff:+$vol_diff
+}$kind $key"
+    fi
+  done <<< "$env_diff"
+
+  [ -n "$vol_diff" ] || return 0
+
+  # Emit warning (non-fatal)
+  warn "Env divergence: '$basename_env' has different volume vars than the host's active .env"
+  warn "  Affected vars: $(echo "$vol_diff" | awk '{print $2}' | tr '\n' ' ')"
+  warn "  The host may be running from stacks/$stack/.env with different paths."
+  warn "  This is informational — the volguard will catch destructive changes."
+  return 0
+}

--- a/tests/test_cmd_deploy.bats
+++ b/tests/test_cmd_deploy.bats
@@ -375,3 +375,69 @@ EOF
   run cmd_health
   [ "$status" -eq 2 ]
 }
+
+# ── diff_warn_env_divergence (OSS-327) ────────────────────────────────────────
+
+@test "diff_warn_env_divergence: silent when no VPS_HOST" {
+  export VPS_HOST=""
+  run diff_warn_env_divergence "test-stack" "$TEST_TMP/.prod.env" "$TEST_TMP/stacks/test-stack"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "diff_warn_env_divergence: silent when resolved file is .env itself" {
+  export VPS_HOST="example.com"
+  touch "$TEST_TMP/.env"
+  run diff_warn_env_divergence "test-stack" "$TEST_TMP/.env" "$TEST_TMP/stacks/test-stack"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "diff_warn_env_divergence: warns when host .env has different volume var" {
+  export VPS_HOST="example.com"
+  export VPS_USER="ubuntu"
+  export VPS_DEPLOY_DIR=""
+
+  # Local .prod.env
+  cat > "$TEST_TMP/.prod.env" <<'EOF'
+VPS_HOST=example.com
+INSTALL_DIR=/opt/plane
+EOF
+
+  # Stub diff_fetch_remote to return host's .env with different INSTALL_DIR
+  diff_fetch_remote() {
+    echo "VPS_HOST=example.com
+INSTALL_DIR=./plane"
+  }
+  export -f diff_fetch_remote
+
+  run diff_warn_env_divergence "test-stack" "$TEST_TMP/.prod.env" "$TEST_TMP/stacks/test-stack"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"INSTALL_DIR"* ]]
+  [[ "$output" == *"divergence"* ]] || [[ "$output" == *"Divergence"* ]]
+}
+
+@test "diff_warn_env_divergence: silent when volume vars match" {
+  export VPS_HOST="example.com"
+  export VPS_USER="ubuntu"
+  export VPS_DEPLOY_DIR=""
+
+  cat > "$TEST_TMP/.prod.env" <<'EOF'
+VPS_HOST=example.com
+INSTALL_DIR=/opt/plane
+LOG_LEVEL=info
+EOF
+
+  # Host .env has same INSTALL_DIR
+  diff_fetch_remote() {
+    echo "VPS_HOST=example.com
+INSTALL_DIR=/opt/plane
+LOG_LEVEL=debug"
+  }
+  export -f diff_fetch_remote
+
+  run diff_warn_env_divergence "test-stack" "$TEST_TMP/.prod.env" "$TEST_TMP/stacks/test-stack"
+  [ "$status" -eq 0 ]
+  # LOG_LEVEL differs but it's not a volume var — should be silent
+  [[ "$output" != *"divergence"* ]] && [[ "$output" != *"Divergence"* ]]
+}


### PR DESCRIPTION
## What

**OSS-327**: Warn when the resolved env file diverges from the host's active `.env` for volume-defining vars.

## Why

Plane: [OSS-279](https://compass.tailb82ead.ts.net:3443/gfargo/browse/OSS-279/) Part B

When deploying with `.prod.env` but the host runs from a plain `.env` (compose auto-load) with different volume paths, the deploy could silently repoint data directories. The volguard catches same-file value changes; this catches the "wrong file entirely" case.

## How

- `lib/diff.sh`: new `diff_warn_env_divergence()` — fetches the host's `stacks/<stack>/.env`, diffs against the resolved env, filters to volume-defining vars, warns if they differ
- `lib/cmd_deploy.sh`: wired after volguard in cmd_deploy, cmd_release, cmd_rebuild
- Non-fatal (warn only) — the volguard handles the abort case

## Testing

- [x] 4 new tests: no-VPS silent, .env-itself silent, divergence warns, non-volume-var silent
- [x] Full test_cmd_deploy.bats: 30/30 pass
- CI: pending
