### PR TITLE
fix(deploy): blue-green teardown no longer destroys shared volumes

### DIFF
--- a/lib/deploy_blue_green.sh
+++ b/lib/deploy_blue_green.sh
@@ -260,14 +260,15 @@ _bg_stop_color() {
 # _bg_teardown_failed_color <compose_cmd>
 #
 # Invoked when health probes for a freshly-started color never succeed.
-# Same as _bg_stop_color today but kept as a distinct helper so failure
-# cleanup can grow (container logs capture, snapshot, etc.) without
-# bloating the success path.
+# Uses `down --remove-orphans` WITHOUT --volumes: named volumes may be shared
+# with the live color (e.g. postgres_data), and destroying them here would
+# cause data loss for the running stack. The failed containers are removed
+# (freeing ports/names) but volumes are preserved.
 _bg_teardown_failed_color() {
   local compose_cmd="$1"
-  warn "Tearing down failed green color"
+  warn "Tearing down failed green color (volumes preserved)"
   # shellcheck disable=SC2086
-  $compose_cmd down --remove-orphans --volumes 2>/dev/null || true
+  $compose_cmd down --remove-orphans 2>/dev/null || true
 }
 
 # ── Main ──────────────────────────────────────────────────────────────────────

--- a/tests/test_deploy_blue_green.bats
+++ b/tests/test_deploy_blue_green.bats
@@ -479,3 +479,16 @@ EOF
   grep -q "^cmd:stop" "$CALLS_FILE"
   ! grep -q "^cmd:down" "$CALLS_FILE"
 }
+
+
+@test "_bg_teardown_failed_color: uses 'down' without --volumes (data safety)" {
+  compose-recorder() { _record "cmd:$*"; }
+  export -f compose-recorder
+
+  _bg_teardown_failed_color "compose-recorder"
+
+  # Should call 'down --remove-orphans' (containers removed, ports freed)
+  grep -q "^cmd:down --remove-orphans" "$CALLS_FILE"
+  # Must NOT pass --volumes (would destroy shared named volumes)
+  ! grep -q "volumes" "$CALLS_FILE"
+}


### PR DESCRIPTION
Fixes #247

## Problem

`_bg_teardown_failed_color` used `down --remove-orphans --volumes` — if a failed green deployment shares named volumes with the live blue (e.g. `postgres_data`), tearing down green **destroys the live database**.

## Fix

Use `down --remove-orphans` (no `--volumes`). The failed containers are removed (freeing ports and names for the next attempt) but volumes are preserved.

## Scoped Out

The second part of #247 (COMPOSE_PROJECT_NAME being ignored, causing the first bg deploy to not drain the original project) is a deeper change tracked separately.

## Testing

- Added unit test asserting `--volumes` is never passed
- All 25 blue-green tests pass
