### PR TITLE
fix(release): match release-please tag format to existing v* tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
     ".": {
       "release-type": "simple",
       "package-name": "strut",
+      "include-component-in-tag": false,
       "extra-files": [
         {
           "type": "generic",


### PR DESCRIPTION
## What
Adds \`"include-component-in-tag": false\` to \`release-please-config.json\`.

## Why
The first automated run (PR #293, closed) proposed \`v0.31.0\` with a changelog covering all 294 commits back to the initial commit. Root cause: with \`package-name: "strut"\` set, release-please defaults to expecting tags in the form \`strut-v<version>\`, but every tag in this repo is plain \`v<version>\` (v0.30.1, v0.30.0, ...). Since \`strut-v0.30.1\` never existed, release-please had no bootstrap point to anchor on and walked the entire history instead.

## How
\`include-component-in-tag: false\` restores the plain \`v${version}\` tag format so release-please correctly finds the existing \`v0.30.1\` tag and only considers commits after it.