### PR TITLE
chore: gitignore local Kiro MCP config snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 config/.vps.env
 secrets/
 
+# Local Kiro IDE MCP config snapshots (may contain live API keys/tokens)
+.kiro/mcp-*.json
+
 # OS
 .DS_Store
 


### PR DESCRIPTION
## What
Adds \`.kiro/mcp-*.json\` to \`.gitignore\`.

## Why
Found while troubleshooting the strut MCP server: three untracked files (\`mcp-global-baseline.json\`, \`mcp-updated.json\`, \`mcp-workspace-override.json\`) contained a live Plane API key in plaintext, sitting ungitignored in this public repo's working tree — one \`git add .\` away from landing in history. They look like local Kiro IDE scratch/snapshot files, not something meant to be committed.

The legitimate strut-generated \`.kiro/settings/mcp.json\` is unaffected — different filename pattern, and it doesn't contain secrets.