### PR TITLE
fix(tests): close three DB/container readiness races behind flaky Integration Tests

### DIFF
--- a/lib/backup.sh
+++ b/lib/backup.sh
@@ -473,14 +473,27 @@ restore_postgres() {
 
   log "Restoring PostgreSQL (service: $pg_service)..."
 
-  # Drop and recreate the database to avoid "already exists" errors
+  # Drop and recreate the database to avoid "already exists" errors.
+  # pg_terminate_backend() only sends SIGTERM and returns immediately — it
+  # does not wait for the target backend to actually disconnect. DROP
+  # DATABASE run right after can still race a backend that hasn't finished
+  # tearing down yet and fail with "database ... is being accessed by other
+  # users". Retry a few times with a short backoff instead of failing the
+  # whole restore over that transient window.
   log "Dropping and recreating database..."
-  $compose_cmd exec -T "$pg_service" \
-    psql -v ON_ERROR_STOP=1 -U "${POSTGRES_USER:-postgres}" -d postgres \
-    -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='${POSTGRES_DB:-${POSTGRES_USER:-postgres}}' AND pid <> pg_backend_pid();" \
-    -c "DROP DATABASE IF EXISTS \"${POSTGRES_DB:-${POSTGRES_USER:-postgres}}\";" \
-    -c "CREATE DATABASE \"${POSTGRES_DB:-${POSTGRES_USER:-postgres}}\";" \
-  || { error "Failed to recreate database"; return 1; }
+  local db_recreate_attempt db_recreated=false
+  for db_recreate_attempt in 1 2 3; do
+    if $compose_cmd exec -T "$pg_service" \
+      psql -v ON_ERROR_STOP=1 -U "${POSTGRES_USER:-postgres}" -d postgres \
+      -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='${POSTGRES_DB:-${POSTGRES_USER:-postgres}}' AND pid <> pg_backend_pid();" \
+      -c "DROP DATABASE IF EXISTS \"${POSTGRES_DB:-${POSTGRES_USER:-postgres}}\";" \
+      -c "CREATE DATABASE \"${POSTGRES_DB:-${POSTGRES_USER:-postgres}}\";"; then
+      db_recreated=true
+      break
+    fi
+    [ "$db_recreate_attempt" -eq 3 ] || { warn "Database recreate failed (attempt $db_recreate_attempt/3) — retrying after connections settle"; sleep 1; }
+  done
+  $db_recreated || { error "Failed to recreate database"; return 1; }
 
   # ON_ERROR_STOP=1 makes psql exit non-zero on the first failed statement,
   # so a partial restore is reported as a failure instead of "complete".

--- a/lib/deploy_blue_green.sh
+++ b/lib/deploy_blue_green.sh
@@ -174,15 +174,21 @@ _bg_any_container_restarted() {
 _bg_wait_healthy() {
   local stack_dir="$1" compose_cmd="$2" compose_file="$3"
   local timeout="${4:-${BLUE_GREEN_HEALTH_TIMEOUT:-30}}"
-  local interval=3
+  # Overridable only for tests — production callers always get the real 3s
+  # poll cadence.
+  local interval="${BLUE_GREEN_HEALTH_POLL_INTERVAL:-3}"
   local elapsed=0
   # A single healthy snapshot isn't enough: `up -d` returns as soon as the
   # container reaches "running", which can be a split second before a
   # crash-looping entrypoint actually exits — the very first poll can land
   # in that window and see "running" with no restart yet recorded. Require
   # back-to-back healthy polls so a crash gets at least one interval to
-  # reveal itself before we trust it.
-  local required_consecutive=2
+  # reveal itself before we trust it. Widened from 2 to 3: under enough CI
+  # runner contention, even RestartCount can still read 0 a full interval
+  # after the container first started — the crash hasn't been scheduled and
+  # detected by dockerd yet, not just hidden between polls. A wider window
+  # gives that detection more real time to happen before we ever accept.
+  local required_consecutive=3
   local consecutive_ok=0
 
   log "Waiting for green health (timeout: ${timeout}s)"
@@ -192,18 +198,18 @@ _bg_wait_healthy() {
     # dead green would pass) and host-global resources (a load spike during
     # pull would fail a healthy deploy). Subshell keeps its counters local.
     if ( health_check_green "$(basename "$stack_dir")" "$compose_cmd" "$compose_file" >/dev/null 2>&1 ); then
-      consecutive_ok=$((consecutive_ok + 1))
-      if [ "$consecutive_ok" -ge "$required_consecutive" ]; then
-        # Belt-and-suspenders on top of the consecutive-poll requirement:
-        # under enough scheduling delay (a loaded CI runner, for example),
-        # even two 3s-apart polls can both land while a crash-looping
-        # container is mid-"running" between restarts. RestartCount doesn't
-        # have that window — it's still nonzero long after the container
-        # cycles back to "running".
-        if _bg_any_container_restarted "$compose_cmd"; then
-          warn "green container(s) restarted during health checks — not trusting this as healthy"
-          consecutive_ok=0
-        else
+      # Check RestartCount on every passing poll, not just once we've hit
+      # the consecutive threshold: a restart spotted on poll 2 should reset
+      # progress immediately instead of waiting to be re-derived at the end.
+      # RestartCount doesn't have the "mid-'running' between restarts"
+      # window a single State snapshot does — it's still nonzero long after
+      # the container cycles back to "running".
+      if _bg_any_container_restarted "$compose_cmd"; then
+        warn "green container(s) restarted during health checks — not trusting this as healthy"
+        consecutive_ok=0
+      else
+        consecutive_ok=$((consecutive_ok + 1))
+        if [ "$consecutive_ok" -ge "$required_consecutive" ]; then
           ok "green healthy"
           return 0
         fi

--- a/tests/integration/test_backup_restore_e2e.bats
+++ b/tests/integration/test_backup_restore_e2e.bats
@@ -21,6 +21,36 @@ _skip_without_docker() {
   docker info >/dev/null 2>&1 || skip "docker daemon not running"
 }
 
+# _wait_ready <label> <max_attempts> <interval> <check_cmd...>
+#
+# Polls <check_cmd> until it succeeds twice in a row before trusting
+# readiness. A single success isn't proof: Postgres and MySQL both run a
+# temporary bootstrap server during initialization (init scripts, root
+# password/grant setup) that can answer a liveness probe successfully
+# moments before shutting down to hand off to the real server — a
+# false-positive "ready" window that a bare pg_isready/mysqladmin-ping poll
+# will happily report as success. Requiring two consecutive successes
+# closes that window, mirroring the belt-and-suspenders pattern the
+# blue-green health gate uses against the analogous crash-loop race
+# (lib/deploy_blue_green.sh's _bg_wait_healthy + _bg_any_container_restarted).
+_wait_ready() {
+  local label="$1" max_attempts="$2" interval="$3"
+  shift 3
+  local consecutive_ok=0
+  local attempt
+  for attempt in $(seq 1 "$max_attempts"); do
+    if "$@" >/dev/null 2>&1; then
+      consecutive_ok=$((consecutive_ok + 1))
+      [ "$consecutive_ok" -ge 2 ] && return 0
+    else
+      consecutive_ok=0
+    fi
+    sleep "$interval"
+  done
+  echo "timed out waiting for $label to be ready" >&2
+  return 1
+}
+
 setup_file() {
   CLI_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
   export CLI_ROOT
@@ -97,16 +127,11 @@ setup() {
 # ── Postgres round trip ────────────────────────────────────────────────────────
 
 @test "postgres backup/restore: marker row survives a full backup -> destroy -> restore cycle" {
-  # Wait for Postgres to accept connections.
-  local ready=1
-  for _ in $(seq 1 30); do
-    if $PG_COMPOSE_CMD exec -T postgres pg_isready -U postgres >/dev/null 2>&1; then
-      ready=0
-      break
-    fi
-    sleep 2
-  done
-  [ "$ready" -eq 0 ]
+  # Wait for Postgres to accept real queries (not just answer pg_isready —
+  # see _wait_ready above).
+  run _wait_ready "postgres" 30 2 \
+    $PG_COMPOSE_CMD exec -T postgres psql -U postgres -d app_db -c "SELECT 1;"
+  [ "$status" -eq 0 ]
 
   run $PG_COMPOSE_CMD exec -T postgres psql -U postgres -d app_db \
     -c "CREATE TABLE marker (val text); INSERT INTO marker VALUES ('backup-restore-e2e');"
@@ -135,15 +160,15 @@ setup() {
 # ── MySQL round trip ───────────────────────────────────────────────────────────
 
 @test "mysql backup/restore: marker row survives a full backup -> destroy -> restore cycle" {
-  local ready=1
-  for _ in $(seq 1 30); do
-    if docker exec "$MYSQL_CONTAINER_NAME" mysqladmin ping -uroot -ptestpass --silent >/dev/null 2>&1; then
-      ready=0
-      break
-    fi
-    sleep 3
-  done
-  [ "$ready" -eq 0 ]
+  # `mysqladmin ping` answers successfully against MySQL's temporary
+  # bootstrap server (used while docker-entrypoint runs init scripts) before
+  # the real server — with the configured database and credentials — is up.
+  # Confirmed locally: ping can report ready ~1-2s before an authenticated
+  # query actually succeeds. Poll with a real query instead (see _wait_ready
+  # above).
+  run _wait_ready "mysql" 30 3 \
+    docker exec "$MYSQL_CONTAINER_NAME" mysql -uroot -ptestpass -e "SELECT 1;"
+  [ "$status" -eq 0 ]
 
   export MYSQL_DATABASE="app_db"
   export MYSQL_ROOT_PASSWORD="testpass"

--- a/tests/test_backup_restore_safety.bats
+++ b/tests/test_backup_restore_safety.bats
@@ -134,6 +134,57 @@ teardown() {
   [[ "$output" == *"restore complete"* ]]
 }
 
+@test "restore_postgres: retries the database recreate after a transient connection-teardown race" {
+  local sql_file="$TEST_TMP/valid.sql"
+  echo "SELECT 1;" > "$sql_file"
+
+  # pg_terminate_backend() signals but doesn't wait for the backend to
+  # actually disconnect, so DROP DATABASE can transiently fail with
+  # "being accessed by other users" right after. Simulate that: the first
+  # two recreate attempts fail, the third (once the connection has
+  # settled) succeeds.
+  local drop_attempts_file="$TEST_TMP/drop_attempts"
+  echo 0 > "$drop_attempts_file"
+  fake_compose() {
+    echo "$*" >> "$COMPOSE_CALL_LOG"
+    if [[ "$*" == *"DROP DATABASE"* ]]; then
+      local n
+      n=$(($(cat "$drop_attempts_file") + 1))
+      echo "$n" > "$drop_attempts_file"
+      [ "$n" -ge 3 ] && return 0
+      return 1
+    fi
+    [ "${FAKE_RESTORE_FAIL:-0}" = "1" ] && return 1
+    return 0
+  }
+  export -f fake_compose
+
+  run restore_postgres "test-stack" "fake_compose" "$sql_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"restore complete"* ]]
+  [ "$(cat "$drop_attempts_file")" -eq 3 ]
+}
+
+@test "restore_postgres: gives up after repeated database-recreate failures" {
+  local sql_file="$TEST_TMP/valid.sql"
+  echo "SELECT 1;" > "$sql_file"
+
+  fake_compose() {
+    echo "$*" >> "$COMPOSE_CALL_LOG"
+    [[ "$*" == *"DROP DATABASE"* ]] && return 1
+    [ "${FAKE_RESTORE_FAIL:-0}" = "1" ] && return 1
+    return 0
+  }
+  export -f fake_compose
+
+  run restore_postgres "test-stack" "fake_compose" "$sql_file"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Failed to recreate database"* ]]
+  # Exactly 3 recreate attempts, then gave up — never reached the
+  # dump-apply step (which would add a 4th call without "DROP DATABASE").
+  [ "$(wc -l < "$COMPOSE_CALL_LOG")" -eq 3 ]
+}
+
 # ── restore_neo4j_from_targz ──────────────────────────────────────────────────
 
 @test "restore_neo4j_from_targz: refuses an empty archive without wiping /data" {

--- a/tests/test_deploy_blue_green.bats
+++ b/tests/test_deploy_blue_green.bats
@@ -522,6 +522,42 @@ EOF
   [ "$status" -ne 0 ]
 }
 
+# ── Wait-healthy: restart resets progress instead of accepting early ────────
+
+@test "_bg_wait_healthy: a restart spotted mid-poll resets progress rather than being missed" {
+  health_check_green() { return 0; }
+  export -f health_check_green
+
+  local poll_count_file="$TEST_TMP/restart_poll_count"
+  echo 0 > "$poll_count_file"
+  # Report a restart on the 2nd poll only, simulating a crash that shows up
+  # between polls. The gate must not have already accepted by then, and
+  # must require a fresh run of consecutive clean polls afterward.
+  _bg_any_container_restarted() {
+    local n
+    n=$(($(cat "$poll_count_file") + 1))
+    echo "$n" > "$poll_count_file"
+    [ "$n" -eq 2 ]
+  }
+  export -f _bg_any_container_restarted
+
+  export BLUE_GREEN_HEALTH_POLL_INTERVAL=1
+  run _bg_wait_healthy "$CLI_ROOT/stacks/$STACK" "fake-compose" "$CLI_ROOT/stacks/$STACK/docker-compose.yml" 10
+  [ "$status" -eq 0 ]
+  # Poll 1: ok=1. Poll 2: restart seen, resets to 0. Polls 3-5: ok=1,2,3 → accept.
+  [ "$(cat "$poll_count_file")" -eq 5 ]
+}
+
+@test "_bg_wait_healthy: never accepts a container that keeps restarting" {
+  health_check_green() { return 0; }
+  export -f health_check_green
+  _bg_any_container_restarted() { return 0; }
+  export -f _bg_any_container_restarted
+
+  export BLUE_GREEN_HEALTH_POLL_INTERVAL=1
+  run _bg_wait_healthy "$CLI_ROOT/stacks/$STACK" "fake-compose" "$CLI_ROOT/stacks/$STACK/docker-compose.yml" 2
+  [ "$status" -ne 0 ]
+}
 
 @test "_bg_teardown_failed_color: uses 'down' without --volumes (data safety)" {
   compose-recorder() { _record "cmd:$*"; }


### PR DESCRIPTION
## What
Closes three distinct container/DB-readiness races behind the Integration Tests workflow's ~40% flake rate on `main` — a different test failing each run (postgres backup/restore, mysql backup/restore, or the blue-green crash-loop gate).

## Why
That pattern (same shape of failure, different test each time) pointed at a systemic issue rather than a bug in any one test — the same class of race #347 partially fixed for the blue-green health gate. Pulled logs from six recent failing runs (29114470276, 29114111984, 29102764512, 28950348570, 28913522455, 28912238099) and reproduced two of the three races directly against real Docker containers on this machine; hardened the third defensively.

## How

**1. MySQL bootstrap-server false positive (reproduced conclusively)**
`mysqladmin ping` succeeds against MySQL's *temporary* bootstrap server (the one `docker-entrypoint` uses to run init scripts) up to ~2s before the real server — with the configured database and root password — is actually up:
```
t=3.5s ping=yes query=no   ← false positive
t=6.0s ping=yes query=yes  ← actually ready
```
`tests/integration/test_backup_restore_e2e.bats`'s `CREATE TABLE` step can land in that window and fail — matching the exact CI failure line. Replaced the ping-based wait with a real authenticated query, requiring two consecutive successes before trusting readiness (mirrors the blue-green gate's belt-and-suspenders pattern). Applied the same hardening to the postgres wait for consistency, though `pg_isready` didn't reproduce a false positive locally.

**2. Postgres restore's connection-teardown race**
The postgres e2e failures were actually one step later, inside `restore_postgres` itself: `pg_terminate_backend()` only sends SIGTERM and returns immediately — it doesn't wait for the target backend to actually disconnect — so the `DROP DATABASE` run right after can race a backend that hasn't finished tearing down and fail with `database ... is being accessed by other users`. Wrapped the terminate+drop+create sequence in a 3-attempt retry with backoff.

**3. Blue-green crash-loop gate — widen the window further**
#347 added a `RestartCount` check to `_bg_wait_healthy`, but only applied it once the consecutive-poll counter hit its threshold — a restart could still be invisible if it hadn't been recorded by dockerd on either of the first two polls (run 29102764512, cited in #347 as the original repro, recurred after that fix landed). Now every passing poll checks `RestartCount` immediately, and the required run of clean polls is 3 instead of 2, giving dockerd more real wall-clock time to register a crash before the gate can ever accept.

## Test plan
- [x] New unit tests: `_bg_wait_healthy` restart-mid-poll reset + never-accepts-a-crash-loop (`tests/test_deploy_blue_green.bats`)
- [x] New unit tests: `restore_postgres` retries a transient recreate failure + gives up after 3 (`tests/test_backup_restore_safety.bats`)
- [x] `tests/integration/` against a real Docker daemon: 5/5 pass
- [x] Full suite: 1926/1928 pass — the only 2 failures are pre-existing macOS-only cron/flock environment issues in files this PR doesn't touch
- [x] `shellcheck -x` clean on both modified `lib/*.sh` files