### PR TITLE
fix(utils): validate VPS_DEPLOY_DIR for spaces; update Known Limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,21 +224,13 @@ See [GitHub Action](https://github.com/gfargo/strut/wiki/GitHub-Action) for the 
 ## Known Limitations
 
 **Project paths must not contain spaces.** strut's compose and SSH command
-builders use word-split path expansion. A project root like
-`/Users/me/My Projects/infra` will cause truncated, confusing errors.
+builders use word-split path expansion internally, so a project root like
+`/Users/me/My Projects/infra` is rejected up front with a clear error rather
+than failing confusingly deep in the pipeline.
 
 Workarounds:
 - Create a space-free symlink: `ln -s "/path/with spaces/infra" ~/strut-project`
 - Or set `STRUT_PROJECT` to the symlink: `STRUT_PROJECT=~/strut-project strut <stack> <cmd>`
-
-**macOS SSH ControlPath** — if you hit `unix_listener: path "..." too long for
-Unix domain socket`, the installed build may predate the `/tmp/%C` fix. Run
-`strut upgrade` to get the current build. As an escape hatch:
-
-```bash
-STRUT_SSH_NO_MUX=1 strut <stack> <cmd>          # disable mux entirely
-STRUT_SSH_CONTROL_DIR=/tmp strut <stack> <cmd>   # explicit short socket dir
-```
 
 ---
 

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -819,6 +819,7 @@ _validate_no_spaces() {
   local path="$1" label="${2:-path}"
   if [[ "$path" == *" "* ]]; then
     fail "The $label path contains spaces: '$path'. strut requires paths without spaces."
+    # shellcheck disable=SC2317 # reachable in tests, where fail() is mocked to `return` instead of `exit`
     return 1
   fi
   return 0

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -371,7 +371,12 @@ is_running_on_vps() {
 # The caller must source the env file BEFORE calling this so VPS_USER and
 # VPS_DEPLOY_DIR are populated.
 resolve_deploy_dir() {
-  echo "${VPS_DEPLOY_DIR:-/home/${VPS_USER:-ubuntu}/strut}"
+  local dir="${VPS_DEPLOY_DIR:-/home/${VPS_USER:-ubuntu}/strut}"
+  # Remote command strings built from this path (e.g. "cd $deploy_dir && ...")
+  # are word-split on both the local and remote shell, so a space here breaks
+  # silently rather than raising the guard at the top of the strut entrypoint.
+  _validate_no_spaces "$dir" "VPS_DEPLOY_DIR" || return 1
+  echo "$dir"
 }
 
 # require_cmd <cmd> [install-hint]
@@ -814,6 +819,7 @@ _validate_no_spaces() {
   local path="$1" label="${2:-path}"
   if [[ "$path" == *" "* ]]; then
     fail "The $label path contains spaces: '$path'. strut requires paths without spaces."
+    return 1
   fi
   return 0
 }

--- a/tests/test_deploy_dir.bats
+++ b/tests/test_deploy_dir.bats
@@ -53,3 +53,11 @@ teardown() {
   [ "$status" -eq 0 ]
   [ "$output" = "/home/gfargo/strut" ]
 }
+
+@test "resolve_deploy_dir: rejects VPS_DEPLOY_DIR containing spaces" {
+  export VPS_DEPLOY_DIR="/opt/my stacks"
+  run resolve_deploy_dir
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"VPS_DEPLOY_DIR"* ]]
+  [[ "$output" == *"spaces"* ]]
+}


### PR DESCRIPTION
## Summary

Investigated both entries in README's "Known Limitations" to see what a real fix would take.

**Spaces in paths** — turned out to be mostly already guard-railed (`STRUT_HOME`, project root, compose/env file paths, and the SSH key path all fail fast with a clear error today). The one real, executing-in-production gap: `VPS_DEPLOY_DIR` had zero validation and is interpolated unquoted into remote SSH command strings (e.g. `lib/backup.sh`'s `db:push` running-check). Fixed by centralizing the guard inside `resolve_deploy_dir()` — every caller (backup, deploy, ship, fleet, stop, remote:init) inherits it for free.

Along the way, found a real latent bug: `_validate_no_spaces` never returned non-zero after calling `fail()`, so callers' `|| return 1` guards were silently inert whenever `fail()` doesn't itself `exit` (i.e. under test, where it's mocked to `return`). Fixed that too — it was masking test coverage for every existing space-guard, not just this new one.

**macOS SSH ControlPath** — already fixed. `/tmp/%C` is the unconditional default (`lib/utils.sh:498-503`), confirmed via git history (`a3611cd`) and worst-case path-length math (~62 chars, well under the 104-char limit). No current install can hit this under default config — only a manual `STRUT_SSH_CONTROL_DIR` override to something long could reintroduce it, which is self-inflicted. Dropped it from Known Limitations.

## Test plan
- [x] `bats tests/test_deploy_dir.bats` — 6/6 passing (new regression test for the space guard)
- [x] Full suite: `bats tests/` — 1924/1924 passing