### PR TITLE
fix(blue-green): guard the health gate with Docker's RestartCount too

### DIFF
--- a/lib/deploy_blue_green.sh
+++ b/lib/deploy_blue_green.sh
@@ -142,6 +142,28 @@ _bg_start_color() {
   $compose_cmd up -d --remove-orphans
 }
 
+# _bg_any_container_restarted <compose_cmd>
+#
+# True if any container in the project has a nonzero Docker RestartCount.
+# This is the authoritative, timing-independent signal that a container
+# crash-looped at some point — unlike polled `State`, it doesn't reset once
+# the container cycles back to "running", so it still catches a crash that
+# happened to fall between two polls.
+_bg_any_container_restarted() {
+  local compose_cmd="$1"
+  local _sudo
+  _sudo="$(vps_sudo_prefix 2>/dev/null || echo "")"
+
+  local cid
+  # shellcheck disable=SC2086
+  for cid in $($compose_cmd ps -q 2>/dev/null); do
+    local restarts
+    restarts=$(${_sudo}docker inspect "$cid" --format '{{.RestartCount}}' 2>/dev/null || echo 0)
+    [ "${restarts:-0}" -gt 0 ] && return 0
+  done
+  return 1
+}
+
 # _bg_wait_healthy <stack_dir> <compose_cmd> <compose_file> [timeout_seconds]
 #
 # Polls health_run_all (scoped to the green compose project) until it
@@ -172,8 +194,19 @@ _bg_wait_healthy() {
     if ( health_check_green "$(basename "$stack_dir")" "$compose_cmd" "$compose_file" >/dev/null 2>&1 ); then
       consecutive_ok=$((consecutive_ok + 1))
       if [ "$consecutive_ok" -ge "$required_consecutive" ]; then
-        ok "green healthy"
-        return 0
+        # Belt-and-suspenders on top of the consecutive-poll requirement:
+        # under enough scheduling delay (a loaded CI runner, for example),
+        # even two 3s-apart polls can both land while a crash-looping
+        # container is mid-"running" between restarts. RestartCount doesn't
+        # have that window — it's still nonzero long after the container
+        # cycles back to "running".
+        if _bg_any_container_restarted "$compose_cmd"; then
+          warn "green container(s) restarted during health checks — not trusting this as healthy"
+          consecutive_ok=0
+        else
+          ok "green healthy"
+          return 0
+        fi
       fi
     else
       consecutive_ok=0

--- a/tests/test_deploy_blue_green.bats
+++ b/tests/test_deploy_blue_green.bats
@@ -480,6 +480,48 @@ EOF
   ! grep -q "^cmd:down" "$CALLS_FILE"
 }
 
+# ── Restart-count guard (crash-loop can hide between polls) ─────────────────
+
+@test "_bg_any_container_restarted: false when every container has RestartCount 0" {
+  compose-fake() {
+    [ "$1" = "ps" ] && [ "$2" = "-q" ] && { echo "cid-a"; echo "cid-b"; }
+  }
+  export -f compose-fake
+  docker() {
+    [ "$1" = "inspect" ] && echo 0
+  }
+  export -f docker
+
+  run _bg_any_container_restarted "compose-fake"
+  [ "$status" -ne 0 ]
+}
+
+@test "_bg_any_container_restarted: true when any container has RestartCount > 0" {
+  compose-fake() {
+    [ "$1" = "ps" ] && [ "$2" = "-q" ] && { echo "cid-a"; echo "cid-b"; }
+  }
+  export -f compose-fake
+  docker() {
+    [ "$1" = "inspect" ] || return 0
+    [ "$2" = "cid-b" ] && { echo 3; return 0; }
+    echo 0
+  }
+  export -f docker
+
+  run _bg_any_container_restarted "compose-fake"
+  [ "$status" -eq 0 ]
+}
+
+@test "_bg_any_container_restarted: false when the project has no containers" {
+  compose-fake() {
+    [ "$1" = "ps" ] && [ "$2" = "-q" ] && return 0
+  }
+  export -f compose-fake
+
+  run _bg_any_container_restarted "compose-fake"
+  [ "$status" -ne 0 ]
+}
+
 
 @test "_bg_teardown_failed_color: uses 'down' without --volumes (data safety)" {
   compose-recorder() { _record "cmd:$*"; }


### PR DESCRIPTION
## What
Adds a second, timing-independent signal to the blue-green health gate's crash-loop detection.

## Why
CI failed on the latest \`main\` push (run [29102764512](https://github.com/gfargo/strut/actions/runs/29102764512)): \`test_blue_green_health_gate.bats\`'s crash-looping-green test intermittently returned status 0 (should be nonzero — a crash-looping deploy must be rejected), and the following healthy-deploy test then failed on the stale state that left behind.

\`_bg_wait_healthy\` already requires 2 consecutive healthy polls (3s apart) specifically to survive the window between \`up -d\` returning and a crash-looping entrypoint actually exiting — but that's still fundamentally a wall-clock race, just a narrower one. Under enough CI scheduling delay, both polls can land while the container happens to be mid-\"running\" between restart attempts.

## How
Docker's \`RestartCount\` doesn't have that window — it's a persistent counter on the container that stays nonzero long after the container cycles back to \"running\", so it's a genuinely different signal rather than a tighter poll. Added \`_bg_any_container_restarted()\`, checked once a container clears the consecutive-poll gate: any nonzero \`RestartCount\` resets the gate instead of declaring victory.

## Testing
- New unit tests for \`_bg_any_container_restarted\` (mocked docker/compose, no real daemon needed).
- Full \`tests/test_deploy_blue_green.bats\`: 28/28 pass.
- \`tests/integration/test_blue_green_health_gate.bats\` against a real Docker daemon: 5 consecutive clean runs.

Note: I could not reproduce the exact CI flake locally even before this fix (ran clean every time on this machine) — this is a defense-in-depth fix for a race that's real and narrow (the existing consecutive-poll requirement already narrowed it once), not a reproduction-confirmed root-cause fix. If it recurs on CI after this lands, that'll tell us the window is still open somewhere else.