### PR TITLE
fix(secrets): secure temp files and mask values in ci:init

### DIFF
--- a/lib/cmd_ci_init.sh
+++ b/lib/cmd_ci_init.sh
@@ -235,7 +235,9 @@ _ci_print_commands() {
         if [ "$category" = "KEY" ] && [ -n "$value" ]; then
           echo "  gh secret set $name < $value${repo:+ -R $repo}"
         elif [ -n "$value" ]; then
-          echo "  gh secret set $name --body \"$value\"${repo:+ -R $repo}"
+          local masked="${value:0:4}••••${value: -4}"
+          [ ${#value} -le 8 ] && masked="••••••••"
+          echo "  echo '<value>' | gh secret set $name${repo:+ -R $repo}  # value: ${masked}"
         fi
       done <<< "$secrets_data"
       ;;
@@ -248,7 +250,9 @@ _ci_print_commands() {
         if [ "$category" = "KEY" ] && [ -n "$value" ]; then
           echo "  glab variable set $name --value \"\$(cat $value)\"${repo:+ -R $repo}"
         elif [ -n "$value" ]; then
-          echo "  glab variable set $name --value \"$value\"${repo:+ -R $repo}"
+          local masked="${value:0:4}••••${value: -4}"
+          [ ${#value} -le 8 ] && masked="••••••••"
+          echo "  echo '<value>' | glab variable set $name${repo:+ -R $repo}  # value: ${masked}"
         fi
       done <<< "$secrets_data"
       ;;
@@ -261,7 +265,9 @@ _ci_print_commands() {
         if [ "$category" = "KEY" ] && [ -n "$value" ]; then
           echo "  $name = (contents of $value)"
         elif [ -n "$value" ]; then
-          echo "  $name = $value"
+          local masked="${value:0:4}••••${value: -4}"
+          [ ${#value} -le 8 ] && masked="••••••••"
+          echo "  $name = ${masked}"
         fi
       done <<< "$secrets_data"
       ;;

--- a/lib/cmd_secrets.sh
+++ b/lib/cmd_secrets.sh
@@ -1549,7 +1549,10 @@ _secrets_lock() {
     return 0
   fi
 
-  local tmp_encrypted="${encrypted_file}.tmp"
+  local tmp_encrypted
+  tmp_encrypted=$(mktemp "${encrypted_file}.XXXXXX") || { fail "Failed to create secure temp file"; return 1; }
+  chmod 600 "$tmp_encrypted"
+  trap "rm -f '$tmp_encrypted'" EXIT INT TERM
 
   if [ "$backend" = "age" ]; then
     # Resolve recipients file
@@ -1668,7 +1671,11 @@ _secrets_unlock() {
     return 0
   fi
 
-  local tmp_output="${output_env}.tmp"
+  local tmp_output
+  tmp_output=$(mktemp "${output_env}.XXXXXX") || { fail "Failed to create secure temp file"; return 1; }
+  chmod 600 "$tmp_output"
+  # Ensure cleanup on interrupt
+  trap "rm -f '$tmp_output'" EXIT INT TERM
 
   if [ "$backend" = "age" ]; then
     # Resolve identity


### PR DESCRIPTION
Fixes #237, fixes #238

## Problem

1. **Predictable temp paths** (#237): `secrets lock/unlock` wrote decrypted plaintext to `${file}.tmp` — a fixed, predictable path with no cleanup on interrupt. Race conditions, symlink attacks, and leftover plaintext on Ctrl-C.

2. **Secrets on argv/output** (#238): `ci:init` printed full secret values in copy-paste commands (`gh secret set X --body "actual-secret"`), visible in terminal scrollback and shell history.

## Fix

1. Use `mktemp` with random suffix, `chmod 600` before writing, `trap` cleanup on EXIT/INT/TERM
2. Mask secret values in ci:init output (show first/last 4 chars only), suggest piping from stdin instead of `--body`

Note: `keys env:set` argv issue was already fixed (uses `_secrets_write_var`), and `mysql --password` was already fixed (uses `MYSQL_PWD` env var).
