### PR TITLE
feat(skills): install skills via agent-add for real Agent Skills support

### DIFF
--- a/lib/cmd_mcp.sh
+++ b/lib/cmd_mcp.sh
@@ -86,27 +86,7 @@ _mcp_cmd_install() {
   # Prefer agent-add if npx is available — handles Cursor, Claude Code,
   # VS Code Copilot, Windsurf, Kiro, and 10+ other editors automatically.
   local npx_bin=""
-  # Resolve npx from nvm if available (lazy-load shells may not have it on PATH)
-  if [ -n "${NVM_DIR:-}" ] && [ -d "$NVM_DIR/versions/node" ]; then
-    # Try the default alias first, then the highest installed version
-    local nvm_node_dir=""
-    if [ -f "$NVM_DIR/alias/default" ]; then
-      local alias_val
-      alias_val=$(cat "$NVM_DIR/alias/default" 2>/dev/null)
-      # Resolve partial aliases like "22" to full version dirs
-      nvm_node_dir=$(ls -d "$NVM_DIR/versions/node/v${alias_val}"* 2>/dev/null | sort -V | tail -1)
-    fi
-    # Fallback: highest installed version
-    if [ -z "$nvm_node_dir" ] || [ ! -d "$nvm_node_dir" ]; then
-      nvm_node_dir=$(ls -d "$NVM_DIR/versions/node/"v* 2>/dev/null | sort -V | tail -1)
-    fi
-    if [ -n "$nvm_node_dir" ] && [ -x "$nvm_node_dir/bin/npx" ]; then
-      npx_bin="$nvm_node_dir/bin/npx"
-      # Prepend to PATH so #!/usr/bin/env node resolves to the same version
-      export PATH="$nvm_node_dir/bin:$PATH"
-    fi
-  fi
-  [ -z "$npx_bin" ] && command -v npx >/dev/null 2>&1 && npx_bin="$(command -v npx)"
+  resolve_npx_bin && npx_bin="$RESOLVED_NPX_BIN"
 
   if [ -n "$npx_bin" ]; then
     log "Installing strut MCP server via agent-add..."

--- a/lib/cmd_skills.sh
+++ b/lib/cmd_skills.sh
@@ -49,8 +49,8 @@ _skills_install() {
   case "$format" in
     kiro)     _install_kiro "$strut_home" "$project_root" ;;
     claude)   _install_claude "$strut_home" "$project_root" ;;
-    cursor)   _install_rules_file "$strut_home" "$project_root" ".cursorrules" "Cursor" ;;
-    windsurf) _install_rules_file "$strut_home" "$project_root" ".windsurfrules" "Windsurf" ;;
+    cursor)   _install_rules_file "$strut_home" "$project_root" ".cursorrules" "Cursor" "cursor" ;;
+    windsurf) _install_rules_file "$strut_home" "$project_root" ".windsurfrules" "Windsurf" "windsurf" ;;
     zed)      _install_rules_file "$strut_home" "$project_root" ".rules" "Zed" ;;
     cline)    _install_rules_file "$strut_home" "$project_root" ".clinerules" "Cline" ;;
     copilot)  _install_copilot "$strut_home" "$project_root" ;;
@@ -152,33 +152,88 @@ _backup_if_exists() {
   warn "Backed up existing $label → $(basename "$backup")"
 }
 
