### PR TITLE
fix(secrets): pull writes to the stack-level path, not always project root

### DIFF
--- a/lib/cmd_secrets.sh
+++ b/lib/cmd_secrets.sh
@@ -437,8 +437,14 @@ _secrets_pull() {
   local remote_path
   remote_path=$(_secrets_resolve_remote_path "$deploy_dir" "$env_name")
 
-  # Output path: project-level
-  local local_env="$CLI_ROOT/.${env_name}.env"
+  # Output path: reuse whichever local file already exists (stack-level takes
+  # priority — same order push/diff/etc. read from), defaulting to stack-level
+  # for a brand new file so a multi-stack project's pull for stack A can't
+  # collide with stack B, and push -> edit -> pull round-trips the same file.
+  local local_env
+  if ! local_env=$(_secrets_resolve_local_env "$stack_dir" "$env_name" 2>/dev/null); then
+    local_env="$stack_dir/.${env_name}.env"
+  fi
 
   local ssh_opts
   ssh_opts=$(build_ssh_opts -p "$vps_port" -k "$vps_ssh_key" --batch)
@@ -490,6 +496,7 @@ _secrets_pull() {
   scp $scp_opts "$vps_user@$vps_host:$remote_path" "$tmp_pull" || { rm -f "$tmp_pull"; fail "Download failed"; }
   mv "$tmp_pull" "$local_env"
   chmod 600 "$local_env"
+  trap - RETURN
   ok "Env file downloaded: $local_env"
 }
 
@@ -569,6 +576,7 @@ _secrets_diff() {
   _secrets_render_env_diff "$local_env" "$tmp_remote"
 
   rm -f "$tmp_remote"
+  trap - RETURN
 }
 
 # _secrets_check_content <env_file>

--- a/tests/test_secrets_pull.bats
+++ b/tests/test_secrets_pull.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_secrets_pull.bats — Tests for `secrets pull`
+# ==================================================
+# Run:  bats tests/test_secrets_pull.bats
+# Covers strut#357: pull must write to the same stack-level path push/diff/
+# status prefer, not unconditionally to the project root — otherwise pulling
+# for stack B silently overwrites stack A's downloaded env at the same
+# project-root path in a multi-stack project.
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_utils
+
+  fail()  { echo "FAIL: $1" >&2; return 1; }
+  ok()    { echo "OK: $*"; }
+  warn()  { echo "WARN: $*" >&2; }
+  log()   { echo "LOG: $*"; }
+  error() { echo "ERROR: $*" >&2; }
+  print_banner() { echo "== $* =="; }
+  export -f fail ok warn log error print_banner
+
+  export RED="" GREEN="" YELLOW="" BLUE="" NC=""
+
+  source "$CLI_ROOT/lib/topology.sh"
+  source "$CLI_ROOT/lib/secrets_providers.sh"
+  source "$CLI_ROOT/lib/cmd_secrets.sh"
+
+  build_ssh_opts() { echo "-o BatchMode=yes"; }
+  ssh() { return 0; }  # remote file exists, by default
+  scp() { echo "remote-content" > "${@: -1}"; return 0; }  # "download" writes to the last arg
+  export -f build_ssh_opts ssh scp
+
+  export HOME="$TEST_TMP/fakehome"
+  mkdir -p "$HOME/.ssh"
+
+  export CLI_ROOT="$TEST_TMP"
+  export CMD_STACK="my-app"
+  export CMD_STACK_DIR="$TEST_TMP/stacks/my-app"
+  export CMD_ENV_NAME="prod"
+  mkdir -p "$CMD_STACK_DIR"
+
+  export VPS_HOST="vps.example.com"
+  export VPS_USER="deploy"
+
+  _TOPO_LOADED=true
+  declare -gA _TOPO_HOSTS=()
+  declare -gA _TOPO_STACK_HOST=()
+}
+
+teardown() { common_teardown; }
+
+@test "secrets pull: new file defaults to the stack-level path, not project root" {
+  run _secrets_pull
+  [ "$status" -eq 0 ]
+
+  [ -f "$CMD_STACK_DIR/.prod.env" ]
+  [ ! -f "$CLI_ROOT/.prod.env" ]
+}
+
+@test "secrets pull: two different stacks don't clobber each other's env" {
+  export CMD_STACK="app-a"
+  export CMD_STACK_DIR="$TEST_TMP/stacks/app-a"
+  mkdir -p "$CMD_STACK_DIR"
+  scp() { echo "app-a-secrets" > "${@: -1}"; return 0; }
+  export -f scp
+  run _secrets_pull
+  [ "$status" -eq 0 ]
+
+  export CMD_STACK="app-b"
+  export CMD_STACK_DIR="$TEST_TMP/stacks/app-b"
+  mkdir -p "$CMD_STACK_DIR"
+  scp() { echo "app-b-secrets" > "${@: -1}"; return 0; }
+  export -f scp
+  run _secrets_pull
+  [ "$status" -eq 0 ]
+
+  [ -f "$TEST_TMP/stacks/app-a/.prod.env" ]
+  [ -f "$TEST_TMP/stacks/app-b/.prod.env" ]
+  [ "$(cat "$TEST_TMP/stacks/app-a/.prod.env")" = "app-a-secrets" ]
+  [ "$(cat "$TEST_TMP/stacks/app-b/.prod.env")" = "app-b-secrets" ]
+}
+
+@test "secrets pull: reuses an existing project-level file (backward compat)" {
+  printf 'EXISTING=1\n' > "$CLI_ROOT/.prod.env"
+  chmod 600 "$CLI_ROOT/.prod.env"
+
+  run _secrets_pull --force
+  [ "$status" -eq 0 ]
+
+  [ -f "$CLI_ROOT/.prod.env" ]
+  [ ! -f "$CMD_STACK_DIR/.prod.env" ]
+}
+
+@test "secrets pull: prefers an existing stack-level file over project-level" {
+  printf 'STACK_LEVEL=1\n' > "$CMD_STACK_DIR/.prod.env"
+  chmod 600 "$CMD_STACK_DIR/.prod.env"
+  printf 'PROJECT_LEVEL=1\n' > "$CLI_ROOT/.prod.env"
+  chmod 600 "$CLI_ROOT/.prod.env"
+
+  run _secrets_pull --force
+  [ "$status" -eq 0 ]
+
+  [ "$(cat "$CMD_STACK_DIR/.prod.env")" = "remote-content" ]
+  [ "$(cat "$CLI_ROOT/.prod.env")" = "PROJECT_LEVEL=1" ]
+}
+
+@test "secrets pull: round-trips with push's read location" {
+  # push reads via _secrets_resolve_local_env; pull's write target for a new
+  # file must resolve to the exact same path.
+  local push_would_read
+  push_would_read=$(_secrets_resolve_local_env "$CMD_STACK_DIR" "prod" 2>/dev/null || echo "$CMD_STACK_DIR/.prod.env")
+
+  run _secrets_pull
+  [ "$status" -eq 0 ]
+
+  [ -f "$push_would_read" ]
+}


