### PR TITLE
feat(release): add --backup-first for a pre-deploy database snapshot

### DIFF
--- a/completions/bash.sh
+++ b/completions/bash.sh
@@ -69,7 +69,7 @@ _strut_completions() {
   cword=$COMP_CWORD
 
   local top_cmds="init list scaffold upgrade doctor status-all posture group monitoring audit audit:list audit:diff audit:generate migrate migrate:status notify sync fleet webhook mcp skills help completions --version -v --help -h"
-  local per_stack_cmds="update release deploy rebuild ship stop diff lock health logs logs:download logs:rotate backup drift migrate restore db:pull db:push db:schema shell exec remote:init provision ssh:keygen ci:init cert:renew cert:status init-secrets secrets status volumes prune local prod staging dev debug keys validate rollback domain --help"
+  local per_stack_cmds="update release deploy rebuild ship stop diff lock health logs logs:download logs:rotate backup drift migrate restore db:pull db:push db:schema shell exec remote:init provision ssh:keygen ci:init cert:renew cert:status init-secrets secrets status volumes prune local prod staging dev debug keys validate rollback history domain --help"
   local profiles="messaging ui full"
 
   # Flag-value completions — operate on prev regardless of position

--- a/completions/fish.fish
+++ b/completions/fish.fish
@@ -61,7 +61,7 @@ function __strut_tok
 end
 
 set -l top_cmds init list scaffold upgrade doctor status-all posture group monitoring audit audit:list audit:diff audit:generate migrate migrate:status notify sync fleet webhook mcp skills help completions
-set -l per_stack_cmds update release deploy rebuild ship stop diff lock health logs logs:download logs:rotate backup drift migrate restore db:pull db:push db:schema shell exec remote:init provision ssh:keygen ci:init cert:renew cert:status init-secrets secrets status volumes prune local prod staging dev debug keys validate rollback domain
+set -l per_stack_cmds update release deploy rebuild ship stop diff lock health logs logs:download logs:rotate backup drift migrate restore db:pull db:push db:schema shell exec remote:init provision ssh:keygen ci:init cert:renew cert:status init-secrets secrets status volumes prune local prod staging dev debug keys validate rollback history domain
 
 # Disable file completion by default; re-enable where relevant
 complete -c strut -f

--- a/completions/zsh.sh
+++ b/completions/zsh.sh
@@ -50,7 +50,7 @@ _strut_groups() {
 _strut() {
   local -a top_cmds per_stack_cmds profiles
   top_cmds=(init list scaffold upgrade doctor status-all posture group monitoring audit audit:list audit:diff audit:generate migrate migrate:status notify sync fleet webhook mcp skills help completions --version --help)
-  per_stack_cmds=(update release deploy rebuild ship stop diff lock health logs logs:download logs:rotate backup drift migrate restore db:pull db:push db:schema shell exec remote:init provision ssh:keygen ci:init cert:renew cert:status init-secrets secrets status volumes prune local prod staging dev debug keys validate rollback domain --help)
+  per_stack_cmds=(update release deploy rebuild ship stop diff lock health logs logs:download logs:rotate backup drift migrate restore db:pull db:push db:schema shell exec remote:init provision ssh:keygen ci:init cert:renew cert:status init-secrets secrets status volumes prune local prod staging dev debug keys validate rollback history domain --help)
   profiles=(messaging ui full)
 
   local -a words_arr

--- a/lib/cmd_deploy.sh
+++ b/lib/cmd_deploy.sh
@@ -359,14 +359,25 @@ cmd_deploy() {
   _deploy_volguard "$stack" "$env_file" "$confirm_data_move" || return 1
   diff_warn_env_divergence "$stack" "$env_file" "${CMD_STACK_DIR:-$CLI_ROOT/stacks/$stack}"
 
+  declare -F history_record >/dev/null || source "$LIB/history.sh"
+  local _deploy_stack_dir="${CMD_STACK_DIR:-$CLI_ROOT/stacks/$stack}"
+  local _deploy_rc=0
+
   case "$deploy_mode" in
     blue-green)
-      bg_deploy_stack "$stack" "$env_file" "$services"
+      bg_deploy_stack "$stack" "$env_file" "$services" || _deploy_rc=$?
       ;;
     standard|*)
-      deploy_stack "$stack" "$env_file" "$services"
+      deploy_stack "$stack" "$env_file" "$services" || _deploy_rc=$?
       ;;
   esac
+
+  if [ "$_deploy_rc" -eq 0 ]; then
+    history_record "$_deploy_stack_dir" "deploy" "success" "env=${env_name:-}" "mode=$deploy_mode"
+  else
+    history_record "$_deploy_stack_dir" "deploy" "failed" "env=${env_name:-}" "mode=$deploy_mode"
+  fi
+  return "$_deploy_rc"
 }
 
 # cmd_health (no args — reads CMD_*)

--- a/lib/cmd_deploy.sh
+++ b/lib/cmd_deploy.sh
@@ -242,7 +242,7 @@ _usage_rebuild() {
   echo ""
 }
 
-# cmd_release [--strict] [--confirm-data-move] [--no-rollback] (reads CMD_*)
+# cmd_release [--strict] [--confirm-data-move] [--no-rollback] [--backup-first] (reads CMD_*)
 cmd_release() {
   local stack="$CMD_STACK"
   local env_file="$CMD_ENV_FILE"
@@ -251,12 +251,14 @@ cmd_release() {
   # Parse release-specific flags
   local confirm_data_move=false
   local auto_rollback=true
+  local backup_first=false
   local args=("${CMD_ARGS[@]+"${CMD_ARGS[@]}"}")
   for arg in "${args[@]+"${args[@]}"}"; do
     case "$arg" in
       --strict) export MIGRATION_FAILURE_MODE="halt" ;;
       --confirm-data-move) confirm_data_move=true ;;
       --no-rollback) auto_rollback=false ;;
+      --backup-first) backup_first=true ;;
     esac
   done
 
@@ -266,7 +268,7 @@ cmd_release() {
   _deploy_volguard "$stack" "$env_file" "$confirm_data_move" || return 1
   diff_warn_env_divergence "$stack" "$env_file" "${CMD_STACK_DIR:-$CLI_ROOT/stacks/$stack}"
 
-  vps_release "$stack" "$env_file" "$services" "$auto_rollback"
+  vps_release "$stack" "$env_file" "$services" "$auto_rollback" "$backup_first"
 }
 
 # cmd_deploy [--pull-only] [--skip-validation] [positional...] (reads CMD_*)

