### PR TITLE
feat(release): add --backup-first for a pre-deploy database snapshot

### DIFF
--- a/lib/cmd_deploy.sh
+++ b/lib/cmd_deploy.sh
@@ -242,7 +242,7 @@ _usage_rebuild() {
   echo ""
 }
 
-# cmd_release [--strict] [--confirm-data-move] [--no-rollback] (reads CMD_*)
+# cmd_release [--strict] [--confirm-data-move] [--no-rollback] [--backup-first] (reads CMD_*)
 cmd_release() {
   local stack="$CMD_STACK"
   local env_file="$CMD_ENV_FILE"
@@ -251,12 +251,14 @@ cmd_release() {
   # Parse release-specific flags
   local confirm_data_move=false
   local auto_rollback=true
+  local backup_first=false
   local args=("${CMD_ARGS[@]+"${CMD_ARGS[@]}"}")
   for arg in "${args[@]+"${args[@]}"}"; do
     case "$arg" in
       --strict) export MIGRATION_FAILURE_MODE="halt" ;;
       --confirm-data-move) confirm_data_move=true ;;
       --no-rollback) auto_rollback=false ;;
+      --backup-first) backup_first=true ;;
     esac
   done
 
@@ -266,7 +268,7 @@ cmd_release() {
   _deploy_volguard "$stack" "$env_file" "$confirm_data_move" || return 1
   diff_warn_env_divergence "$stack" "$env_file" "${CMD_STACK_DIR:-$CLI_ROOT/stacks/$stack}"
 
-  vps_release "$stack" "$env_file" "$services" "$auto_rollback"
+  vps_release "$stack" "$env_file" "$services" "$auto_rollback" "$backup_first"
 }
 
 # cmd_deploy [--pull-only] [--skip-validation] [positional...] (reads CMD_*)

