### PR TITLE
fix: two real bugs behind main's red Tests workflow

### DIFF
--- a/completions/bash.sh
+++ b/completions/bash.sh
@@ -68,7 +68,7 @@ _strut_completions() {
   prev="${COMP_WORDS[COMP_CWORD-1]}"
   cword=$COMP_CWORD
 
-  local top_cmds="init list scaffold upgrade doctor status-all posture group monitoring audit audit:list audit:diff audit:generate migrate migrate:status notify sync fleet skills help completions --version -v --help -h"
+  local top_cmds="init list scaffold upgrade doctor status-all posture group monitoring audit audit:list audit:diff audit:generate migrate migrate:status notify sync fleet webhook mcp skills help completions --version -v --help -h"
   local per_stack_cmds="update release deploy rebuild ship stop diff lock health logs logs:download logs:rotate backup drift migrate restore db:pull db:push db:schema shell exec remote:init provision ssh:keygen ci:init cert:renew cert:status init-secrets secrets status volumes prune local prod staging dev debug keys validate rollback domain --help"
   local profiles="messaging ui full"
 

--- a/completions/fish.fish
+++ b/completions/fish.fish
@@ -60,7 +60,7 @@ function __strut_tok
     end
 end
 
-set -l top_cmds init list scaffold upgrade doctor status-all posture group monitoring audit audit:list audit:diff audit:generate migrate migrate:status notify sync fleet skills help completions
+set -l top_cmds init list scaffold upgrade doctor status-all posture group monitoring audit audit:list audit:diff audit:generate migrate migrate:status notify sync fleet webhook mcp skills help completions
 set -l per_stack_cmds update release deploy rebuild ship stop diff lock health logs logs:download logs:rotate backup drift migrate restore db:pull db:push db:schema shell exec remote:init provision ssh:keygen ci:init cert:renew cert:status init-secrets secrets status volumes prune local prod staging dev debug keys validate rollback domain
 
 # Disable file completion by default; re-enable where relevant

--- a/completions/zsh.sh
+++ b/completions/zsh.sh
@@ -49,7 +49,7 @@ _strut_groups() {
 
 _strut() {
   local -a top_cmds per_stack_cmds profiles
-  top_cmds=(init list scaffold upgrade doctor status-all posture group monitoring audit audit:list audit:diff audit:generate migrate migrate:status notify sync fleet skills help completions --version --help)
+  top_cmds=(init list scaffold upgrade doctor status-all posture group monitoring audit audit:list audit:diff audit:generate migrate migrate:status notify sync fleet webhook mcp skills help completions --version --help)
   per_stack_cmds=(update release deploy rebuild ship stop diff lock health logs logs:download logs:rotate backup drift migrate restore db:pull db:push db:schema shell exec remote:init provision ssh:keygen ci:init cert:renew cert:status init-secrets secrets status volumes prune local prod staging dev debug keys validate rollback domain --help)
   profiles=(messaging ui full)
 

--- a/lib/backup/rehearsal.sh
+++ b/lib/backup/rehearsal.sh
@@ -68,6 +68,7 @@ restore_rehearsal_postgres() {
 
   if [ "$restore_rc" -ne 0 ]; then
     error "Restore rehearsal FAILED — dump does not apply cleanly"
+    trap - RETURN
     _rehearsal_cleanup
     return 1
   fi
@@ -107,12 +108,20 @@ restore_rehearsal_postgres() {
 
   echo ""
 
-  # 4. Cleanup (triggered by RETURN trap)
   if $diff_found; then
     warn "Row count differences found between live and backup (expected if data changed since backup)"
   else
     ok "Rehearsal complete — dump restores cleanly, row counts match live"
   fi
+
+  # Disarm before returning: a `trap ... RETURN` set inside a function isn't
+  # scoped to that one call — left armed, it fires again on the *caller's*
+  # next return too, by which point $_cleanup_done no longer exists and
+  # `set -u` kills the whole call chain with "unbound variable". Cleanup
+  # itself still runs here explicitly; the trap stays as a safety net only
+  # for exit paths we didn't anticipate (e.g. an unexpected `set -e` abort).
+  trap - RETURN
+  _rehearsal_cleanup
 
   return 0
 }

--- a/tests/test_cmd_db.bats
+++ b/tests/test_cmd_db.bats
@@ -127,11 +127,29 @@ teardown() {
   [[ "$output" == *"Unknown backup file type"* ]]
 }
 
-@test "cmd_restore: dry-run shows plan" {
+@test "cmd_restore: dry-run routes .sql to a non-destructive rehearsal, not a real restore" {
+  # restore_rehearsal_postgres can't be stubbed here: cmd_restore's dry-run
+  # branch sources lib/backup/rehearsal.sh at call time, which unconditionally
+  # redefines the function and clobbers any pre-set stub. So this exercises
+  # the real rehearsal function instead, relying on this file's
+  # resolve_compose_cmd stub ("echo COMPOSE") to keep every docker/psql call
+  # a harmless echo — never a real destructive restore_postgres call.
+  local sql_file="$TEST_TMP/fake-backup.sql"
+  echo "SELECT 1;" > "$sql_file"
+
   export DRY_RUN=true
-  run cmd_restore /tmp/backup.sql
+  run cmd_restore "$sql_file"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"DRY-RUN"* ]]
+  [[ "$output" == *"Restore rehearsal:"* ]]
+  [[ "$output" != *"restore_postgres "* ]]
+}
+
+@test "cmd_restore: dry-run has no rehearsal support for non-Postgres types yet" {
+  export DRY_RUN=true
+  run cmd_restore /tmp/backup.dump
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[DRY-RUN]"* ]]
+  [[ "$output" == *"only supported for Postgres"* ]]
 }
 
 @test "cmd_restore: --target-env flag recognized" {

--- a/tests/test_dry_run.bats
+++ b/tests/test_dry_run.bats
@@ -146,7 +146,7 @@ _load_utils() {
 
 # ── cmd_restore dry-run ───────────────────────────────────────────────────────
 
-@test "cmd_restore: shows dry-run plan when DRY_RUN=true" {
+@test "cmd_restore: dry-run routes to a non-destructive rehearsal, never a real restore" {
   _load_utils
   source "$CLI_ROOT/lib/docker.sh"
   source "$CLI_ROOT/lib/backup.sh" 2>/dev/null || true
@@ -165,11 +165,22 @@ EOF
   export CMD_SERVICES=""
   export CMD_JSON=""
 
-  run cmd_restore "fake-backup.sql"
+  # restore_rehearsal_postgres can't be stubbed: cmd_restore's dry-run branch
+  # sources lib/backup/rehearsal.sh at call time, which unconditionally
+  # redefines the function and clobbers any pre-set stub. So this exercises
+  # the real rehearsal function instead — stubbing resolve_compose_cmd to a
+  # harmless echo keeps every docker/psql call inert, never a real restore.
+  resolve_compose_cmd() { echo "echo COMPOSE"; }
+  restore_postgres() { echo "restore_postgres $*"; }
+  export -f resolve_compose_cmd restore_postgres
+
+  local sql_file="$TEST_TMP/fake-backup.sql"
+  echo "SELECT 1;" > "$sql_file"
+
+  run cmd_restore "$sql_file"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"[DRY-RUN]"* ]]
-  [[ "$output" == *"Restore from backup file"* ]]
-  [[ "$output" == *"No changes made"* ]]
+  [[ "$output" == *"Restore rehearsal:"* ]]
+  [[ "$output" != *"restore_postgres "* ]]
 }
 
 # ── cmd_db_push dry-run ───────────────────────────────────────────────────────
@@ -210,6 +221,7 @@ _capture_deploy_dryrun() {
   _load_utils
   source "$CLI_ROOT/lib/config.sh"
   source "$CLI_ROOT/lib/docker.sh"
+  source "$CLI_ROOT/lib/hooks.sh"
   source "$CLI_ROOT/lib/deploy.sh"
 
   export REGISTRY_TYPE="$registry_type"


### PR DESCRIPTION
## What
`main`'s \`Tests\` workflow has been failing since ~16:45 UTC today (5 consecutive runs). This fixes both root causes.

## 1. Restore rehearsal crashes in production (lib/backup/rehearsal.sh)

\`restore_rehearsal_postgres\` sets \`trap _rehearsal_cleanup RETURN\` to guarantee scratch-DB cleanup on any exit path, but never disarms it. A RETURN trap set inside a function isn't scoped to that one call — left armed, it fires again on the *caller's* next return too. Since \`cmd_restore\` calls this function directly from its dry-run branch, the leftover trap fired a second time when \`cmd_restore\` itself returned, by which point \`$_cleanup_done\` (local to the already-finished inner call) no longer existed — \`set -u\` then killed the whole call chain with "unbound variable", right after the rehearsal had already done all its useful work.

**In production this meant `strut <stack> restore <file.sql> --dry-run` always crashed at the very end.** Reproduced in isolation with a minimal trap/local repro, and against the real function through \`cmd_restore\`. Fixed by explicitly disarming the trap and running cleanup at both of the function's own return points, leaving the trap armed only as a safety net for exit paths that aren't explicitly handled.

Also updates \`tests/test_cmd_db.bats\` and \`tests/test_dry_run.bats\`, which predated the dry-run rehearsal feature (#326) and still asserted the old "print a static plan" behavior. \`restore_rehearsal_postgres\` can't be stubbed in tests — \`cmd_restore\` sources \`rehearsal.sh\` at call time, which clobbers any pre-set stub — so both now exercise the real function against a stubbed \`resolve_compose_cmd\` instead.

## 2. Completions out of sync (completions/bash.sh, zsh.sh, fish.fish)

The \`mcp\` (#339) and \`webhook\` (#336) commands were wired into \`strut\`'s dispatch table but never added to the completion scripts, so \`strut <TAB>\` never suggested them and \`tests/test_completions_sync.bats\` — which diffs completions against the actual dispatch table — was failing.

## Testing
- Full \`bats tests/\` suite: clean except the 2 pre-existing \`flock\`-not-installed-on-macOS gaps (unrelated, pass on CI's Linux runner).
- \`shellcheck -s bash lib/backup/rehearsal.sh strut\`: clean.
- Verified the trap fix against a minimal isolated repro before touching the real file.