--- a/lib/cmd_fleet.sh
+++ b/lib/cmd_fleet.sh
@@ -14,11 +14,13 @@ _usage_fleet() {
   echo "Usage: strut fleet <command> [options]"
   echo ""
   echo "Commands:"
-  echo "  status [--json]    Show git sync state across all topology hosts"
+  echo "  status [--json]              Show git sync state across all topology hosts"
+  echo "  history [--json] [--limit N] Aggregate deploy/release/rollback history across all hosts"
   echo ""
   echo "Examples:"
   echo "  strut fleet status"
   echo "  strut fleet status --json"
+  echo "  strut fleet history --limit 20"
   echo ""
 }
 
@@ -27,7 +29,8 @@ cmd_fleet() {
   shift || true
 
   case "$subcmd" in
-    status) _fleet_status "$@" ;;
+    status)  _fleet_status "$@" ;;
+    history) _fleet_history "$@" ;;
     ""|help) _usage_fleet ;;
     *) _usage_fleet; fail "Unknown fleet subcommand: $subcmd" ;;
   esac
@@ -133,5 +136,112 @@ _fleet_status() {
     echo "{\"hosts\":[$joined],\"branch\":\"$branch\"}"
   else
     echo ""
+  fi
+}
+
+# _fleet_history [--json] [--limit N]
+#
+# Iterates every [stacks] mapping in topology, SSHes into each stack's host,
+# and cats its .deploy-history.jsonl. Aggregates everything, sorts by
+# timestamp descending (via jq when available — otherwise best-effort file
+# order), and prints the most recent N entries across the whole fleet.
+_fleet_history() {
+  local json_flag=false
+  local limit=20
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --json)  json_flag=true; shift ;;
+      --limit) limit="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+
+  topology_load
+
+  local stacks
+  stacks=$(topology_list_stacks)
+
+  if [ -z "$stacks" ]; then
+    if $json_flag; then
+      echo '{"entries":[],"error":"No stacks mapped in [stacks] section of strut.conf"}'
+    else
+      warn "No stacks mapped in [stacks] section of strut.conf"
+    fi
+    return 0
+  fi
+
+  local raw_entries=""
+  local stack host_alias host_spec deploy_dir ssh_opts entry_lines
+
+  while IFS= read -r stack; do
+    [ -n "$stack" ] || continue
+    host_alias="${_TOPO_STACK_HOST[$stack]:-}"
+    [ -n "$host_alias" ] || continue
+
+    host_spec="${_TOPO_HOSTS[$host_alias]:-}"
+    [ -n "$host_spec" ] || continue
+    parse_host_spec "$host_spec" || continue
+
+    deploy_dir="${CONN_DEPLOY_DIR:-/home/${CONN_USER}/strut}"
+    ssh_opts=$(build_ssh_opts -p "${CONN_PORT:-22}" -k "${CONN_KEY:-}" --batch)
+
+    # shellcheck disable=SC2029
+    entry_lines=$(ssh $ssh_opts "$CONN_USER@$CONN_HOST" "tail -n $limit '$deploy_dir/stacks/$stack/.deploy-history.jsonl' 2>/dev/null" 2>/dev/null) || continue
+    [ -n "$entry_lines" ] || continue
+
+    # Tag each entry with the host alias it came from — history_record
+    # itself doesn't know its topology alias, only the aggregator does.
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      if command -v jq &>/dev/null; then
+        line=$(echo "$line" | jq -c --arg host "$host_alias" '. + {host: $host}' 2>/dev/null) || continue
+      fi
+      raw_entries="${raw_entries}${line}"$'\n'
+    done <<< "$entry_lines"
+  done <<< "$stacks"
+
+  if [ -z "$raw_entries" ]; then
+    if $json_flag; then
+      echo '{"entries":[]}'
+    else
+      echo "No history recorded across the fleet yet."
+    fi
+    return 0
+  fi
+
+  local sorted_entries
+  if command -v jq &>/dev/null; then
+    sorted_entries=$(echo "$raw_entries" | jq -c -s 'sort_by(.timestamp) | reverse | .[]' 2>/dev/null | head -n "$limit")
+  else
+    sorted_entries=$(echo "$raw_entries" | sed '1!G;h;$!d' | head -n "$limit")
+  fi
+
+  if $json_flag; then
+    printf '['
+    local first=true line
+    while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      if [ "$first" = "true" ]; then first=false; else printf ','; fi
+      printf '%s' "$line"
+    done <<< "$sorted_entries"
+    printf ']\n'
+    return 0
+  fi
+
+  if command -v jq &>/dev/null; then
+    printf "  %-21s %-10s %-9s %-9s %-8s %s\n" "TIMESTAMP" "HOST" "ACTION" "OUTCOME" "USER" "ENV"
+    local line ts host action outcome user env
+    while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      ts=$(echo "$line" | jq -r '.timestamp // "?"')
+      host=$(echo "$line" | jq -r '.host // "?"')
+      action=$(echo "$line" | jq -r '.action // "?"')
+      outcome=$(echo "$line" | jq -r '.outcome // "?"')
+      user=$(echo "$line" | jq -r '.user // "?"')
+      env=$(echo "$line" | jq -r '.env // "-"')
+      printf "  %-21s %-10s %-9s %-9s %-8s %s\n" "$ts" "$host" "$action" "$outcome" "$user" "$env"
+    done <<< "$sorted_entries"
+  else
+    echo "$sorted_entries"
   fi
 }