+# ── agent-add: multi-editor skill installer ───────────────────────────────────
+# agent-add (https://github.com/pea3nut/agent-add) natively understands the
+# Agent Skills directory spec (a SKILL.md-rooted folder) and knows the right
+# skills location per editor. Only a subset of strut's formats map to a real
+# agent-add host — zed and cline aren't in its host list — so this is used
+# where available and every caller falls back to strut's own directory copy
+# when it isn't (no npx, no network, or the call itself fails).
+
+# _agent_add_install_skills <strut_home> <host_id> <label>
+#
+# Installs every strut skill directory (anything under .kiro/skills/ with a
+# SKILL.md) to the given agent-add host in one invocation. Echoes the number
+# of skills installed and returns 0 on success; returns 1 (no output on
+# stdout) if npx can't be resolved, there are no skills to install, or
+# agent-add itself fails — callers should fall back to their own install
+# path in that case.
+#
+# Callers capture this via `skill_count=$(... _agent_add_install_skills ...)`,
+# so every log/warn call here must go to stderr explicitly — log()/warn()
+# both write to stdout by default, and command substitution captures ALL of
+# a subshell's stdout, not just the final echo. Left as plain stdout calls,
+# the progress message corrupts the captured count on success, and the
+# fallback warning is silently swallowed (never reaches the user) on failure.
+_agent_add_install_skills() {
+  local strut_home="$1"
+  local host_id="$2"
+  local label="$3"
+
+  local npx_bin=""
+  resolve_npx_bin && npx_bin="$RESOLVED_NPX_BIN" || return 1
+
+  local -a skill_args=()
+  local skill_dir
+  for skill_dir in "$strut_home/.kiro/skills"/*/; do
+    [ -f "$skill_dir/SKILL.md" ] || continue
+    skill_args+=(--skill "$skill_dir")
+  done
+  [ "${#skill_args[@]}" -gt 0 ] || return 1
+
+  log "$label: installing $(( ${#skill_args[@]} / 2 )) skill(s) via agent-add..." >&2
+  if ! "$npx_bin" -y agent-add --host "$host_id" "${skill_args[@]}" >/dev/null 2>&1; then
+    warn "$label: agent-add install failed; falling back to direct copy" >&2
+    return 1
+  fi
+
+  echo "$(( ${#skill_args[@]} / 2 ))"
+  return 0
+}
+
 # ── Kiro: native format ───────────────────────────────────────────────────────
 # Steering → .kiro/steering/
 # Skills   → .kiro/skills/<skill-name>/ (one folder per skill, per Agent Skills spec)
+#            via agent-add when npx is available, else direct copy
 _install_kiro() {
   local strut_home="$1"
   local project_root="$2"
 
-  # Install skills — each skill folder goes directly under .kiro/skills/
-  # per the Agent Skills spec (name must match parent directory name).
-  local skills_target="$project_root/.kiro/skills"
-  mkdir -p "$skills_target"
-
   local skill_count=0
-  for skill_dir in "$strut_home/.kiro/skills"/*/; do
-    [ -d "$skill_dir" ] || continue
-    local skill_name
-    skill_name=$(basename "$skill_dir")
-    [ -f "$skill_dir/SKILL.md" ] || continue
+  skill_count=$(cd "$project_root" && _agent_add_install_skills "$strut_home" "kiro" "Kiro") || skill_count=""
 
-    # Remove existing copy if present
-    if [ -d "$skills_target/$skill_name" ]; then
-      rm -rf "${skills_target:?}/${skill_name:?}"
-    fi
-    cp -r "$skill_dir" "$skills_target/$skill_name"
-    rm -f "$skills_target/$skill_name/.DS_Store" 2>/dev/null || true
-    skill_count=$((skill_count + 1))
-  done
+  if [ -z "$skill_count" ]; then
+    # Install skills — each skill folder goes directly under .kiro/skills/
+    # per the Agent Skills spec (name must match parent directory name).
+    local skills_target="$project_root/.kiro/skills"
+    mkdir -p "$skills_target"
+
+    skill_count=0
+    for skill_dir in "$strut_home/.kiro/skills"/*/; do
+      [ -d "$skill_dir" ] || continue
+      local skill_name
+      skill_name=$(basename "$skill_dir")
+      [ -f "$skill_dir/SKILL.md" ] || continue
+
+      # Remove existing copy if present
+      if [ -d "$skills_target/$skill_name" ]; then
+        rm -rf "${skills_target:?}/${skill_name:?}"
+      fi
+      cp -r "$skill_dir" "$skills_target/$skill_name"
+      rm -f "$skills_target/$skill_name/.DS_Store" 2>/dev/null || true
+      skill_count=$((skill_count + 1))
+    done
+  fi
 
   # Install steering
   local steering_count=0
@@ -202,6 +257,7 @@ _install_kiro() {
 # ── Claude Code: CLAUDE.md + .claude/skills/ ──────────────────────────────────
 # Steering → CLAUDE.md (always loaded)
 # Skills   → .claude/skills/<name>/ (Agent Skills spec — progressive disclosure)
+#            via agent-add when npx is available, else direct copy
 _install_claude() {
   local strut_home="$1"
   local project_root="$2"
@@ -212,30 +268,37 @@ _install_claude() {
   _build_steering_content "$strut_home" > "$claude_file"
   ok "Claude: steering → CLAUDE.md"
 
-  # Skills → .claude/skills/<name>/ (native Agent Skills support)
-  local skills_target="$project_root/.claude/skills"
-  mkdir -p "$skills_target"
-
   local skill_count=0
-  for skill_dir in "$strut_home/.kiro/skills"/*/; do
-    [ -d "$skill_dir" ] || continue
-    [ -f "$skill_dir/SKILL.md" ] || continue
-    local name
-    name=$(basename "$skill_dir")
-    if [ -d "$skills_target/$name" ]; then
-      rm -rf "${skills_target:?}/${name:?}"
-    fi
-    cp -r "$skill_dir" "$skills_target/$name"
-    rm -f "$skills_target/$name/.DS_Store" 2>/dev/null || true
-    skill_count=$((skill_count + 1))
-  done
+  skill_count=$(cd "$project_root" && _agent_add_install_skills "$strut_home" "claude-code" "Claude") || skill_count=""
+
+  if [ -z "$skill_count" ]; then
+    # Skills → .claude/skills/<name>/ (native Agent Skills support)
+    local skills_target="$project_root/.claude/skills"
+    mkdir -p "$skills_target"
+
+    skill_count=0
+    for skill_dir in "$strut_home/.kiro/skills"/*/; do
+      [ -d "$skill_dir" ] || continue
+      [ -f "$skill_dir/SKILL.md" ] || continue
+      local name
+      name=$(basename "$skill_dir")
+      if [ -d "$skills_target/$name" ]; then
+        rm -rf "${skills_target:?}/${name:?}"
+      fi
+      cp -r "$skill_dir" "$skills_target/$name"
+      rm -f "$skills_target/$name/.DS_Store" 2>/dev/null || true
+      skill_count=$((skill_count + 1))
+    done
+  fi
 
   ok "Claude: $skill_count skill → .claude/skills/ (Agent Skills spec)"
 }
 
 # ── Copilot: .github/copilot-instructions.md ──────────────────────────────────
 # Steering → .github/copilot-instructions.md (always loaded)
-# Skills   → appended to same file (no separate invocation mechanism)
+# Skills   → .github/skills/<name>/ via agent-add (Agent Skills spec) when npx
+#            is available; otherwise appended into the same file (Copilot has
+#            no separate invocation mechanism to fall back on without it)
 _install_copilot() {
   local strut_home="$1"
   local project_root="$2"
@@ -243,38 +306,61 @@ _install_copilot() {
   local target="$project_root/.github/copilot-instructions.md"
   mkdir -p "$(dirname "$target")"
 
-  {
-    _build_steering_content "$strut_home"
-    echo ""
-    echo "---"
-    echo ""
-    _build_skills_content "$strut_home"
-  } > "$target"
+  local skill_count=""
+  skill_count=$(cd "$project_root" && _agent_add_install_skills "$strut_home" "github-copilot" "Copilot") || skill_count=""
 
-  ok "Copilot: steering + skills → .github/copilot-instructions.md"
+  if [ -n "$skill_count" ]; then
+    _build_steering_content "$strut_home" > "$target"
+    ok "Copilot: steering → .github/copilot-instructions.md"
+    ok "Copilot: $skill_count skill(s) → .github/skills/ (Agent Skills spec)"
+  else
+    {
+      _build_steering_content "$strut_home"
+      echo ""
+      echo "---"
+      echo ""
+      _build_skills_content "$strut_home"
+    } > "$target"
+    ok "Copilot: steering + skills → .github/copilot-instructions.md"
+  fi
 }
 
 # ── Single rules file (Cursor, Windsurf, Zed, Cline, AGENTS.md) ──────────────
 # Steering → top of file (always loaded)
-# Skills   → appended below (always available as reference)
+# Skills   → via agent-add (Agent Skills spec) when an agent_add_host is given
+#            and npx is available; otherwise appended below the steering
+#            content in the same flat file (always available as reference).
+#            agent_add_host is empty for zed/cline/agents — agent-add has no
+#            host entry for them, so they always use the flat-file path.
 _install_rules_file() {
   local strut_home="$1"
   local project_root="$2"
   local filename="$3"
   local tool_name="$4"
+  local agent_add_host="${5:-}"
 
   local target="$project_root/$filename"
   _backup_if_exists "$target" "$filename"
 
-  {
-    _build_steering_content "$strut_home"
-    echo ""
-    echo "---"
-    echo ""
-    _build_skills_content "$strut_home"
-  } > "$target"
+  local skill_count=""
+  if [ -n "$agent_add_host" ]; then
+    skill_count=$(cd "$project_root" && _agent_add_install_skills "$strut_home" "$agent_add_host" "$tool_name") || skill_count=""
+  fi
 
-  ok "$tool_name: steering + skills → $filename"
+  if [ -n "$skill_count" ]; then
+    _build_steering_content "$strut_home" > "$target"
+    ok "$tool_name: steering → $filename"
+    ok "$tool_name: $skill_count skill(s) → Agent Skills spec (via agent-add)"
+  else
+    {
+      _build_steering_content "$strut_home"
+      echo ""
+      echo "---"
+      echo ""
+      _build_skills_content "$strut_home"
+    } > "$target"
+    ok "$tool_name: steering + skills → $filename"
+  fi
 }
 
 # ── Generic: docs/ directory ──────────────────────────────────────────────────
@@ -308,8 +394,8 @@ _install_all() {
 
   _install_kiro "$strut_home" "$project_root"
   _install_claude "$strut_home" "$project_root"
-  _install_rules_file "$strut_home" "$project_root" ".cursorrules" "Cursor"
-  _install_rules_file "$strut_home" "$project_root" ".windsurfrules" "Windsurf"
+  _install_rules_file "$strut_home" "$project_root" ".cursorrules" "Cursor" "cursor"
+  _install_rules_file "$strut_home" "$project_root" ".windsurfrules" "Windsurf" "windsurf"
   _install_rules_file "$strut_home" "$project_root" ".rules" "Zed"
   _install_rules_file "$strut_home" "$project_root" ".clinerules" "Cline"
   _install_copilot "$strut_home" "$project_root"
@@ -392,18 +478,21 @@ _skills_usage() {
   echo "Formats:"
   echo "  kiro      Kiro IDE [default]"
   echo "              steering → .kiro/steering/strut-*.md"
-  echo "              skills   → .kiro/skills/strut/"
+  echo "              skills   → via agent-add (Agent Skills spec), falls back to .kiro/skills/"
   echo "  claude    Claude Code / Claude Desktop"
   echo "              steering → CLAUDE.md"
-  echo "              skills   → .claude/skills/strut/ (Agent Skills spec)"
+  echo "              skills   → via agent-add (Agent Skills spec), falls back to .claude/skills/"
   echo "  cursor    Cursor"
-  echo "              steering + skills → .cursorrules"
+  echo "              steering → .cursorrules"
+  echo "              skills   → via agent-add (Agent Skills spec), falls back to inline .cursorrules"
   echo "  windsurf  Windsurf"
-  echo "              steering + skills → .windsurfrules"
+  echo "              steering → .windsurfrules"
+  echo "              skills   → via agent-add (Agent Skills spec), falls back to inline .windsurfrules"
+  echo "  copilot   GitHub Copilot"
+  echo "              steering → .github/copilot-instructions.md"
+  echo "              skills   → via agent-add (Agent Skills spec), falls back to inline copilot-instructions.md"
   echo "  zed       Zed (also reads .cursorrules, CLAUDE.md)"
   echo "              steering + skills → .rules"
-  echo "  copilot   GitHub Copilot"
-  echo "              steering + skills → .github/copilot-instructions.md"
   echo "  cline     Cline"
   echo "              steering + skills → .clinerules"
   echo "  agents    Generic agent convention"
@@ -412,6 +501,12 @@ _skills_usage() {
   echo "              steering → docs/strut-context.md"
   echo "              skills   → docs/strut-skills.md"
   echo "  all       Generate all formats at once"
+  echo ""
+  echo "kiro/claude/cursor/windsurf/copilot install skills via agent-add"
+  echo "(https://github.com/pea3nut/agent-add) when npx is available, so skills"
+  echo "land as real Agent Skills — loaded on demand, not always inlined into"
+  echo "context. zed/cline/agents/generic have no agent-add host and always get"
+  echo "everything flattened into one file."
   echo ""
   echo "Examples:"
   echo "  strut skills list"

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -381,6 +381,64 @@ require_cmd() {
   command -v "$cmd" &>/dev/null || fail "$cmd not found${hint:+. $hint}"
 }
 
+# resolve_npx_bin
+#
+# Resolves a working npx binary, sets RESOLVED_NPX_BIN to its path, and
+# returns 0 — or returns 1 with RESOLVED_NPX_BIN unset if none can be found.
+#
+# Deliberately NOT called as `x=$(resolve_npx_bin)`: npx itself internally
+# re-spawns the actually-downloaded package as a child process, which does
+# its own PATH lookup for `node` — so the fix has to be a real PATH change
+# in the CALLER's shell that's still in effect when the caller later runs
+# npx, not just a captured path string. `export PATH=...` inside a command
+# substitution only affects that subshell and is discarded the moment it
+# returns, silently making the whole fix a no-op. Call this directly —
+# `resolve_npx_bin && npx_bin="$RESOLVED_NPX_BIN"` — so PATH changes happen
+# in place.
+#
+# Prefers an nvm-managed Node over whatever `npx` a lazy-load shell exposes
+# (or doesn't): lazy-loaded nvm shells often define `npx`/`node` as wrapper
+# FUNCTIONS that call a `_nvm_lazy_load` helper and re-exec themselves — and
+# NVM_DIR itself may not be exported yet until that wrapper actually fires
+# once. So this doesn't gate nvm resolution on NVM_DIR being set; it also
+# tries the conventional $HOME/.nvm location. Resolving a real binary path
+# directly from .../versions/node sidesteps the wrapper entirely.
+#
+# Deliberately picks the HIGHEST installed nvm version, not the user's
+# `nvm alias default` — this npx call is a one-off tool invocation
+# (agent-add, etc.), not a build step for the user's own project, so their
+# pinned project-default Node has no bearing here and may be an old LTS
+# that's simply too old to run current npm-published tooling (reproduced:
+# agent-add's dist bundle uses node:util's `styleText`, added in Node
+# 21.7/22.13 — it hard-crashes on a Node 16 default alias).
+resolve_npx_bin() {
+  RESOLVED_NPX_BIN=""
+  local npx_bin=""
+  local nvm_dir="${NVM_DIR:-$HOME/.nvm}"
+  if [ -d "$nvm_dir/versions/node" ]; then
+    local nvm_node_dir
+    nvm_node_dir=$(ls -d "$nvm_dir/versions/node/"v* 2>/dev/null | sort -V | tail -1)
+    if [ -n "$nvm_node_dir" ] && [ -x "$nvm_node_dir/bin/npx" ]; then
+      npx_bin="$nvm_node_dir/bin/npx"
+      # In effect for the rest of the CALLER's shell, not just this
+      # function — see the comment above on why that matters here.
+      export PATH="$nvm_node_dir/bin:$PATH"
+    fi
+  fi
+  if [ -z "$npx_bin" ]; then
+    local candidate
+    candidate="$(command -v npx 2>/dev/null)"
+    # A lazy-load nvm shell integration can shadow npx with a wrapper
+    # function; `command -v` then reports it as the bare word "npx" with
+    # no path component, not a real executable. Only trust an actual file.
+    if [[ "$candidate" == */* ]] && [ -x "$candidate" ]; then
+      npx_bin="$candidate"
+    fi
+  fi
+  [ -n "$npx_bin" ] || return 1
+  RESOLVED_NPX_BIN="$npx_bin"
+}
+
 # confirm <prompt> — returns 0 if user types y/yes, 1 otherwise
 #
 # Auto-yes paths (never blocks the caller):

