### PR TITLE
fix: python-api e2e test flake

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,7 +23,7 @@ jobs:
   integration:
     name: Integration (bats, Docker)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +44,10 @@ jobs:
 
       - name: Pre-pull test images
         # Warm the cache so the deploy step isn't measuring image-pull time.
-        run: docker pull nginx:alpine
+        run: |
+          docker pull nginx:alpine
+          docker pull python:3.12-slim
+          docker pull postgres:16-alpine
 
       - name: Run integration tests
         run: bats tests/integration/

--- a/templates/recipes/next-postgres/services.conf
+++ b/templates/recipes/next-postgres/services.conf
@@ -8,3 +8,6 @@ SERVICE_POSTGRES_DB=true
 
 SERVICE_PROXY_NAME=proxy
 SERVICE_PROXY_PORT=80
+
+# The web image is always built from ./app (no registry pull).
+BUILD_MODE=local

--- a/templates/recipes/python-api/services.conf
+++ b/templates/recipes/python-api/services.conf
@@ -5,3 +5,6 @@ SERVICE_API_HEALTH_PATH=/health
 SERVICE_POSTGRES_NAME=postgres
 SERVICE_POSTGRES_PORT=5432
 SERVICE_POSTGRES_DB=true
+
+# The API image is always built from ./app (no registry pull).
+BUILD_MODE=local

--- a/tests/integration/test_recipes_e2e.bats
+++ b/tests/integration/test_recipes_e2e.bats
@@ -164,15 +164,32 @@ EOF
 
   # deploy — skip validation (our placeholder password would trip the
   # weak-password scan) and skip locking (tmp stack, no concurrent access).
-  run "$CLI_ROOT/strut" "$stack" deploy --env test --skip-validation --no-lock
-  [ "$status" -eq 0 ]
+  # Retry up to 2 times to handle transient Docker build/network failures.
+  local deploy_ok=false
+  local attempt
+  for attempt in 1 2; do
+    run "$CLI_ROOT/strut" "$stack" deploy --env test --skip-validation --no-lock
+    if [ "$status" -eq 0 ]; then
+      deploy_ok=true
+      break
+    fi
+    echo "# deploy attempt $attempt failed (status=$status), retrying..." >&3
+    # Clean up before retry so ports/containers don't conflict.
+    docker compose \
+      --env-file "$env_file" \
+      --project-name "${stack}-test" \
+      -f "$stack_dir/docker-compose.yml" \
+      down --volumes --remove-orphans 2>/dev/null || true
+    sleep 5
+  done
+  [ "$deploy_ok" = "true" ]
 
   # Let postgres finish starting even if the deploy returned a bit early.
   local code=""
-  for _ in $(seq 1 30); do
+  for _ in $(seq 1 40); do
     code="$(curl -sf -o /dev/null -w '%{http_code}' "http://127.0.0.1:8000/health" || true)"
     [ "$code" = "200" ] && break
-    sleep 2
+    sleep 3
   done
   [ "$code" = "200" ]
 


### PR DESCRIPTION
## Problem

The `python-api full deploy` integration test (test 7) was failing intermittently in CI. The deploy step itself returned non-zero.

## Root Cause

The `python-api` and `next-postgres` recipes have `build: ./app` directives in their compose files, but `services.conf` didn't set `BUILD_MODE=local`. The deploy defaulted to `BUILD_MODE=registry` and tried to pull a nonexistent image (`testorg/e2e-python-api-...:latest`). While `--ignore-pull-failures` prevented a hard failure during pull, the subsequent `docker compose up -d` had to implicitly build the image — behavior that's fragile across Docker Compose versions and fails under CI resource pressure.

## Fix

1. **Set `BUILD_MODE=local`** in both `python-api` and `next-postgres` recipe `services.conf` files
2. **Add deploy retry logic** (2 attempts with cleanup between) for transient failures
3. **Pre-pull base images** (`python:3.12-slim`, `postgres:16-alpine`) in CI
4. **Increase health polling window** from 30x2s to 40x3s
5. **Bump integration timeout** from 10 to 15 minutes

## Testing

- All unit tests pass locally (`test_build_mode.bats`, `test_cmd_deploy.bats`)
- Recipe compose-config tests unaffected (only test 7 changed)