--- a/lib/cmd_history.sh
+++ b/lib/cmd_history.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# ==================================================
+# cmd_history.sh — `strut <stack> history` command handler
+# ==================================================
+
+set -euo pipefail
+
+_usage_history() {
+  echo ""
+  echo "Usage: strut <stack> history [--env <name>] [--limit N] [--json]"
+  echo ""
+  echo "Show recent deploy/release/rollback history for a stack. Entries are"
+  echo "recorded automatically on release, deploy, and rollback."
+  echo ""
+  echo "Flags:"
+  echo "  --env <name>   Environment (used to resolve VPS dispatch)"
+  echo "  --limit N      Number of entries to show (default: 10)"
+  echo "  --json         Output as a JSON array"
+  echo ""
+  echo "Examples:"
+  echo "  strut my-stack history --env prod"
+  echo "  strut my-stack history --env prod --json --limit 20"
+  echo ""
+}
+
+# cmd_history [--limit N] [--json] (reads CMD_*)
+cmd_history() {
+  local stack="$CMD_STACK"
+  local stack_dir="$CMD_STACK_DIR"
+  local env_file="$CMD_ENV_FILE"
+  local env_name="$CMD_ENV_NAME"
+
+  local limit=10
+  local json_mode=false
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --limit) limit="$2"; shift 2 ;;
+      --json)  json_mode=true; shift ;;
+      --help|-h) _usage_history; return 0 ;;
+      *) shift ;;
+    esac
+  done
+
+  # Prefer remote execution for VPS-mapped stacks — history lives with the
+  # deploy dir wherever release/deploy/rollback actually ran, same
+  # dispatch pattern as `strut <stack> rollback`.
+  [ -f "$env_file" ] && validate_env_file "$env_file" 2>/dev/null
+  if should_dispatch_remote; then
+    local remote_args="history --limit $limit"
+    [ "$json_mode" = "true" ] && remote_args="$remote_args --json"
+    run_remote_strut "$stack" "$env_name" "$remote_args"
+    return $?
+  fi
+
+  declare -F history_list >/dev/null || source "$LIB/history.sh"
+
+  local args=(--limit "$limit")
+  [ "$json_mode" = "true" ] && args+=(--json)
+  history_list "$stack_dir" "${args[@]}"
+}