### PR DESCRIPTION
Fixes #357

## Problem

`_secrets_pull` unconditionally wrote to `$CLI_ROOT/.<env>.env`, unlike every other `secrets` subcommand (`push`, `diff`, `set`, `validate`, `status`, `rotate`, `lock`/`unlock`), which all resolve the local file via the shared `_secrets_resolve_local_env` helper — stack-level first, then project-level.

In a multi-stack project (the normal case), `secrets pull` for stack A followed by stack B silently overwrites stack A's downloaded env at the same project-root path. It also broke the `push` → edit → `pull` round trip, since `push` reads from the stack-level file but `pull` could never write back to it.

## Fix

`pull` now reuses `_secrets_resolve_local_env` to find where a local file already lives (respecting an existing project-level file for backward compat — no silent path migration for existing users), defaulting to the stack-level path only when creating a brand new file. Exactly the fix path the issue suggested.

## Bonus fix — stale RETURN trap

This function had **zero test coverage** before this PR. While adding it, the very first test run crashed the entire bats process (not just failed a test) with `tmp_pull: unbound variable` — thrown from inside bats' own internals, not my test or `cmd_secrets.sh`.

Root cause: `_secrets_pull` (and, same bug, `_secrets_diff`) set `trap 'rm -f "$tmp_pull" ...' RETURN` to clean up a temp download file, but never cleared it with `trap - RETURN` before returning — unlike every other function in this file using the identical pattern (`_secrets_write_var`, two others). An uncleared `RETURN` trap in bash isn't scoped to the function that set it — it keeps firing on *every* subsequent function return in the same shell, referencing a `local` variable that's long out of scope. Harmless in a real one-shot CLI process (exits right after), but a real latent bug — and exactly what crashed bats' own machinery once a real test finally exercised this code path. Fixed both functions to match the established cleanup convention.

## Test plan
- [x] New `tests/test_secrets_pull.bats` (5 tests, previously zero coverage): new file → stack-level; two stacks don't clobber each other; existing project-level file respected; stack-level preferred when both exist; round-trips with where `push` reads from. All pass.
- [x] Full suite (`bats tests/`) — no regressions (1935/1937, the 2 failures are pre-existing, unrelated environment flakes)
- [x] `shellcheck -s bash lib/cmd_secrets.sh` — clean