--- a/lib/deploy.sh
+++ b/lib/deploy.sh
@@ -411,6 +411,7 @@ vps_release() {
   local env_file="$2"
   local services_profile="${3:-}"
   local auto_rollback="${4:-true}"
+  local backup_first="${5:-false}"
 
   validate_env_file "$env_file" VPS_HOST
 
@@ -447,6 +448,9 @@ vps_release() {
     local branch="${DEFAULT_BRANCH:-main}"
     echo ""
     echo -e "${YELLOW}[DRY-RUN] Execution plan for release:${NC}"
+    if [ "$backup_first" = "true" ]; then
+      run_cmd "Back up databases before release (--backup-first)" ssh "$vps_user@$vps_host" "cd $deploy_dir && ./strut $stack backup all --env $env_name"
+    fi
     run_cmd "Update strut repo on VPS" ssh "$vps_user@$vps_host" "cd $deploy_dir && git fetch && git reset --hard origin/$branch"
     run_cmd "Run Postgres migrations" ssh "$vps_user@$vps_host" "cd $deploy_dir && ./strut $stack migrate postgres --env $env_name"
     run_cmd "Run Neo4j migrations" ssh "$vps_user@$vps_host" "cd $deploy_dir && ./strut $stack migrate neo4j --env $env_name"
@@ -459,6 +463,19 @@ vps_release() {
     echo ""
     echo -e "${YELLOW}[DRY-RUN] No changes made.${NC}"
     return 0
+  fi
+
+  # Pre-deploy backup (opt-in — Neo4j backups require ~10-30s of downtime,
+  # so this is never silently default-on). Runs before anything else changes
+  # so the snapshot reflects truly pre-release state, not post-migration.
+  if [ "$backup_first" = "true" ]; then
+    log "Backing up databases before release (--backup-first)..."
+    # shellcheck disable=SC2029
+    ssh $ssh_opts "$vps_user@$vps_host" "
+      cd '$deploy_dir'
+      ./strut $stack backup all --env $env_name
+    " || fail "Pre-deploy backup failed — aborting release. Check backup config/logs, or omit --backup-first to skip."
+    ok "Pre-deploy backup complete"
   fi
 
   # Step 1: Update repo

--- a/strut
+++ b/strut
@@ -264,7 +264,7 @@ usage() {
   echo ""
   echo "Commands:"
   echo "  update   [--env <name>]                                        Pull latest strut on VPS"
-  echo "  release  [--env <name>] [--services <profile>] [--strict] [--no-rollback]  Full VPS release (update + migrate + deploy)"
+  echo "  release  [--env <name>] [--services <profile>] [--strict] [--no-rollback] [--backup-first]  Full VPS release (update + migrate + deploy)"
   echo "  deploy   [--env <name>] [--services <profile>] [--pull-only]  Deploy stack"
   echo "  rebuild  [--env <name>] [--no-cache] [--pull]                  Build images + deploy"
   echo "  ship     [--env <name>] [-m <msg>] [--no-commit]               Commit, push, rebuild on remote"

--- a/tests/test_cmd_deploy.bats
+++ b/tests/test_cmd_deploy.bats
@@ -172,6 +172,19 @@ EOF
   [[ "$output" == *" false"* ]]
 }
 
+@test "cmd_release: backup_first defaults to false" {
+  run cmd_release
+  [ "$status" -eq 0 ]
+  [[ "$output" == *" true false"* ]]
+}
+
+@test "cmd_release: --backup-first passes backup_first=true to vps_release" {
+  export CMD_ARGS=(--backup-first)
+  run cmd_release
+  [ "$status" -eq 0 ]
+  [[ "$output" == *" true true"* ]]
+}
+
 @test "cmd_health: dispatches to health_run_all" {
   run cmd_health
   [ "$status" -eq 0 ]

--- a/tests/test_release.bats
+++ b/tests/test_release.bats
@@ -239,3 +239,54 @@ teardown() {
   run cat "$SSH_CALL_LOG"
   [[ "$output" == *"history_record 'stacks/test-stack' release 'failed'"* ]]
 }
+
+# ── --backup-first ─────────────────────────────────────────────────────────────
+
+@test "vps_release: backup_first defaults to false — no backup call" {
+  run vps_release "test-stack" "$TEST_TMP/.test.env" ""
+  [ "$status" -eq 0 ]
+
+  run cat "$SSH_CALL_LOG"
+  [[ "$output" != *"backup all"* ]]
+}
+
+@test "vps_release: --backup-first (backup_first=true) backs up before updating the repo" {
+  run vps_release "test-stack" "$TEST_TMP/.test.env" "" "true" "true"
+  [ "$status" -eq 0 ]
+
+  local line1
+  line1=$(sed -n '1p' "$SSH_CALL_LOG")
+  [[ "$line1" == *"backup all --env test"* ]]
+
+  local line2
+  line2=$(sed -n '2p' "$SSH_CALL_LOG")
+  [[ "$line2" == *"vps_update_repo"* ]]
+}
+
+@test "vps_release: dry-run plan includes the backup step when --backup-first" {
+  export DRY_RUN=true
+
+  run vps_release "test-stack" "$TEST_TMP/.test.env" "" "true" "true"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Back up databases before release"* ]]
+}
+
+@test "vps_release: dry-run plan omits the backup step by default" {
+  export DRY_RUN=true
+
+  run vps_release "test-stack" "$TEST_TMP/.test.env" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Back up databases before release"* ]]
+}
+
+@test "vps_release: aborts the release when the pre-deploy backup fails" {
+  export SSH_FAIL_PATTERN="backup all"
+
+  run vps_release "test-stack" "$TEST_TMP/.test.env" "" "true" "true"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Pre-deploy backup failed"* ]]
+
+  # Nothing past the backup step should have run.
+  run cat "$SSH_CALL_LOG"
+  [[ "$output" != *"vps_update_repo"* ]]
+}


### PR DESCRIPTION
Closes the remaining item of #186 (health-gated auto-rollback + on_health_fail were already done in #362)

Recreated from scratch off up-to-date main — the original attempt (#364, closed) was accidentally branched off the pre-merge feat/deploy-audit-history branch, which is why CI never triggered for it (same root cause as #351 earlier in this repo's history).

## Problem

The auto-rollback added in #362 only restores container images (`rollback_save_snapshot` captures image references, not data). If a release's migration step makes an incompatible schema change, rolling back the image alone won't undo the schema change — old app code would run against the new schema. A pre-deploy DB snapshot closes that gap.

## Fix

New `--backup-first` flag on `release`:

```bash
strut my-stack release --env prod --backup-first
```

Runs `./strut $stack backup all --env $env_name` on the remote host as the very first step — before the repo update, before any migration. Reuses the existing backup subsystem entirely (`BACKUP_ENGINES` + `backup_engine_enabled` from `lib/backup/engines.sh`) — zero new backup logic, just wiring it into the release pipeline at the earliest possible point so the snapshot reflects genuinely pre-release state.

A backup failure aborts the release outright. If you explicitly asked for a safety net, it shouldn't fail silently and let the release proceed anyway.

## Why opt-in, not default-on

Considered making this default-on (matching #362's `--no-rollback` opt-out pattern), but `backup_neo4j` requires stopping the Neo4j container for ~10-30s to take a consistent dump (Community Edition has no online backup mechanism). Defaulting this on would silently inject unexpected downtime into every routine release for any Neo4j-backed stack — a much bigger behavior change than #362's rollback addition, which had no downtime side effect. Opt-in avoids that surprise while still making the capability one flag away.

## Test plan
- [x] `tests/test_release.bats` — 5 new tests: backup runs before repo update when `--backup-first`, no backup call by default, dry-run plan includes/omits the step correctly, backup failure aborts the release before any other step runs
- [x] `tests/test_cmd_deploy.bats` — 2 new tests: flag defaults to false, `--backup-first` propagates `backup_first=true` to `vps_release`
- [x] `shellcheck -s bash strut lib/deploy.sh lib/cmd_deploy.sh` — clean
- [x] Verified `backup all`'s code path is fully non-interactive (no `confirm()` prompts) — safe to run unattended during a release