--- a/lib/cmd_rollback.sh
+++ b/lib/cmd_rollback.sh
@@ -213,6 +213,8 @@ cmd_rollback() {
 
   rollback_restore_snapshot "$stack" "$compose_cmd" "$rb_snapshot_file"
 
+  declare -F history_record >/dev/null || source "$LIB/history.sh"
+
   # Post-restore health gate — without this, a rollback that restores a
   # broken image (or fails to restart cleanly) still prints "Rollback
   # complete" and the operator has no signal that they need to intervene.
@@ -222,7 +224,9 @@ cmd_rollback() {
   health_check_containers "$compose_cmd" "$compose_file" || true
   if [ "$HEALTH_FAILED" -gt 0 ]; then
     warn "Rollback restored the snapshot images, but $HEALTH_FAILED container(s) are unhealthy — investigate before trusting this rollback"
+    history_record "$stack_dir" "rollback" "failed" "env=$env_name" "snapshot=$(basename "$rb_snapshot_file" .json)"
     return 1
   fi
   ok "Post-restore health check passed"
+  history_record "$stack_dir" "rollback" "success" "env=$env_name" "snapshot=$(basename "$rb_snapshot_file" .json)"
 }

--- a/lib/deploy.sh
+++ b/lib/deploy.sh
@@ -434,6 +434,9 @@ vps_release() {
   local ssh_opts
   ssh_opts=$(build_ssh_opts -p "$vps_port" -k "$vps_ssh_key" --batch)
 
+  local _release_start_epoch
+  _release_start_epoch=$(date +%s 2>/dev/null || echo 0)
+
   print_banner "VPS Release Deploy"
   log "Target: $vps_user@$vps_host"
   log "Stack: $stack | Env: $env_name | Services: ${services_profile:-core}"
@@ -518,7 +521,6 @@ vps_release() {
     cd '$deploy_dir'
     ./strut $stack health --env $env_name $profile_flag
   " || health_ok=false
-
   if [ "$health_ok" = "false" ]; then
     if [ "$auto_rollback" = "true" ]; then
       warn "Health check failed — rolling back to the previous release..."
@@ -534,6 +536,25 @@ vps_release() {
     else
       warn "Health check failed (auto-rollback disabled with --no-rollback)"
     fi
+  fi
+
+  # Record release history on the remote host — same disk-durability
+  # reasoning as every other release step: it lives with the deploy dir,
+  # so `strut <stack> history` (remote-dispatched) finds it after reboots.
+  # Recorded before the fail() below so a failed release still gets an
+  # outcome=failed entry instead of history recording being skipped by exit.
+  local release_outcome="success"
+  [ "$health_ok" = "false" ] && release_outcome="failed"
+  local _release_end_epoch
+  _release_end_epoch=$(date +%s 2>/dev/null || echo "$_release_start_epoch")
+  local release_duration=$(( _release_end_epoch - _release_start_epoch ))
+  # shellcheck disable=SC2029
+  ssh $ssh_opts "$vps_user@$vps_host" "
+    cd '$deploy_dir'
+    source lib/utils.sh 2>/dev/null && source lib/history.sh 2>/dev/null && history_record 'stacks/$stack' release '$release_outcome' env=$env_name duration_s:=$release_duration
+  " >/dev/null 2>&1 || true
+
+  if [ "$health_ok" = "false" ]; then
     fail "Release failed health checks after deploy — check logs with: strut $stack logs --env $env_name"
   fi
 

--- a/lib/deploy.sh
+++ b/lib/deploy.sh
@@ -411,6 +411,7 @@ vps_release() {
   local env_file="$2"
   local services_profile="${3:-}"
   local auto_rollback="${4:-true}"
+  local backup_first="${5:-false}"
 
   validate_env_file "$env_file" VPS_HOST
 
@@ -447,6 +448,9 @@ vps_release() {
     local branch="${DEFAULT_BRANCH:-main}"
     echo ""
     echo -e "${YELLOW}[DRY-RUN] Execution plan for release:${NC}"
+    if [ "$backup_first" = "true" ]; then
+      run_cmd "Back up databases before release (--backup-first)" ssh "$vps_user@$vps_host" "cd $deploy_dir && ./strut $stack backup all --env $env_name"
+    fi
     run_cmd "Update strut repo on VPS" ssh "$vps_user@$vps_host" "cd $deploy_dir && git fetch && git reset --hard origin/$branch"
     run_cmd "Run Postgres migrations" ssh "$vps_user@$vps_host" "cd $deploy_dir && ./strut $stack migrate postgres --env $env_name"
     run_cmd "Run Neo4j migrations" ssh "$vps_user@$vps_host" "cd $deploy_dir && ./strut $stack migrate neo4j --env $env_name"
@@ -459,6 +463,19 @@ vps_release() {
     echo ""
     echo -e "${YELLOW}[DRY-RUN] No changes made.${NC}"
     return 0
+  fi
+
+  # Pre-deploy backup (opt-in — Neo4j backups require ~10-30s of downtime,
+  # so this is never silently default-on). Runs before anything else changes
+  # so the snapshot reflects truly pre-release state, not post-migration.
+  if [ "$backup_first" = "true" ]; then
+    log "Backing up databases before release (--backup-first)..."
+    # shellcheck disable=SC2029
+    ssh $ssh_opts "$vps_user@$vps_host" "
+      cd '$deploy_dir'
+      ./strut $stack backup all --env $env_name
+    " || fail "Pre-deploy backup failed — aborting release. Check backup config/logs, or omit --backup-first to skip."
+    ok "Pre-deploy backup complete"
   fi
 
   # Step 1: Update repo

--- a/lib/history.sh
+++ b/lib/history.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# ==================================================
+# lib/history.sh — Deploy/rollback audit trail
+# ==================================================
+# Append-only JSONL history per stack: <stack_dir>/.deploy-history.jsonl
+#
+# Recording always happens on whichever machine actually performs the
+# action. For VPS-mapped stacks, release/deploy/rollback already dispatch
+# their real work onto the remote host (should_dispatch_remote /
+# run_remote_strut, or vps_release's own SSH steps), so a plain local file
+# write there naturally lands the history file inside the deploy dir on
+# that host — it survives VPS reboots as ordinary disk state, and reading
+# it back (cmd_history.sh) uses the same remote-dispatch pattern.
+#
+# Functions:
+#   history_record  — append one entry (best-effort, never fails the caller)
+#   history_list     — read + format entries for `strut <stack> history`
+
+set -euo pipefail
+
+# history_record <stack_dir> <action> <outcome> [key=value ...] [key:=rawvalue ...]
+#
+# Always sets: timestamp, stack, action, user, outcome.
+# Extra fields: `key=value` is written as an escaped JSON string;
+# `key:=value` is written raw/unquoted (caller-guaranteed valid JSON —
+# for numbers and arrays, e.g. duration_s:=45 or flags:='["--force-clean"]').
+#
+# Best-effort by design: a broken history write must never fail a deploy.
+history_record() {
+  local stack_dir="$1" action="$2" outcome="$3"
+  shift 3
+
+  local hist_file="$stack_dir/.deploy-history.jsonl"
+  mkdir -p "$stack_dir" 2>/dev/null || return 0
+
+  local ts
+  ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null) || return 0
+  local user="${USER:-$(whoami 2>/dev/null || echo unknown)}"
+  local stack
+  stack=$(basename "$stack_dir")
+
+  local line
+  line="{\"timestamp\":\"$(json_escape "$ts")\",\"stack\":\"$(json_escape "$stack")\",\"action\":\"$(json_escape "$action")\",\"user\":\"$(json_escape "$user")\",\"outcome\":\"$(json_escape "$outcome")\""
+
+  local kv key val
+  for kv in "$@"; do
+    if [[ "$kv" == *":="* ]]; then
+      key="${kv%%:=*}"
+      val="${kv#*:=}"
+      line="${line},\"$(json_escape "$key")\":${val}"
+    else
+      key="${kv%%=*}"
+      val="${kv#*=}"
+      line="${line},\"$(json_escape "$key")\":\"$(json_escape "$val")\""
+    fi
+  done
+  line="${line}}"
+
+  echo "$line" >> "$hist_file" 2>/dev/null || true
+}
+
+# history_list <stack_dir> [--limit N] [--json]
+#
+# Prints recent history entries, most recent first. Text mode renders a
+# compact table (via jq if available, else raw JSONL); --json emits a
+# JSON array.
+history_list() {
+  local stack_dir="$1"; shift
+  local limit=10
+  local json_mode=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --limit) limit="$2"; shift 2 ;;
+      --json)  json_mode=true; shift ;;
+      *) shift ;;
+    esac
+  done
+
+  local hist_file="$stack_dir/.deploy-history.jsonl"
+
+  if [ ! -f "$hist_file" ]; then
+    if [ "$json_mode" = "true" ]; then
+      echo "[]"
+    else
+      echo "No history recorded yet."
+    fi
+    return 0
+  fi
+
+  # Reverse to most-recent-first with a portable sed idiom (tac/tail -r are
+  # GNU/BSD-specific respectively — this runs on both macOS and Linux VPS
+  # hosts via remote dispatch).
+  local entries
+  entries=$(tail -n "$limit" "$hist_file" | sed '1!G;h;$!d')
+
+  if [ "$json_mode" = "true" ]; then
+    printf '['
+    local first=true line
+    while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      if [ "$first" = "true" ]; then first=false; else printf ','; fi
+      printf '%s' "$line"
+    done <<< "$entries"
+    printf ']\n'
+    return 0
+  fi
+
+  if command -v jq &>/dev/null; then
+    printf '%-21s %-9s %-9s %-10s %s\n' "TIMESTAMP" "ACTION" "OUTCOME" "USER" "ENV"
+    local line ts action outcome user env
+    while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      ts=$(echo "$line" | jq -r '.timestamp // "?"')
+      action=$(echo "$line" | jq -r '.action // "?"')
+      outcome=$(echo "$line" | jq -r '.outcome // "?"')
+      user=$(echo "$line" | jq -r '.user // "?"')
+      env=$(echo "$line" | jq -r '.env // "-"')
+      printf '%-21s %-9s %-9s %-10s %s\n' "$ts" "$action" "$outcome" "$user" "$env"
+    done <<< "$entries"
+  else
+    echo "$entries"
+  fi
+}

--- a/strut
+++ b/strut
@@ -264,7 +264,7 @@ usage() {
   echo ""
   echo "Commands:"
   echo "  update   [--env <name>]                                        Pull latest strut on VPS"
-  echo "  release  [--env <name>] [--services <profile>] [--strict] [--no-rollback]  Full VPS release (update + migrate + deploy)"
+  echo "  release  [--env <name>] [--services <profile>] [--strict] [--no-rollback] [--backup-first]  Full VPS release (update + migrate + deploy)"
   echo "  deploy   [--env <name>] [--services <profile>] [--pull-only]  Deploy stack"
   echo "  rebuild  [--env <name>] [--no-cache] [--pull]                  Build images + deploy"
   echo "  ship     [--env <name>] [-m <msg>] [--no-commit]               Commit, push, rebuild on remote"

--- a/strut
+++ b/strut
@@ -174,6 +174,8 @@ source "$LIB/cmd_stop.sh"
 source "$LIB/cmd_skills.sh"
 source "$LIB/cmd_validate.sh"
 source "$LIB/cmd_rollback.sh"
+source "$LIB/history.sh"
+source "$LIB/cmd_history.sh"
 source "$LIB/diff.sh"
 source "$LIB/cmd_diff.sh"
 source "$LIB/lock.sh"
@@ -310,7 +312,7 @@ usage() {
   echo "  list plugins [--json]                                          List discovered project plugins"
   echo "  status-all [--env <name>] [--json]                             Dashboard across all stacks"
   echo "  sync       [<host>|--all] [--env <name>] [--dry-run]          Bring host checkout in sync with origin"
-  echo "  fleet      status [--json]                                    Show git sync state across all hosts"
+  echo "  fleet      status|history [--json] [--limit N]                  Git sync state or deploy history across all hosts"
   echo "  webhook    poll|serve|install                                  Push-to-deploy automation"
   echo "  mcp        serve|install                                       MCP server for AI agents"
   echo "  rollback   [--env <name>]                                      Rollback to previous deploy snapshot"
@@ -941,6 +943,7 @@ case "$COMMAND" in
   keys)                cmd_keys "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   validate)            cmd_validate ;;
   rollback)            cmd_rollback "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
+  history)             cmd_history "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   domain)              cmd_domain "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   diff)                cmd_diff "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   lock)                cmd_lock "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;

--- a/tests/test_cmd_deploy.bats
+++ b/tests/test_cmd_deploy.bats
@@ -50,10 +50,37 @@ EOF
   export CMD_JSON=""
   export DRY_RUN=false
   export CLI_ROOT="$CLI_ROOT"
+  export LIB="$CLI_ROOT/lib"
 }
 
 teardown() {
   common_teardown
+}
+
+@test "cmd_deploy: records a success history entry after deploy_stack succeeds" {
+  run cmd_deploy
+  [ "$status" -eq 0 ]
+
+  local hist_file="$TEST_TMP/stacks/test-stack/.deploy-history.jsonl"
+  [ -f "$hist_file" ]
+  run cat "$hist_file"
+  [[ "$output" == *'"action":"deploy"'* ]]
+  [[ "$output" == *'"outcome":"success"'* ]]
+  [[ "$output" == *'"mode":"standard"'* ]]
+}
+
+@test "cmd_deploy: records a failed history entry when deploy_stack fails, and propagates the exit code" {
+  deploy_stack() { echo "deploy_stack $*"; return 1; }
+  export -f deploy_stack
+
+  run cmd_deploy
+  [ "$status" -ne 0 ]
+
+  local hist_file="$TEST_TMP/stacks/test-stack/.deploy-history.jsonl"
+  [ -f "$hist_file" ]
+  run cat "$hist_file"
+  [[ "$output" == *'"action":"deploy"'* ]]
+  [[ "$output" == *'"outcome":"failed"'* ]]
 }
 
 @test "_usage_deploy: prints usage with flags" {

--- a/tests/test_cmd_deploy.bats
+++ b/tests/test_cmd_deploy.bats
@@ -172,6 +172,19 @@ EOF
   [[ "$output" == *" false"* ]]
 }
 