--- a/tests/test_cmd_skills.bats
+++ b/tests/test_cmd_skills.bats
@@ -114,6 +114,11 @@ teardown() {
 @test "install kiro: skill lands at .kiro/skills/<name>/SKILL.md with references" {
   # Restore real installer implementations (setup() stubbed them)
   source "$CLI_ROOT/lib/cmd_skills.sh"
+  # Force the direct-copy fallback deterministically — without this, whether
+  # the test exercises agent-add or the fallback depends on whether the CI
+  # runner happens to have a working npx, which is exactly what this test
+  # must not depend on.
+  _agent_add_install_skills() { return 1; }
 
   # Build a fake single-skill source tree
   mkdir -p "$STRUT_HOME/.kiro/skills/strut/references"
@@ -133,6 +138,7 @@ teardown() {
 
 @test "install kiro: skill name in SKILL.md matches its directory" {
   source "$CLI_ROOT/lib/cmd_skills.sh"
+  _agent_add_install_skills() { return 1; }
 
   mkdir -p "$STRUT_HOME/.kiro/skills/strut"
   printf -- '---\nname: strut\ndescription: test\n---\n' \
@@ -148,6 +154,7 @@ teardown() {
 
 @test "install claude: skill copied to .claude/skills/ with references" {
   source "$CLI_ROOT/lib/cmd_skills.sh"
+  _agent_add_install_skills() { return 1; }
 
   mkdir -p "$STRUT_HOME/.kiro/skills/strut/references"
   printf -- '---\nname: strut\ndescription: test\n---\n' \
@@ -160,4 +167,164 @@ teardown() {
   [ -f "$PROJECT_ROOT/.claude/skills/strut/SKILL.md" ]
   [ -f "$PROJECT_ROOT/.claude/skills/strut/references/backups.md" ]
   [ -f "$PROJECT_ROOT/CLAUDE.md" ]
+}
+
+# ── agent-add integration ─────────────────────────────────────────────────────
+
+@test "_agent_add_install_skills: returns 1 when npx can't be resolved" {
+  source "$CLI_ROOT/lib/cmd_skills.sh"
+  resolve_npx_bin() { return 1; }
+
+  mkdir -p "$STRUT_HOME/.kiro/skills/strut"
+  printf -- '---\nname: strut\ndescription: test\n---\n' > "$STRUT_HOME/.kiro/skills/strut/SKILL.md"
+
+  run _agent_add_install_skills "$STRUT_HOME" "kiro" "Kiro"
+  [ "$status" -eq 1 ]
+  [ -z "$output" ]
+}
+
+@test "_agent_add_install_skills: returns 1 when there are no skills to install" {
+  source "$CLI_ROOT/lib/cmd_skills.sh"
+  resolve_npx_bin() { RESOLVED_NPX_BIN="/fake/npx"; return 0; }
+  # No SKILL.md anywhere under $STRUT_HOME/.kiro/skills
+
+  run _agent_add_install_skills "$STRUT_HOME" "kiro" "Kiro"
+  [ "$status" -eq 1 ]
+}
+
+@test "_agent_add_install_skills: on success, echoes the skill count and passes --skill per skill dir" {
+  source "$CLI_ROOT/lib/cmd_skills.sh"
+
+  mkdir -p "$STRUT_HOME/.kiro/skills/strut" "$STRUT_HOME/.kiro/skills/second"
+  printf -- '---\nname: strut\ndescription: test\n---\n' > "$STRUT_HOME/.kiro/skills/strut/SKILL.md"
+  printf -- '---\nname: second\ndescription: test\n---\n' > "$STRUT_HOME/.kiro/skills/second/SKILL.md"
+
+  local calls_file="$TEST_TMP/npx-calls"
+  local fake_npx="$TEST_TMP/fake-npx"
+  cat > "$fake_npx" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> "$calls_file"
+exit 0
+EOF
+  chmod +x "$fake_npx"
+  resolve_npx_bin() { RESOLVED_NPX_BIN="$fake_npx"; return 0; }
+
+  # `run` merges stdout+stderr into $output, but callers of this function
+  # capture stdout only (`skill_count=$(...)`) — so verify that exact
+  # contract via a plain command substitution, not `run`.
+  local stdout_only
+  stdout_only=$(_agent_add_install_skills "$STRUT_HOME" "kiro" "Kiro" 2>/dev/null)
+  [ "$stdout_only" = "2" ]
+
+  run cat "$calls_file"
+  [[ "$output" == *"-y agent-add --host kiro"* ]]
+  [[ "$output" == *"--skill $STRUT_HOME/.kiro/skills/strut/"* ]]
+  [[ "$output" == *"--skill $STRUT_HOME/.kiro/skills/second/"* ]]
+}
+
+@test "_agent_add_install_skills: returns 1 and warns on stderr (not swallowed) when agent-add fails" {
+  source "$CLI_ROOT/lib/cmd_skills.sh"
+
+  mkdir -p "$STRUT_HOME/.kiro/skills/strut"
+  printf -- '---\nname: strut\ndescription: test\n---\n' > "$STRUT_HOME/.kiro/skills/strut/SKILL.md"
+
+  local fake_npx="$TEST_TMP/fake-npx-fail"
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$fake_npx"
+  chmod +x "$fake_npx"
+  resolve_npx_bin() { RESOLVED_NPX_BIN="$fake_npx"; return 0; }
+
+  # stdout must stay clean on failure too — it's what callers capture as the
+  # count via `skill_count=$(...)`, so any stray stdout output would corrupt
+  # it. Checked separately from stderr since bats `run` merges both streams.
+  local stdout_only stderr_only rc
+  stdout_only=$(_agent_add_install_skills "$STRUT_HOME" "kiro" "Kiro" 2>/dev/null) && rc=0 || rc=$?
+  [ -z "$stdout_only" ]
+  [ "$rc" -eq 1 ]
+
+  stderr_only=$(_agent_add_install_skills "$STRUT_HOME" "kiro" "Kiro" 2>&1 1>/dev/null) || true
+  [[ "$stderr_only" == *"agent-add install failed"* ]]
+}
+
+@test "install kiro: uses agent-add when available, skips the direct-copy fallback" {
+  source "$CLI_ROOT/lib/cmd_skills.sh"
+  local agent_add_called=0
+  _agent_add_install_skills() { agent_add_called=1; echo "1"; return 0; }
+
+  mkdir -p "$STRUT_HOME/.kiro/skills/strut"
+  printf -- '---\nname: strut\ndescription: test\n---\n' > "$STRUT_HOME/.kiro/skills/strut/SKILL.md"
+
+  run _install_kiro "$STRUT_HOME" "$PROJECT_ROOT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"1 skill(s)"* ]]
+  # The fallback direct-copy never ran — no file was ever placed here by it.
+  [ ! -f "$PROJECT_ROOT/.kiro/skills/strut/SKILL.md" ]
+}
+
+@test "install claude: uses agent-add when available, skips the direct-copy fallback" {
+  source "$CLI_ROOT/lib/cmd_skills.sh"
+  _agent_add_install_skills() { echo "1"; return 0; }
+
+  mkdir -p "$STRUT_HOME/.kiro/skills/strut"
+  printf -- '---\nname: strut\ndescription: test\n---\n' > "$STRUT_HOME/.kiro/skills/strut/SKILL.md"
+
+  run _install_claude "$STRUT_HOME" "$PROJECT_ROOT"
+  [ "$status" -eq 0 ]
+  [ -f "$PROJECT_ROOT/CLAUDE.md" ]
+  [ ! -f "$PROJECT_ROOT/.claude/skills/strut/SKILL.md" ]
+}
+
+@test "install cursor (_install_rules_file with agent_add_host): success writes steering-only, no inlined skills" {
+  source "$CLI_ROOT/lib/cmd_skills.sh"
+  _agent_add_install_skills() { echo "1"; return 0; }
+  _build_skills_content() { echo "SHOULD-NOT-APPEAR-IN-OUTPUT"; }
+
+  run _install_rules_file "$STRUT_HOME" "$PROJECT_ROOT" ".cursorrules" "Cursor" "cursor"
+  [ "$status" -eq 0 ]
+  [ -f "$PROJECT_ROOT/.cursorrules" ]
+  run cat "$PROJECT_ROOT/.cursorrules"
+  [[ "$output" != *"SHOULD-NOT-APPEAR-IN-OUTPUT"* ]]
+}
+
+@test "install cursor (_install_rules_file with agent_add_host): falls back to flattened steering+skills when agent-add fails" {
+  source "$CLI_ROOT/lib/cmd_skills.sh"
+  _agent_add_install_skills() { return 1; }
+  _build_skills_content() { echo "SKILLS-CONTENT-MARKER"; }
+
+  run _install_rules_file "$STRUT_HOME" "$PROJECT_ROOT" ".cursorrules" "Cursor" "cursor"
+  [ "$status" -eq 0 ]
+  run cat "$PROJECT_ROOT/.cursorrules"
+  [[ "$output" == *"SKILLS-CONTENT-MARKER"* ]]
+}
+
+@test "install zed (_install_rules_file with no agent_add_host): always flattens, never calls agent-add" {
+  source "$CLI_ROOT/lib/cmd_skills.sh"
+  _agent_add_install_skills() { echo "SHOULD-NOT-BE-CALLED"; return 0; }
+  _build_skills_content() { echo "SKILLS-CONTENT-MARKER"; }
+
+  run _install_rules_file "$STRUT_HOME" "$PROJECT_ROOT" ".rules" "Zed"
+  [ "$status" -eq 0 ]
+  run cat "$PROJECT_ROOT/.rules"
+  [[ "$output" == *"SKILLS-CONTENT-MARKER"* ]]
+}
+
+@test "install copilot: success writes steering-only copilot-instructions.md" {
+  source "$CLI_ROOT/lib/cmd_skills.sh"
+  _agent_add_install_skills() { echo "1"; return 0; }
+  _build_skills_content() { echo "SHOULD-NOT-APPEAR-IN-OUTPUT"; }
+
+  run _install_copilot "$STRUT_HOME" "$PROJECT_ROOT"
+  [ "$status" -eq 0 ]
+  run cat "$PROJECT_ROOT/.github/copilot-instructions.md"
+  [[ "$output" != *"SHOULD-NOT-APPEAR-IN-OUTPUT"* ]]
+}
+
+@test "install copilot: falls back to flattened steering+skills when agent-add fails" {
+  source "$CLI_ROOT/lib/cmd_skills.sh"
+  _agent_add_install_skills() { return 1; }
+  _build_skills_content() { echo "SKILLS-CONTENT-MARKER"; }
+
+  run _install_copilot "$STRUT_HOME" "$PROJECT_ROOT"
+  [ "$status" -eq 0 ]
+  run cat "$PROJECT_ROOT/.github/copilot-instructions.md"
+  [[ "$output" == *"SKILLS-CONTENT-MARKER"* ]]
 }

--- a/tests/test_utils.bats
+++ b/tests/test_utils.bats
@@ -448,3 +448,93 @@ EOF
   [ "$status" -ne 0 ]
   [[ "$output" == *"Install with: brew install xyz"* ]]
 }
+
+# ── resolve_npx_bin ────────────────────────────────────────────────────────────
+
+# _fake_nvm_npx <version> — creates a fake $NVM_DIR/versions/node/v<version>/bin/npx
+_fake_nvm_npx() {
+  local version="$1"
+  local dir="$TEST_TMP/nvm/versions/node/v$version/bin"
+  mkdir -p "$dir"
+  printf '#!/usr/bin/env bash\necho "fake-npx-%s"\n' "$version" > "$dir/npx"
+  chmod +x "$dir/npx"
+}
+
+@test "resolve_npx_bin: picks the highest installed nvm version, not the first found" {
+  _load_utils
+  _fake_nvm_npx "18.17.0"
+  _fake_nvm_npx "22.13.0"
+  _fake_nvm_npx "20.19.0"
+
+  NVM_DIR="$TEST_TMP/nvm" resolve_npx_bin
+  [ "$RESOLVED_NPX_BIN" = "$TEST_TMP/nvm/versions/node/v22.13.0/bin/npx" ]
+}
+
+@test "resolve_npx_bin: ignores nvm alias/default, still picks highest version" {
+  _load_utils
+  _fake_nvm_npx "16.13.1"
+  _fake_nvm_npx "22.13.0"
+  mkdir -p "$TEST_TMP/nvm/alias"
+  echo "16.13.1" > "$TEST_TMP/nvm/alias/default"
+
+  NVM_DIR="$TEST_TMP/nvm" resolve_npx_bin
+  [ "$RESOLVED_NPX_BIN" = "$TEST_TMP/nvm/versions/node/v22.13.0/bin/npx" ]
+}
+
+@test "resolve_npx_bin: prepends the resolved bin dir to PATH" {
+  _load_utils
+  _fake_nvm_npx "22.13.0"
+
+  local orig_path="$PATH"
+  NVM_DIR="$TEST_TMP/nvm" resolve_npx_bin
+  [[ "$PATH" == "$TEST_TMP/nvm/versions/node/v22.13.0/bin:$orig_path" ]]
+}
+
+@test "resolve_npx_bin: falls back to \$HOME/.nvm when NVM_DIR is unset" {
+  _load_utils
+  local fake_home="$TEST_TMP/home"
+  mkdir -p "$fake_home/.nvm/versions/node/v22.13.0/bin"
+  printf '#!/usr/bin/env bash\necho fake-npx\n' > "$fake_home/.nvm/versions/node/v22.13.0/bin/npx"
+  chmod +x "$fake_home/.nvm/versions/node/v22.13.0/bin/npx"
+
+  unset NVM_DIR
+  HOME="$fake_home" resolve_npx_bin
+  [ "$RESOLVED_NPX_BIN" = "$fake_home/.nvm/versions/node/v22.13.0/bin/npx" ]
+}
+
+@test "resolve_npx_bin: falls back to a real PATH npx when no nvm install exists" {
+  _load_utils
+  local fake_bin="$TEST_TMP/fakebin"
+  mkdir -p "$fake_bin"
+  printf '#!/usr/bin/env bash\necho fake-npx\n' > "$fake_bin/npx"
+  chmod +x "$fake_bin/npx"
+
+  NVM_DIR="$TEST_TMP/no-such-nvm-dir" PATH="$fake_bin:$PATH" resolve_npx_bin
+  [ "$RESOLVED_NPX_BIN" = "$fake_bin/npx" ]
+}
+
+@test "resolve_npx_bin: rejects a shell-function-shadowed npx, doesn't treat the bare name as a path" {
+  # A lazy-load nvm shell integration defines npx as a function; `command -v`
+  # then reports the bare word "npx" (no slash), not a real executable path.
+  # No nvm install and an isolated PATH — the only "npx" in scope is the
+  # shell function — so this exercises the command-v fallback in isolation.
+  run bash -c "
+    source '$CLI_ROOT/lib/utils.sh'
+    npx() { _nvm_lazy_load; npx \"\$@\"; }
+    NVM_DIR='$TEST_TMP/no-such-nvm-dir' PATH='/nonexistent-only'
+    resolve_npx_bin && rc=0 || rc=\$?
+    echo \"status=\$rc resolved=[\$RESOLVED_NPX_BIN]\"
+  "
+  [[ "$output" == *"status=1 resolved=[]"* ]]
+}
+
+@test "resolve_npx_bin: returns 1 and leaves RESOLVED_NPX_BIN empty when nothing is found" {
+  run bash -c "
+    source '$CLI_ROOT/lib/utils.sh'
+    RESOLVED_NPX_BIN='stale-value-from-a-previous-call'
+    NVM_DIR='$TEST_TMP/no-such-nvm-dir' PATH='/nonexistent-only'
+    resolve_npx_bin && rc=0 || rc=\$?
+    echo \"status=\$rc resolved=[\$RESOLVED_NPX_BIN]\"
+  "
+  [[ "$output" == *"status=1 resolved=[]"* ]]
+}


### PR DESCRIPTION
## What
\`strut skills install\` now delegates skill-directory installation to [agent-add](https://github.com/pea3nut/agent-add) for the 5 formats it has a real host for — \`kiro\`, \`claude\`, \`cursor\`, \`windsurf\`, \`copilot\` — with automatic fallback to the existing direct-copy/flatten behavior when npx is unavailable or the agent-add call itself fails. \`zed\`/\`cline\`/\`agents\`/\`generic\` are unchanged (no agent-add host exists for zed or cline; agents/generic are strut-only conventions).

## Why
This isn't just a refactor for kiro/claude (which already copied skill directories by hand) — it's a real improvement for cursor/windsurf/copilot. Those three previously got skills *flattened* into the same single rules file as steering content, because strut assumed they had no directory-based skill support. agent-add's own host compatibility table says otherwise: Cursor, Windsurf, and GitHub Copilot all support native Skill assets now, so those formats get a proper on-demand Agent Skills directory (\`.cursor/skills/\`, etc.) plus a steering-only rules file, instead of permanently inlining the skill body into context.

## Two real bugs found and fixed along the way (\`lib/utils.sh\`)

Building this against a genuinely broken local Node/nvm setup (stale \`heroku-node\` symlink, lazy-load nvm shell plugin, nvm alias default pinned to Node 16) surfaced two bugs in the npx-resolution logic — extracted here into a shared \`resolve_npx_bin()\` used by both this feature and the pre-existing \`strut mcp install\`:

1. **Wrong Node version picked.** The old logic preferred \`nvm alias default\` over the highest installed version — irrelevant for a one-off tool invocation, and agent-add's bundled code uses \`node:util\`'s \`styleText\` (added in Node 21.7/22.13), so an old pinned default hard-crashed every agent-add call with a \`TypeError\`.
2. **The PATH fix was silently discarded.** Every caller resolved npx via \`npx_bin=$(resolve_npx_bin)\` — command substitution forks a subshell, so the \`export PATH=...\` inside only lived there and vanished the instant it returned. This wasn't cosmetic: npx re-spawns the downloaded package as a *child process* that does its own separate PATH lookup for \`node\`, so even an explicit full-path npx invocation still ran under a stale \`node\`. Fixed by changing the calling convention to \`resolve_npx_bin && npx_bin=\"$RESOLVED_NPX_BIN\"\` (never via \`$(...)\`), so the PATH change happens in the caller's real shell.

Both bugs pre-date this PR and affected the already-shipped \`strut mcp install\`, not just the new code that surfaced them. Verified end-to-end: \`agent-add --host kiro --skill <dir>\` failed with the styleText TypeError before the fix and succeeds after it.

## Also fixed
\`_agent_add_install_skills\`'s \`log()\`/\`warn()\` calls now go to stderr explicitly. Callers capture this function via \`skill_count=$(...)\`, and \`log()\`/\`warn()\` write to stdout by default — left as-is, the in-progress message corrupted the captured count on success, and the fallback warning was silently swallowed (never reaching the user) on failure.

## Testing
- New \`resolve_npx_bin\` coverage in \`tests/test_utils.bats\` (nvm version selection, alias-default rejection, PATH prepending, \$HOME/.nvm fallback, PATH fallback, shell-function-shadow rejection, not-found case).
- New \`_agent_add_install_skills\` + per-format integration coverage in \`tests/test_cmd_skills.bats\` (success/failure/fallback paths for kiro, claude, cursor, copilot, zed — all offline via stubs, no real npx/network dependency).
- Manually verified end-to-end against real \`agent-add\` for kiro/claude/cursor formats — correct \`SKILL.md\` + \`references/\` layout, correct steering-only rules files.
- Full \`bats tests/\` suite: 7 pre-existing failures on \`main\`, none related to this change — 2 are the known macOS-only \`flock\`-missing gap, 5 are already fixed by #344 (open, unmerged).

## Note
This PR's CI will likely show the same 5 completions/\`cmd_restore\` failures #344 already fixes, since #344 hasn't merged yet — unrelated to this diff.