### PR TITLE
feat(release): health-gated auto-rollback on the release command

### DIFF
--- a/lib/cmd_deploy.sh
+++ b/lib/cmd_deploy.sh
@@ -242,7 +242,7 @@ _usage_rebuild() {
   echo ""
 }
 
-# cmd_release [--strict] [--confirm-data-move] (reads CMD_*)
+# cmd_release [--strict] [--confirm-data-move] [--no-rollback] (reads CMD_*)
 cmd_release() {
   local stack="$CMD_STACK"
   local env_file="$CMD_ENV_FILE"
@@ -250,11 +250,13 @@ cmd_release() {
 
   # Parse release-specific flags
   local confirm_data_move=false
+  local auto_rollback=true
   local args=("${CMD_ARGS[@]+"${CMD_ARGS[@]}"}")
   for arg in "${args[@]+"${args[@]}"}"; do
     case "$arg" in
       --strict) export MIGRATION_FAILURE_MODE="halt" ;;
       --confirm-data-move) confirm_data_move=true ;;
+      --no-rollback) auto_rollback=false ;;
     esac
   done
 
@@ -264,7 +266,7 @@ cmd_release() {
   _deploy_volguard "$stack" "$env_file" "$confirm_data_move" || return 1
   diff_warn_env_divergence "$stack" "$env_file" "${CMD_STACK_DIR:-$CLI_ROOT/stacks/$stack}"
 
-  vps_release "$stack" "$env_file" "$services"
+  vps_release "$stack" "$env_file" "$services" "$auto_rollback"
 }
 
 # cmd_deploy [--pull-only] [--skip-validation] [positional...] (reads CMD_*)