+@test "cmd_release: backup_first defaults to false" {
+  run cmd_release
+  [ "$status" -eq 0 ]
+  [[ "$output" == *" true false"* ]]
+}
+
+@test "cmd_release: --backup-first passes backup_first=true to vps_release" {
+  export CMD_ARGS=(--backup-first)
+  run cmd_release
+  [ "$status" -eq 0 ]
+  [[ "$output" == *" true true"* ]]
+}
+
 @test "cmd_health: dispatches to health_run_all" {
   run cmd_health
   [ "$status" -eq 0 ]

--- a/tests/test_cmd_fleet.bats
+++ b/tests/test_cmd_fleet.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_cmd_fleet.bats — Tests for `strut fleet history`
+# ==================================================
+# Run:  bats tests/test_cmd_fleet.bats
+# Covers strut#333's fleet-wide aggregation: `strut fleet history`.
+# `strut fleet status` (_fleet_status) has no pre-existing coverage either —
+# out of scope here, this file is scoped to the new history subcommand.
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_utils
+  source "$CLI_ROOT/lib/topology.sh"
+  source "$CLI_ROOT/lib/connection.sh"
+  source "$CLI_ROOT/lib/fleet.sh"
+  source "$CLI_ROOT/lib/cmd_fleet.sh"
+
+  _TOPO_LOADED=true
+  declare -gA _TOPO_HOSTS=()
+  declare -gA _TOPO_STACK_HOST=()
+
+  # Stub ssh — the aggregator cats a remote .deploy-history.jsonl file per
+  # stack; tests configure per-host responses via SSH_HISTORY_<alias>.
+  ssh() {
+    local remote_cmd="${*: -1}"
+    local host_arg="${*}"
+    for alias in "${!_TOPO_HOSTS[@]}"; do
+      local spec="${_TOPO_HOSTS[$alias]}"
+      local host="${spec#*@}"; host="${host%%:*}"; host="${host%% *}"
+      if [[ "$host_arg" == *"$host"* ]]; then
+        local var="SSH_HISTORY_${alias//-/_}"
+        printf '%s\n' "${!var:-}"
+        return 0
+      fi
+    done
+    return 1
+  }
+  export -f ssh
+}
+
+teardown() { common_teardown; }
+
+@test "cmd_fleet history: reports when no stacks are mapped in topology" {
+  run cmd_fleet history
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No stacks mapped"* ]]
+}
+
+@test "cmd_fleet history: aggregates entries from a single host/stack" {
+  _TOPO_HOSTS[compass]="gfargo@compass.local:22 ~/.ssh/id_rsa"
+  _TOPO_STACK_HOST[myapp]="compass"
+
+  SSH_HISTORY_compass='{"timestamp":"2026-07-08T01:00:00Z","stack":"myapp","action":"release","user":"ubuntu","outcome":"success","env":"prod"}'
+  export SSH_HISTORY_compass
+
+  run cmd_fleet history
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"compass"* ]]
+  [[ "$output" == *"release"* ]]
+  [[ "$output" == *"success"* ]]
+}
+
+@test "cmd_fleet history: aggregates across multiple hosts" {
+  _TOPO_HOSTS[compass]="gfargo@compass.local:22 ~/.ssh/id_rsa"
+  _TOPO_HOSTS[harbor]="ubuntu@harbor.local:22 ~/.ssh/id_rsa"
+  _TOPO_STACK_HOST[app-a]="compass"
+  _TOPO_STACK_HOST[app-b]="harbor"
+
+  export SSH_HISTORY_compass='{"timestamp":"2026-07-08T01:00:00Z","stack":"app-a","action":"release","user":"ubuntu","outcome":"success"}'
+  export SSH_HISTORY_harbor='{"timestamp":"2026-07-08T02:00:00Z","stack":"app-b","action":"rollback","user":"ubuntu","outcome":"success"}'
+
+  run cmd_fleet history
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"compass"* ]]
+  [[ "$output" == *"harbor"* ]]
+  [[ "$output" == *"release"* ]]
+  [[ "$output" == *"rollback"* ]]
+}
+
+@test "cmd_fleet history: skips unreachable hosts without failing the whole command" {
+  _TOPO_HOSTS[compass]="gfargo@compass.local:22 ~/.ssh/id_rsa"
+  _TOPO_HOSTS[watch]="ubuntu@watch.local:22 ~/.ssh/id_rsa"
+  _TOPO_STACK_HOST[app-a]="compass"
+  _TOPO_STACK_HOST[app-b]="watch"
+
+  export SSH_HISTORY_compass='{"timestamp":"2026-07-08T01:00:00Z","stack":"app-a","action":"release","user":"ubuntu","outcome":"success"}'
+  unset SSH_HISTORY_watch
+
+  run cmd_fleet history
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"compass"* ]]
+}
+
+@test "cmd_fleet history --json: emits a JSON array" {
+  _TOPO_HOSTS[compass]="gfargo@compass.local:22 ~/.ssh/id_rsa"
+  _TOPO_STACK_HOST[myapp]="compass"
+
+  export SSH_HISTORY_compass='{"timestamp":"2026-07-08T01:00:00Z","stack":"myapp","action":"release","user":"ubuntu","outcome":"success"}'
+
+  run cmd_fleet history --json
+  [ "$status" -eq 0 ]
+  [[ "$output" == "["*"]" ]]
+  if command -v jq &>/dev/null; then
+    echo "$output" > "$TEST_TMP/out.json"
+    run jq -e '. | length >= 1' "$TEST_TMP/out.json"
+    [ "$status" -eq 0 ]
+  fi
+}
+
+@test "cmd_fleet history --json: empty result is a valid empty array shape" {
+  run cmd_fleet history --json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"entries":[]'* ]]
+}

