### PR TITLE
fix(remote-init): verify the strut binary actually works before reporting success

### DIFF
--- a/lib/cmd_remote_init.sh
+++ b/lib/cmd_remote_init.sh
@@ -130,11 +130,30 @@ cmd_remote_init() {
   log "[2/4] Checking remote deploy directory..."
   # shellcheck disable=SC2029
   if ssh $ssh_opts "$user@$host" "test -d '$deploy_dir/.git'"; then
-    # Already exists — verify and report
+    # Already exists — verify the strut binary actually works before
+    # reporting success. A .git checkout with no working strut binary (e.g.
+    # cloned by some other means, or left behind by a partial prior run)
+    # would otherwise report "already initialized" and send the operator
+    # into a release/update loop that fails with an unrelated error later.
     log "Deploy directory already exists at $deploy_dir"
+
+    # Ensure the exec bit is set before checking — mirrors the fresh-clone
+    # path below. Harmless no-op if the binary doesn't exist.
+    # shellcheck disable=SC2029
+    ssh $ssh_opts "$user@$host" "chmod +x '$deploy_dir/strut'" 2>/dev/null || true
+
     local remote_version
     # shellcheck disable=SC2029
-    remote_version=$(ssh $ssh_opts "$user@$host" "cd '$deploy_dir' && ./strut --version 2>/dev/null" || echo "unknown")
+    remote_version=$(ssh $ssh_opts "$user@$host" "cd '$deploy_dir' && ./strut --version 2>/dev/null" || echo "")
+
+    if [ -z "$remote_version" ]; then
+      fail "Deploy directory exists at $deploy_dir, but the strut binary is missing or broken (./strut --version failed).
+This usually means the repo was cloned some other way and never vendored a working strut executable.
+Next step: remove the directory and re-run remote:init for a clean checkout:
+  ssh $user@$host \"rm -rf '$deploy_dir'\"
+  strut ${stack:-<stack>} remote:init --env ${CMD_ENV_NAME:-prod}"
+    fi
+
     local remote_branch
     # shellcheck disable=SC2029
     remote_branch=$(ssh $ssh_opts "$user@$host" "cd '$deploy_dir' && git rev-parse --abbrev-ref HEAD 2>/dev/null" || echo "unknown")

--- a/tests/test_remote_init.bats
+++ b/tests/test_remote_init.bats
@@ -241,3 +241,65 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" == *"main"* ]]
 }
+
+# ── "Already initialized" branch (real, non-dry-run SSH flow) ─────────────────
+
+@test "cmd_remote_init: already-initialized directory with working strut reports success" {
+  export DRY_RUN=false
+  export CMD_STACK="my-stack"
+  cat > "$TEST_TMP/.prod.env" <<'EOF'
+VPS_HOST=existing.example.com
+VPS_USER=deploy
+EOF
+  export CMD_ENV_FILE="$TEST_TMP/.prod.env"
+
+  ssh() {
+    local cmd="$*"
+    case "$cmd" in
+      *"echo ok"*) echo "ok" ;;
+      *"test -d"*".git"*) return 0 ;;
+      *"chmod +x"*) return 0 ;;
+      *"--version"*) echo "0.35.2" ;;
+      *"rev-parse --abbrev-ref HEAD"*) echo "main" ;;
+      *) return 0 ;;
+    esac
+  }
+  export -f ssh
+
+  run cmd_remote_init
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already initialized"* ]]
+  [[ "$output" == *"0.35.2"* ]]
+}
+
+@test "cmd_remote_init: already-initialized directory with broken strut binary fails clearly" {
+  export DRY_RUN=false
+  export CMD_STACK="my-stack"
+  cat > "$TEST_TMP/.prod.env" <<'EOF'
+VPS_HOST=existing.example.com
+VPS_USER=deploy
+EOF
+  export CMD_ENV_FILE="$TEST_TMP/.prod.env"
+
+  # Use exit-based fail so the run subshell actually stops here, matching
+  # the "fails without host" test above.
+  fail() { echo "FAIL: $1" >&2; exit 1; }
+  export -f fail
+
+  ssh() {
+    local cmd="$*"
+    case "$cmd" in
+      *"echo ok"*) echo "ok" ;;
+      *"test -d"*".git"*) return 0 ;;
+      *"chmod +x"*) return 1 ;;
+      *"--version"*) return 1 ;;
+      *) return 0 ;;
+    esac
+  }
+  export -f ssh
+
+  run cmd_remote_init
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"missing or broken"* ]]
+  [[ "$output" != *"already initialized on"* ]]
+}


### PR DESCRIPTION
Fixes #356

## Problem

`remote:init`'s "already initialized" branch only checked `test -d '$deploy_dir/.git'` — never that `$deploy_dir/strut` actually existed or ran. A repo cloned onto the VPS by some other means (or left behind by a partial prior `remote:init` run) without a working vendored `strut` binary would report **"strut already initialized on $host"** and exit 0.

That sends the operator into a loop: `release`/`update` then fails with `ERROR: strut binary not found in $deploy_dir after update`, which recommends running `remote:init` again — which reports success again. No clear signal anything is actually wrong.

## Fix

The "already exists" branch now:
1. `chmod +x`'s the binary first (harmless no-op if missing, mirrors the fresh-clone path's own behavior)
2. Confirms `./strut --version` actually returns a non-empty version before reporting success
3. If it's empty, fails clearly with a concrete next step (remove the directory, re-run `remote:init` for a clean checkout) instead of silently reporting success

## Test plan
- [x] `bats tests/test_remote_init.bats` — added 2 tests covering the real (non-dry-run) SSH flow for this branch: working binary → success, broken binary → clear failure. Both pass, plus all 17 pre-existing tests still pass (19/19)
- [x] Full suite (`bats tests/`) — no regressions (1935/1937, the 2 failures are pre-existing, unrelated environment flakes)
- [x] `shellcheck -s bash lib/cmd_remote_init.sh` — clean