### PR TITLE
fix(portability): macOS-safe alternatives for free/timeout/nproc

### DIFF
--- a/lib/cmd_doctor.sh
+++ b/lib/cmd_doctor.sh
@@ -238,7 +238,7 @@ _doc_check_vps() {
     vps_user="${vps_user:-ubuntu}"
 
     # shellcheck disable=SC2086
-    if timeout 5 ssh $ssh_opts "$vps_user@$vps_host" "echo ok" &>/dev/null; then
+    if portable_timeout 5 ssh $ssh_opts "$vps_user@$vps_host" "echo ok" &>/dev/null; then
       _doc_pass "VPS ($env_name)" "reachable at $vps_host"
 
       # Deploy dir, as declared in the probed env file (not the calling process's env).
@@ -329,7 +329,7 @@ _doc_check_vps_deep() {
   # Run all remote probes in a single SSH session for speed.
   # shellcheck disable=SC2086
   local out
-  if ! out=$(timeout 20 ssh $ssh_opts "$vps_user@$vps_host" bash -s <<'REMOTE' 2>/dev/null
+  if ! out=$(portable_timeout 20 ssh $ssh_opts "$vps_user@$vps_host" bash -s <<'REMOTE' 2>/dev/null
 set -u
 echo "=== docker ==="
 command -v docker >/dev/null && docker --version 2>/dev/null || echo "docker: NOT_INSTALLED"

--- a/lib/health.sh
+++ b/lib/health.sh
@@ -323,14 +323,16 @@ health_check_resources() {
   else                                  _health_record fail "Disk Space" "${disk_usage}% used (critical)"
   fi
 
-  mem_usage=$(free | awk 'NR==2 {printf "%.0f", $3/$2 * 100}')
-  if   [ "$mem_usage" -lt 80 ]; then _health_record pass "Memory Usage" "${mem_usage}% used"
+  mem_usage=$(_get_mem_percent)
+  if [ -z "$mem_usage" ] || [ "$mem_usage" = "0" ]; then
+    _health_record warn "Memory Usage" "unable to determine (no free or vm_stat)"
+  elif [ "$mem_usage" -lt 80 ]; then _health_record pass "Memory Usage" "${mem_usage}% used"
   elif [ "$mem_usage" -lt 90 ]; then _health_record warn "Memory Usage" "${mem_usage}% used (high)"
   else                                 _health_record fail "Memory Usage" "${mem_usage}% used (critical)"
   fi
 
   load=$(uptime | awk -F'load average:' '{print $2}' | awk '{print $1}' | sed 's/,//')
-  cpu_count=$(nproc 2>/dev/null || echo 1)
+  cpu_count=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 1)
   load_percent=$(echo "$load $cpu_count" | awk '{printf "%.0f", ($1/$2)*100}')
   if   [ "$load_percent" -lt 70 ]; then _health_record pass "CPU Load" "${load} (${load_percent}% of capacity)"
   elif [ "$load_percent" -lt 90 ]; then _health_record warn "CPU Load" "${load} (${load_percent}% of capacity)"

--- a/lib/keys.sh
+++ b/lib/keys.sh
@@ -43,7 +43,7 @@ validate_vps_connection() {
   ssh_opts=$(build_ssh_opts -p "$vps_port" -k "$vps_ssh_key" -t "$timeout" --batch --keepalive)
 
   # Try connection with timeout
-  if timeout "$timeout" ssh $ssh_opts "$vps_user@$vps_host" "echo 'ok'" &>/dev/null; then
+  if portable_timeout "$timeout" ssh $ssh_opts "$vps_user@$vps_host" "echo 'ok'" &>/dev/null; then
     return 0
   else
     local exit_code=$?

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -217,7 +217,11 @@ check_memory() {
   local warn_pct="${1:-80}"
   local fail_pct="${2:-90}"
   local usage
-  usage=$(free | awk 'NR==2 {printf "%.0f", $3/$2 * 100}')
+  usage=$(_get_mem_percent)
+  if [ -z "$usage" ] || [ "$usage" = "0" ]; then
+    warn "Memory: unable to determine usage (skipped)"
+    return 0
+  fi
   if [ "$usage" -ge "$fail_pct" ]; then
     warn "Memory: ${usage}% used (critical)"
     return 2
@@ -227,6 +231,60 @@ check_memory() {
   else
     ok "Memory: ${usage}% used"
     return 0
+  fi
+}
+
+# _get_mem_percent — portable memory usage percentage (Linux + macOS)
+_get_mem_percent() {
+  if command -v free >/dev/null 2>&1; then
+    free | awk 'NR==2 {printf "%.0f", $3/$2 * 100}'
+  elif [ "$(uname)" = "Darwin" ]; then
+    # macOS: use vm_stat + sysctl
+    local page_size total_pages pages_free pages_active pages_speculative pages_wired
+    page_size=$(sysctl -n hw.pagesize 2>/dev/null || echo 4096)
+    total_pages=$(( $(sysctl -n hw.memsize 2>/dev/null || echo 0) / page_size ))
+    # vm_stat gives counts in pages
+    local vmstat
+    vmstat=$(vm_stat 2>/dev/null) || { echo "0"; return; }
+    pages_free=$(echo "$vmstat" | awk '/Pages free:/{gsub(/\./,"",$3); print $3}')
+    pages_active=$(echo "$vmstat" | awk '/Pages active:/{gsub(/\./,"",$3); print $3}')
+    pages_speculative=$(echo "$vmstat" | awk '/Pages speculative:/{gsub(/\./,"",$3); print $3}')
+    pages_wired=$(echo "$vmstat" | awk '/Pages wired down:/{gsub(/\./,"",$4); print $4}')
+    local used=$(( (pages_active + pages_wired + pages_speculative) ))
+    if [ "$total_pages" -gt 0 ] 2>/dev/null; then
+      echo $(( used * 100 / total_pages ))
+    else
+      echo "0"
+    fi
+  else
+    echo "0"
+  fi
+}
+
+# portable_timeout <seconds> <command...>
+# Portable replacement for GNU timeout. Uses timeout if available,
+# falls back to gtimeout (Homebrew coreutils), then a backgrounded
+# process with kill.
+portable_timeout() {
+  local seconds="$1"; shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$seconds" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$seconds" "$@"
+  else
+    # Pure-bash fallback: run in background, kill after timeout
+    "$@" &
+    local pid=$!
+    (sleep "$seconds" && kill -TERM "$pid" 2>/dev/null) &
+    local watcher=$!
+    if wait "$pid" 2>/dev/null; then
+      kill "$watcher" 2>/dev/null; wait "$watcher" 2>/dev/null
+      return 0
+    else
+      local rc=$?
+      kill "$watcher" 2>/dev/null; wait "$watcher" 2>/dev/null
+      return $rc
+    fi
   fi
 }
 


### PR DESCRIPTION
Fixes #241

## Problem

`free`, `timeout`, and `nproc` don't exist on stock macOS. This caused:
- `strut health` → crash under `set -e` (no `free`)
- `strut doctor` → every VPS reported "unreachable" (no `timeout`)
- `strut keys` → connection validation always fails (no `timeout`)

## Fix

- `_get_mem_percent()` — uses `free` on Linux, `vm_stat + sysctl` on macOS
- `portable_timeout()` — tries `timeout`, `gtimeout` (Homebrew), then pure-bash background+kill fallback
- `health.sh` — uses `_get_mem_percent()` and adds `sysctl` fallback for CPU count
- `cmd_doctor.sh` / `keys.sh` — replaced `timeout` with `portable_timeout`
- `cmd_cert.sh` — already had `date -jf` fallback (verified, no change needed)

## Testing

Verified on macOS: `_get_mem_percent` returns correct value (44%), `portable_timeout` works. All doctor, cert, and keys tests pass.