--- a/tests/test_cmd_history.bats
+++ b/tests/test_cmd_history.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_cmd_history.bats — Tests for the history command
+# ==================================================
+# Run:  bats tests/test_cmd_history.bats
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_utils
+  source "$CLI_ROOT/lib/history.sh"
+  source "$CLI_ROOT/lib/cmd_history.sh"
+
+  export LIB="$CLI_ROOT/lib"
+
+  mkdir -p "$TEST_TMP/stacks/test-stack"
+  export CLI_ROOT="$TEST_TMP"
+  export PROJECT_ROOT="$TEST_TMP"
+}
+
+teardown() { common_teardown; }
+
+_set_history_ctx() {
+  local env_file="$1"
+  export CMD_STACK="test-stack"
+  export CMD_STACK_DIR="$TEST_TMP/stacks/test-stack"
+  export CMD_ENV_FILE="$env_file"
+  export CMD_ENV_NAME="test"
+  export DRY_RUN=false
+}
+
+@test "cmd_history: dispatches remotely for a VPS-mapped stack" {
+  cat > "$TEST_TMP/.test.env" <<'EOF'
+VPS_HOST=vps.example.internal
+EOF
+
+  should_dispatch_remote() { return 0; }
+  run_remote_strut() { echo "run_remote_strut $*"; }
+  export -f should_dispatch_remote run_remote_strut
+
+  _set_history_ctx "$TEST_TMP/.test.env"
+
+  run cmd_history
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"run_remote_strut test-stack test history --limit 10"* ]]
+}
+
+@test "cmd_history: --json flag is forwarded to the remote dispatch" {
+  cat > "$TEST_TMP/.test.env" <<'EOF'
+VPS_HOST=vps.example.internal
+EOF
+
+  should_dispatch_remote() { return 0; }
+  run_remote_strut() { echo "run_remote_strut $*"; }
+  export -f should_dispatch_remote run_remote_strut
+
+  _set_history_ctx "$TEST_TMP/.test.env"
+
+  run cmd_history --json --limit 5
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"history --limit 5 --json"* ]]
+}
+
+@test "cmd_history: reads local history for a non-VPS stack" {
+  should_dispatch_remote() { return 1; }
+  export -f should_dispatch_remote
+
+  history_record "$TEST_TMP/stacks/test-stack" "deploy" "success" "env=test"
+
+  _set_history_ctx ""
+
+  run cmd_history
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"deploy"* ]]
+  [[ "$output" == *"success"* ]]
+}
+
+@test "cmd_history: reports no history for a stack that's never deployed" {
+  should_dispatch_remote() { return 1; }
+  export -f should_dispatch_remote
+
+  _set_history_ctx ""
+
+  run cmd_history
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No history recorded yet"* ]]
+}
+
+@test "cmd_history: --json emits parseable JSON for the local path" {
+  should_dispatch_remote() { return 1; }
+  export -f should_dispatch_remote
+
+  history_record "$TEST_TMP/stacks/test-stack" "release" "success" "env=test"
+
+  _set_history_ctx ""
+
+  run cmd_history --json
+  [ "$status" -eq 0 ]
+  if command -v jq &>/dev/null; then
+    echo "$output" > "$TEST_TMP/out.json"
+    run jq -e 'length == 1' "$TEST_TMP/out.json"
+    [ "$status" -eq 0 ]
+  fi
+}

--- a/tests/test_cmd_rollback.bats
+++ b/tests/test_cmd_rollback.bats
@@ -132,3 +132,24 @@ EOF
   [ "$status" -ne 0 ]
   [[ "$output" == *"No rollback snapshots found for stack: test-stack, env: test"* ]]
 }
