### PR TITLE
fix(release): give release-please a real token so downstream workflows fire

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -3,6 +3,20 @@ name: Update Homebrew Tap
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to sync (e.g. v0.35.0) — for manually catching up a release that didn't trigger this workflow (see note below)"
+        required: true
+
+# NOTE: releases published by release-please-action using the default
+# GITHUB_TOKEN do NOT trigger this workflow — GitHub suppresses
+# workflow-triggering for events created by the default GITHUB_TOKEN,
+# specifically to prevent runaway recursive triggering. That silently broke
+# this workflow for v0.31.0–v0.35.0 (5 releases) until release-please.yml was
+# given a real PAT/App token instead (see that workflow's comments). If it
+# ever regresses, use the workflow_dispatch `tag` input above to catch up
+# manually rather than editing the tap by hand.
 
 jobs:
   update-tap:
@@ -10,19 +24,22 @@ jobs:
     runs-on: ubuntu-latest
     # Only run for stable releases (not pre-releases / draft releases).
     # Pre-releases (rc, alpha, beta) should not advance the tap formula.
+    # github.event.release.* is empty (falsy) for workflow_dispatch, so this
+    # still evaluates true and the job runs normally in that case.
     if: ${{ !github.event.release.prerelease && !github.event.release.draft }}
     steps:
       - name: Get release info
         id: release
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Download release tarball and compute SHA256
         id: sha
         run: |
-          URL="https://github.com/gfargo/strut/archive/refs/tags/${{ github.ref_name }}.tar.gz"
+          URL="https://github.com/gfargo/strut/archive/refs/tags/${{ steps.release.outputs.tag }}.tar.gz"
           SHA=$(curl -sL "$URL" | sha256sum | awk '{print $1}')
           echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
           echo "url=$URL" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,3 +16,22 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          # A release created with the default GITHUB_TOKEN does NOT trigger
+          # other workflows (GitHub suppresses workflow-triggering for
+          # GITHUB_TOKEN-authored events, to prevent runaway recursive
+          # triggering) — this silently broke homebrew.yml's `on: release`
+          # trigger for every release from v0.31.0 through v0.35.0. A PAT or
+          # GitHub App token is a real actor, so its release events trigger
+          # downstream workflows normally.
+          #
+          # Falls back to the default GITHUB_TOKEN when the secret doesn't
+          # exist yet, so this is safe to merge before it's set up — release
+          # PRs/tags keep working exactly as before, just without waking
+          # homebrew.yml, until the secret is added.
+          #
+          # To fix: create a fine-grained PAT (Contents: write, Pull
+          # requests: write, scoped to this repo) or a GitHub App
+          # installation token, then add it as a repo secret named
+          # RELEASE_PLEASE_TOKEN (Settings → Secrets and variables →
+          # Actions → New repository secret).
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What
Wires \`release-please.yml\` to use a \`RELEASE_PLEASE_TOKEN\` secret (with a safe fallback to the default \`GITHUB_TOKEN\`), and adds a \`workflow_dispatch\` trigger to \`homebrew.yml\` for manual catch-up.

## Why
Found while catching up the Homebrew tap, which turned out to be stuck on v0.30.1: GitHub suppresses workflow-triggering for events created by the default \`GITHUB_TOKEN\`, specifically to prevent runaway recursive triggering. \`release-please-action\` was publishing releases with the default token, so every release it created silently failed to fire \`homebrew.yml\`'s \`on: release: types: [published]\` trigger — **v0.31.0 through v0.35.0 (5 releases) never reached the tap**, even though the workflow itself was fine. v0.30.1 worked because that specific release was tagged manually with a real user's \`gh\` credentials, not through release-please.

## Action needed from you
This PR alone doesn't fully fix it — a workflow file can't mint credentials. You'll need to:
1. Create a fine-grained PAT (Contents: write, Pull requests: write, scoped to \`gfargo/strut\`) or a GitHub App installation token.
2. Add it as a repo secret named \`RELEASE_PLEASE_TOKEN\` (Settings → Secrets and variables → Actions → New repository secret).

Until that secret exists, this PR is a safe no-op — \`${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}\` falls back to exactly today's behavior.

## Also
\`homebrew.yml\` gains a \`workflow_dispatch\` trigger with a \`tag\` input, so a future gap like this one (or another missed release) can be closed with a manual run instead of hand-editing the tap repo directly.

## Related
Homebrew tap catch-up for v0.35.0: gfargo/homebrew-tap#2