--- a/lib/deploy.sh
+++ b/lib/deploy.sh
@@ -410,6 +410,7 @@ vps_release() {
   local stack="$1"
   local env_file="$2"
   local services_profile="${3:-}"
+  local auto_rollback="${4:-true}"
 
   validate_env_file "$env_file" VPS_HOST
 
@@ -449,6 +450,9 @@ vps_release() {
     run_cmd "Pull latest images" ssh "$vps_user@$vps_host" "cd $deploy_dir && ./strut $stack deploy --env $env_name --pull-only"
     run_cmd "Restart services" ssh "$vps_user@$vps_host" "cd $deploy_dir && ./strut $stack deploy --env $env_name"
     run_cmd "Verify deployment" ssh "$vps_user@$vps_host" "cd $deploy_dir && ./strut $stack health --env $env_name"
+    if [ "$auto_rollback" = "true" ]; then
+      run_cmd "Roll back on health failure (auto)" ssh "$vps_user@$vps_host" "cd $deploy_dir && ./strut $stack rollback --env $env_name"
+    fi
     echo ""
     echo -e "${YELLOW}[DRY-RUN] No changes made.${NC}"
     return 0
@@ -508,11 +512,30 @@ vps_release() {
   # Step 6: Verify deployment
   log "[6/6] Verifying deployment..."
   sleep 10  # Give services time to start
+  local health_ok=true
   # shellcheck disable=SC2029
   ssh $ssh_opts "$vps_user@$vps_host" "
     cd '$deploy_dir'
     ./strut $stack health --env $env_name $profile_flag
-  " || warn "Health check failed — check logs with: strut $stack logs --env $env_name"
+  " || health_ok=false
+
+  if [ "$health_ok" = "false" ]; then
+    if [ "$auto_rollback" = "true" ]; then
+      warn "Health check failed — rolling back to the previous release..."
+      # shellcheck disable=SC2029
+      if ssh $ssh_opts "$vps_user@$vps_host" "
+        cd '$deploy_dir'
+        ./strut $stack rollback --env $env_name
+      "; then
+        ok "Rolled back to the previous release"
+      else
+        warn "Automatic rollback also failed — manual intervention required."
+      fi
+    else
+      warn "Health check failed (auto-rollback disabled with --no-rollback)"
+    fi
+    fail "Release failed health checks after deploy — check logs with: strut $stack logs --env $env_name"
+  fi
 
   # Auto-SSL: provision certs for detected domains (if configured)
   local strut_home="${STRUT_HOME:-${CLI_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}}"

--- a/strut
+++ b/strut
@@ -262,7 +262,7 @@ usage() {
   echo ""
   echo "Commands:"
   echo "  update   [--env <name>]                                        Pull latest strut on VPS"
-  echo "  release  [--env <name>] [--services <profile>] [--strict]       Full VPS release (update + migrate + deploy)"
+  echo "  release  [--env <name>] [--services <profile>] [--strict] [--no-rollback]  Full VPS release (update + migrate + deploy)"
   echo "  deploy   [--env <name>] [--services <profile>] [--pull-only]  Deploy stack"
   echo "  rebuild  [--env <name>] [--no-cache] [--pull]                  Build images + deploy"
   echo "  ship     [--env <name>] [-m <msg>] [--no-commit]               Commit, push, rebuild on remote"

--- a/tests/test_cmd_deploy.bats
+++ b/tests/test_cmd_deploy.bats
@@ -132,6 +132,19 @@ EOF
   [[ "$output" == *"vps_release"* ]]
 }
 
+@test "cmd_release: auto_rollback defaults to true" {
+  run cmd_release
+  [ "$status" -eq 0 ]
+  [[ "$output" == *" true"* ]]
+}
+
+@test "cmd_release: --no-rollback passes auto_rollback=false to vps_release" {
+  export CMD_ARGS=(--no-rollback)
+  run cmd_release
+  [ "$status" -eq 0 ]
+  [[ "$output" == *" false"* ]]
+}
+
 @test "cmd_health: dispatches to health_run_all" {
   run cmd_health
   [ "$status" -eq 0 ]

--- a/tests/test_release.bats
+++ b/tests/test_release.bats
@@ -142,15 +142,76 @@ teardown() {
   [ ! -s "$SSH_CALL_LOG" ]
 }
 
-# ── Health check failure is non-fatal ──────────────────────────────────────────
+# ── Health-gated auto-rollback ────────────────────────────────────────────────
 
-@test "vps_release: a failing final health check warns but still returns 0" {
+@test "vps_release: a failing final health check triggers rollback and returns non-zero" {
   export SSH_FAIL_PATTERN="health --env"
 
   run vps_release "test-stack" "$TEST_TMP/.test.env" ""
-  [ "$status" -eq 0 ]
+  [ "$status" -ne 0 ]
   [[ "$output" == *"Health check failed"* ]]
+  [[ "$output" == *"rolling back"* ]]
+  [[ "$output" == *"Rolled back to the previous release"* ]]
 
   run cat "$SSH_CALL_LOG"
   [[ "$output" == *"health --env test"* ]]
+  [[ "$output" == *"rollback --env test"* ]]
+}
+
+@test "vps_release: still returns non-zero even when the rollback itself succeeds" {
+  # A recovered rollback still means the requested release did not happen —
+  # callers (CI, scripts) must see this as a failure, not a silent success.
+  export SSH_FAIL_PATTERN="health --env"
+
+  run vps_release "test-stack" "$TEST_TMP/.test.env" ""
+  [ "$status" -ne 0 ]
+}
+
+@test "vps_release: --no-rollback (auto_rollback=false) skips rollback but still fails" {
+  export SSH_FAIL_PATTERN="health --env"
+
+  run vps_release "test-stack" "$TEST_TMP/.test.env" "" "false"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"auto-rollback disabled"* ]]
+
+  run cat "$SSH_CALL_LOG"
+  [[ "$output" != *"rollback --env"* ]]
+}
+
+@test "vps_release: warns but doesn't mask the original failure when rollback itself fails" {
+  # stub_ssh_conditional only supports one glob pattern — need both the
+  # health check AND the rollback call to fail here, so stub ssh() directly.
+  SSH_CALL_LOG="$TEST_TMP/ssh_calls.log"
+  : > "$SSH_CALL_LOG"
+  export SSH_CALL_LOG
+  ssh() {
+    local remote_cmd
+    remote_cmd="$(echo "${@: -1}" | tr '\n' ' ')"
+    echo "$remote_cmd" >> "$SSH_CALL_LOG"
+    case "$remote_cmd" in
+      *"health --env"*|*"rollback --env"*) return 1 ;;
+      *) return 0 ;;
+    esac
+  }
+  export -f ssh
+
+  run vps_release "test-stack" "$TEST_TMP/.test.env" ""
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Automatic rollback also failed"* ]]
+}
+
+@test "vps_release: dry-run plan includes the rollback-on-failure step" {
+  export DRY_RUN=true
+
+  run vps_release "test-stack" "$TEST_TMP/.test.env" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Roll back on health failure"* ]]
+}
+
+@test "vps_release: a passing health check never invokes rollback" {
+  run vps_release "test-stack" "$TEST_TMP/.test.env" ""
+  [ "$status" -eq 0 ]
+
+  run cat "$SSH_CALL_LOG"
+  [[ "$output" != *"rollback --env"* ]]
 }


### PR DESCRIPTION
Addresses #186 (partially — see below)

## Problem

`vps_release`'s final health check (step 6/6) only `warn`ed on failure and still printed "✓ Release complete!" with exit 0. A release that deployed a broken image looked identical to a successful one to any caller — CI, scripts, or a human glancing at the output.

strut already has a full rollback subsystem (`cmd_rollback` — dry-run, list, diff, blue-green delegation, post-restore health check) and takes a pre-deploy image snapshot on every deploy (`rollback_save_snapshot`). Nothing wired either of those into `release`'s own failure path.

## Fix

`release` now:
- Automatically rolls back to the previous snapshot when the post-deploy health check fails (reuses the existing `strut <stack> rollback` command, invoked remotely — same SSH pattern as every other release step)
- Always returns non-zero when health failed, even if the rollback itself succeeded — the requested release didn't happen, and that should read as a failure to callers, not a silent recovery
- New `--no-rollback` flag to opt out and leave the broken state in place for debugging

## Investigation note — most of #186 turned out to already exist

Before touching anything I checked what #186's 4 asks actually needed:
- **Item 3 (rollback command)** — already exists (`cmd_rollback.sh`), just never auto-invoked. This PR is that missing wire.
- **Item 4 (`on_health_fail` hook "never fired")** — already fires, from `lib/cmd_deploy.sh:406-407`. The issue's claim here appears stale.
- **Item 1 (`--backup-first`)** — genuinely not implemented. See caveat below.
- **Item 2 (dry-run clean preview)** — already implemented for `fleet_sync`/`sync`, not verified for regular `deploy --dry-run` specifically. Not touched here.

## Caveat — this doesn't cover migration-safety

`rollback_save_snapshot` only captures container image references, not database state. If a release's migration step made an incompatible schema change, rolling back the images alone won't undo it — old app code would run against the new schema. A `--backup-first` pre-deploy DB snapshot (the other half of #186, item 1) would close that gap. Deliberately left out of this PR to keep it reviewable as one concern; flagging as the natural follow-up.

## Test plan
- [x] `tests/test_release.bats` — rewrote the one existing test that codified the old "warn but return 0" behavior, added 6 new tests: rollback fires on health failure, still fails even when rollback succeeds, `--no-rollback` skips rollback but still fails, rollback-itself-fails is reported without masking the original failure, dry-run plan shows the rollback step, passing health never invokes rollback. 12/12 pass.
- [x] `tests/test_cmd_deploy.bats` — 2 new tests for `--no-rollback` flag parsing/propagation. Pass.
- [x] Full suite (`bats tests/`) — no regressions (1942/1944, the 2 failures are pre-existing, unrelated environment flakes)
- [x] `shellcheck -s bash lib/deploy.sh lib/cmd_deploy.sh strut` — clean