+
+@test "cmd_rollback: records a history entry on a successful restore" {
+  echo '{"timestamp":"2026-07-05T00:00:00Z","service_count":1,"services":{"web":{"image":"nginx:latest"}}}' > "$TEST_TMP/snapshot.json"
+
+  should_dispatch_remote() { return 1; }
+  rollback_get_latest_snapshot() { echo "$TEST_TMP/snapshot.json"; }
+  resolve_compose_cmd() { echo "echo COMPOSE"; }
+  rollback_restore_snapshot() { echo "rollback_restore_snapshot $*"; }
+  export -f should_dispatch_remote rollback_get_latest_snapshot resolve_compose_cmd rollback_restore_snapshot
+
+  _set_rollback_ctx ""
+
+  run cmd_rollback
+  [ "$status" -eq 0 ]
+
+  local hist_file="$TEST_TMP/stacks/test-stack/.deploy-history.jsonl"
+  [ -f "$hist_file" ]
+  run cat "$hist_file"
+  [[ "$output" == *'"action":"rollback"'* ]]
+  [[ "$output" == *'"outcome":"success"'* ]]
+}

--- a/tests/test_history.bats
+++ b/tests/test_history.bats
@@ -1,0 +1,127 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_history.bats — Tests for lib/history.sh
+# ==================================================
+# Run:  bats tests/test_history.bats
+# Covers strut#333: deploy/release/rollback audit trail.
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_utils
+  source "$CLI_ROOT/lib/history.sh"
+
+  export STACK_DIR="$TEST_TMP/stacks/my-app"
+  mkdir -p "$STACK_DIR"
+}
+
+teardown() { common_teardown; }
+
+# ── history_record ────────────────────────────────────────────────────────────
+
+@test "history_record: creates the history file on first write" {
+  history_record "$STACK_DIR" "deploy" "success"
+  [ -f "$STACK_DIR/.deploy-history.jsonl" ]
+}
+
+@test "history_record: appends one JSON line per call" {
+  history_record "$STACK_DIR" "deploy" "success"
+  history_record "$STACK_DIR" "rollback" "success"
+  [ "$(wc -l < "$STACK_DIR/.deploy-history.jsonl" | tr -d ' ')" = "2" ]
+}
+
+@test "history_record: writes valid JSON with the standard fields" {
+  history_record "$STACK_DIR" "release" "success"
+  run cat "$STACK_DIR/.deploy-history.jsonl"
+  [[ "$output" == *'"action":"release"'* ]]
+  [[ "$output" == *'"outcome":"success"'* ]]
+  [[ "$output" == *'"stack":"my-app"'* ]]
+  [[ "$output" == *'"timestamp":"'* ]]
+  [[ "$output" == *'"user":"'* ]]
+}
+
+@test "history_record: string extra fields (key=value) are JSON-escaped and quoted" {
+  history_record "$STACK_DIR" "release" "success" 'env=prod'
+  run cat "$STACK_DIR/.deploy-history.jsonl"
+  [[ "$output" == *'"env":"prod"'* ]]
+}
+
+@test "history_record: raw extra fields (key:=value) are not quoted" {
+  history_record "$STACK_DIR" "release" "success" 'duration_s:=45'
+  run cat "$STACK_DIR/.deploy-history.jsonl"
+  [[ "$output" == *'"duration_s":45'* ]]
+  [[ "$output" != *'"duration_s":"45"'* ]]
+}
+
+@test "history_record: escapes quotes and backslashes in string field values" {
+  history_record "$STACK_DIR" "release" "success" 'snapshot=weird"quote\path'
+  run cat "$STACK_DIR/.deploy-history.jsonl"
+  [[ "$output" == *'\"quote\\path'* ]]
+
+  # And the line is still valid JSON if jq is available.
+  if command -v jq &>/dev/null; then
+    run jq -e . "$STACK_DIR/.deploy-history.jsonl"
+    [ "$status" -eq 0 ]
+  fi
+}
+
+@test "history_record: is best-effort — never fails the caller even if the dir can't be created" {
+  run history_record "/nonexistent-root-dir-xyz/stacks/app" "deploy" "success"
+  [ "$status" -eq 0 ]
+}
+
+# ── history_list ───────────────────────────────────────────────────────────────
+
+@test "history_list: reports no history when file doesn't exist" {
+  run history_list "$STACK_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No history recorded yet"* ]]
+}
+
+@test "history_list --json: emits an empty array when file doesn't exist" {
+  run history_list "$STACK_DIR" --json
+  [ "$status" -eq 0 ]
+  [ "$output" = "[]" ]
+}
+
+@test "history_list: shows entries most-recent-first" {
+  history_record "$STACK_DIR" "deploy" "success" "env=prod"
+  sleep 1
+  history_record "$STACK_DIR" "rollback" "success" "env=prod"
+
+  run history_list "$STACK_DIR"
+  [ "$status" -eq 0 ]
+  # rollback (recorded second) should appear before deploy in the output
+  local rollback_line deploy_line
+  rollback_line=$(echo "$output" | grep -n "rollback" | head -1 | cut -d: -f1)
+  deploy_line=$(echo "$output" | grep -n "deploy" | grep -v ACTION | head -1 | cut -d: -f1)
+  [ "$rollback_line" -lt "$deploy_line" ]
+}
+
+@test "history_list --json: emits a valid JSON array of all entries" {
+  history_record "$STACK_DIR" "deploy" "success"
+  history_record "$STACK_DIR" "rollback" "failed"
+
+  run history_list "$STACK_DIR" --json
+  [ "$status" -eq 0 ]
+
+  if command -v jq &>/dev/null; then
+    echo "$output" > "$TEST_TMP/entries.json"
+    run jq -e 'length == 2' "$TEST_TMP/entries.json"
+    [ "$status" -eq 0 ]
+  else
+    [[ "$output" == "["*"]" ]]
+  fi
+}
+
+@test "history_list: respects --limit" {
+  history_record "$STACK_DIR" "deploy" "success"
+  history_record "$STACK_DIR" "deploy" "success"
+  history_record "$STACK_DIR" "deploy" "success"
+
+  run history_list "$STACK_DIR" --limit 1
+  [ "$status" -eq 0 ]
+  # header row + exactly one data row (only when jq is present)
+  if command -v jq &>/dev/null; then
+    [ "$(echo "$output" | wc -l | tr -d ' ')" = "2" ]
+  fi
+}

