### PR TITLE
fix(backup): isolate engine failures in backup all, run offsite sync

### DIFF
--- a/lib/backup/cmd.sh
+++ b/lib/backup/cmd.sh
@@ -243,20 +243,38 @@ backup_command() {
           esac
           run_cmd "$label" echo "$dump_desc → $(backup_engine_glob "$engine")"
         done
+        run_cmd "Offsite sync (if configured)" echo "offsite_sync_latest"
         echo ""
         echo -e "${YELLOW}[DRY-RUN] No changes made.${NC}"
         return 0
       fi
+      # Run each engine independently — a failure in one must not abort the rest.
+      local _all_ok=true
+      local _failed_engines=()
       local engine
       for engine in "${BACKUP_ENGINES[@]}"; do
         if backup_engine_enabled "$engine"; then
           local dump_fn
           dump_fn=$(backup_dump_fn "$engine")
-          "$dump_fn" "$stack" "$compose_cmd"
+          if "$dump_fn" "$stack" "$compose_cmd"; then
+            log "✓ $engine backup succeeded"
+          else
+            warn "$engine backup failed (continuing with remaining engines)"
+            _failed_engines+=("$engine")
+            _all_ok=false
+          fi
         fi
       done
+      # Offsite sync — run even if some engines failed (sync what succeeded).
+      offsite_sync_all "$stack" || true
       BACKUP_TARGET="all" fire_hook_or_warn post_backup "$stack_dir"
-      notify_event backup.success stack="$stack" env="$env_name" type=all
+      if [ "$_all_ok" = "true" ]; then
+        notify_event backup.success stack="$stack" env="$env_name" type=all
+      else
+        notify_event backup.failure stack="$stack" env="$env_name" type=all \
+          failed="${_failed_engines[*]}"
+        fail "Backup failed for: ${_failed_engines[*]}"
+      fi
       ;;
     *)
       fail "Unknown backup command: $target

--- a/tests/test_cmd_backup.bats
+++ b/tests/test_cmd_backup.bats
@@ -193,3 +193,49 @@ teardown() {
   [[ "$output" != *"offsite_sync_latest"* ]]
   [[ "$output" != *"notify_event backup.success"* ]]
 }
+
+@test "cmd_backup: all continues after one engine failure and reports which failed" {
+  # Simulate postgres fails, mysql succeeds
+  backup_postgres() { return 1; }
+  backup_mysql() { echo "mysql ok"; return 0; }
+  export -f backup_postgres backup_mysql
+  offsite_sync_all() { echo "offsite_sync_all $*"; return 0; }
+  export -f offsite_sync_all
+  notify_event() { echo "notify_event $*"; }
+  export -f notify_event
+
+  # Enable both engines
+  BACKUP_ENGINES=(postgres mysql)
+  backup_engine_enabled() { return 0; }
+  backup_dump_fn() { echo "backup_$1"; }
+  export -f backup_engine_enabled backup_dump_fn
+
+  run cmd_backup all
+  [ "$status" -ne 0 ]
+  # MySQL should still have run despite postgres failure
+  [[ "$output" == *"mysql ok"* ]]
+  # Offsite sync should have been called
+  [[ "$output" == *"offsite_sync_all"* ]]
+  # Should report which engine(s) failed
+  [[ "$output" == *"postgres"* ]]
+}
+
+@test "cmd_backup: all succeeds and calls offsite sync when all engines pass" {
+  backup_postgres() { echo "pg ok"; return 0; }
+  export -f backup_postgres
+  offsite_sync_all() { echo "offsite_sync_all $*"; return 0; }
+  export -f offsite_sync_all
+  notify_event() { echo "notify_event $*"; }
+  export -f notify_event
+
+  BACKUP_ENGINES=(postgres)
+  backup_engine_enabled() { return 0; }
+  backup_dump_fn() { echo "backup_$1"; }
+  export -f backup_engine_enabled backup_dump_fn
+
+  run cmd_backup all
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"pg ok"* ]]
+  [[ "$output" == *"offsite_sync_all"* ]]
+  [[ "$output" == *"notify_event backup.success"* ]]
+}


### PR DESCRIPTION
Fixes #230

## Problem

`backup all` aborted the entire run on the first engine failure (`set -e` + direct function call). A nightly cron hitting a transient Postgres issue would skip Neo4j/MySQL/SQLite backups entirely. Offsite sync was also never called from the `all` path.

## Fix

- Run each engine independently with error isolation (if/then, not bare call)
- Continue with remaining engines after a failure
- Call `offsite_sync_all` after all engines (syncs whatever succeeded)
- Report which engine(s) failed with clear messaging
- Emit `backup.failure` notification with failed engine list

## Testing

- Added 2 tests: partial failure continues + calls offsite; full success path
- All existing backup tests still pass