--- a/tests/test_pre_deploy.bats
+++ b/tests/test_pre_deploy.bats
@@ -96,6 +96,7 @@ EOF
 
 @test "--skip-validation: parsed correctly by cmd_deploy" {
   source "$CLI_ROOT/lib/cmd_deploy.sh"
+  export LIB="$CLI_ROOT/lib"
 
   export CMD_STACK="test-stack"
   export CMD_STACK_DIR="$TEST_TMP"

--- a/tests/test_release.bats
+++ b/tests/test_release.bats
@@ -239,3 +239,54 @@ teardown() {
   run cat "$SSH_CALL_LOG"
   [[ "$output" == *"history_record 'stacks/test-stack' release 'failed'"* ]]
 }
+
+# ── --backup-first ─────────────────────────────────────────────────────────────
+
+@test "vps_release: backup_first defaults to false — no backup call" {
+  run vps_release "test-stack" "$TEST_TMP/.test.env" ""
+  [ "$status" -eq 0 ]
+
+  run cat "$SSH_CALL_LOG"
+  [[ "$output" != *"backup all"* ]]
+}
+
+@test "vps_release: --backup-first (backup_first=true) backs up before updating the repo" {
+  run vps_release "test-stack" "$TEST_TMP/.test.env" "" "true" "true"
+  [ "$status" -eq 0 ]
+
+  local line1
+  line1=$(sed -n '1p' "$SSH_CALL_LOG")
+  [[ "$line1" == *"backup all --env test"* ]]
+
+  local line2
+  line2=$(sed -n '2p' "$SSH_CALL_LOG")
+  [[ "$line2" == *"vps_update_repo"* ]]
+}
+
+@test "vps_release: dry-run plan includes the backup step when --backup-first" {
+  export DRY_RUN=true
+
+  run vps_release "test-stack" "$TEST_TMP/.test.env" "" "true" "true"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Back up databases before release"* ]]
+}
+
+@test "vps_release: dry-run plan omits the backup step by default" {
+  export DRY_RUN=true
+
+  run vps_release "test-stack" "$TEST_TMP/.test.env" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Back up databases before release"* ]]
+}
+
+@test "vps_release: aborts the release when the pre-deploy backup fails" {
+  export SSH_FAIL_PATTERN="backup all"
+
+  run vps_release "test-stack" "$TEST_TMP/.test.env" "" "true" "true"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Pre-deploy backup failed"* ]]
+
+  # Nothing past the backup step should have run.
+  run cat "$SSH_CALL_LOG"
+  [[ "$output" != *"vps_update_repo"* ]]
+}

--- a/tests/test_release.bats
+++ b/tests/test_release.bats
@@ -232,7 +232,9 @@ teardown() {
   export SSH_FAIL_PATTERN="health --env"
 
   run vps_release "test-stack" "$TEST_TMP/.test.env" ""
-  [ "$status" -eq 0 ]
+  # Health failure is fatal (auto-rollback) — history must still be
+  # recorded before that exit, not skipped by it.
+  [ "$status" -ne 0 ]
 
   run cat "$SSH_CALL_LOG"
   [[ "$output" == *"history_record 'stacks/test-stack' release 'failed'"* ]]

--- a/tests/test_release.bats
+++ b/tests/test_release.bats
@@ -215,3 +215,25 @@ teardown() {
   run cat "$SSH_CALL_LOG"
   [[ "$output" != *"rollback --env"* ]]
 }
+
+# ── Release history recording ─────────────────────────────────────────────────
+
+@test "vps_release: records a release history entry with outcome=success on the remote host" {
+  run vps_release "test-stack" "$TEST_TMP/.test.env" ""
+  [ "$status" -eq 0 ]
+
+  run cat "$SSH_CALL_LOG"
+  [[ "$output" == *"history_record 'stacks/test-stack' release 'success'"* ]]
+  [[ "$output" == *"env=test"* ]]
+  [[ "$output" == *"duration_s:="* ]]
+}
+
+@test "vps_release: records outcome=failed when the final health check fails" {
+  export SSH_FAIL_PATTERN="health --env"
+
+  run vps_release "test-stack" "$TEST_TMP/.test.env" ""
+  [ "$status" -eq 0 ]
+
+  run cat "$SSH_CALL_LOG"
+  [[ "$output" == *"history_record 'stacks/test-stack' release 'failed'"* ]]
+}


### PR DESCRIPTION
Closes the remaining item of #186 (health-gated auto-rollback + on_health_fail were already done in #362)

## Problem

The auto-rollback added in #362 only restores container images (`rollback_save_snapshot` captures image references, not data). If a release's migration step makes an incompatible schema change, rolling back the image alone won't undo the schema change — old app code would run against the new schema. A pre-deploy DB snapshot closes that gap.

## Fix

New `--backup-first` flag on `release`:

```bash
strut my-stack release --env prod --backup-first
```

Runs `./strut $stack backup all --env $env_name` on the remote host as the very first step — before the repo update, before any migration. Reuses the existing backup subsystem entirely (`BACKUP_ENGINES` + `backup_engine_enabled` from `lib/backup/engines.sh`) — zero new backup logic, just wiring it into the release pipeline at the earliest possible point so the snapshot reflects genuinely pre-release state.

A backup failure aborts the release outright. If you explicitly asked for a safety net, it shouldn't fail silently and let the release proceed anyway.

## Why opt-in, not default-on

Considered making this default-on (matching #362's `--no-rollback` opt-out pattern), but `backup_neo4j` requires stopping the Neo4j container for ~10-30s to take a consistent dump (Community Edition has no online backup mechanism). Defaulting this on would silently inject unexpected downtime into every routine release for any Neo4j-backed stack — a much bigger behavior change than #362's rollback addition, which had no downtime side effect. Opt-in avoids that surprise while still making the capability one flag away.

## Test plan
- [x] `tests/test_release.bats` — 5 new tests: backup runs before repo update when `--backup-first`, no backup call by default, dry-run plan includes/omits the step correctly, backup failure aborts the release before any other step runs
- [x] `tests/test_cmd_deploy.bats` — 2 new tests: flag defaults to false, `--backup-first` propagates `backup_first=true` to `vps_release`
- [x] Full suite (`bats tests/`) — no regressions (1977/1979, the 2 failures are pre-existing, unrelated environment flakes)
- [x] `shellcheck -s bash strut lib/deploy.sh lib/cmd_deploy.sh` — clean
- [x] Verified `backup all`'s code path is fully non-interactive (no `confirm()` prompts) — safe to run unattended during a release