### PR TITLE
fix(cli): safely parse the env file instead of sourcing it

### DIFF
--- a/strut
+++ b/strut
@@ -839,7 +839,7 @@ export CMD_JSON="$JSON_FLAG"
 # fill in VPS_HOST/VPS_USER/VPS_PORT/VPS_SSH_KEY from the topology map
 # (env file values take precedence when set).
 if [ -f "$ENV_FILE" ]; then
-  set -a; source "$ENV_FILE" 2>/dev/null; set +a
+  safe_load_env "$ENV_FILE"
 fi
 if [ "$IS_HOST_SCOPED" = true ]; then
   : # host-scoped commands resolve their own host from the alias/--host

--- a/tests/test_cli_env_parsing.bats
+++ b/tests/test_cli_env_parsing.bats
@@ -75,3 +75,29 @@ teardown() {
   [ "$status" -ne 0 ]
   [[ "$output" == *"not found"* ]]
 }
+
+# ── Regression: env file must be safely parsed, not `source`d (P0 audit finding) ──
+
+@test "strut: env value with a bare space does not crash the dispatcher (exit 127)" {
+  echo 'MSG=hello world' > "$CLI_ROOT/.prod.env"
+  echo 'VPS_HOST=example.invalid' >> "$CLI_ROOT/.prod.env"
+  run bash "$CLI" $TEST_STACK status --env prod
+  rm -f "$CLI_ROOT/.prod.env"
+  # A `source`d file would die with exit 127 ("world: command not found")
+  # before any of strut's own logic runs. It must instead proceed into
+  # strut's normal (SSH-failure) error path.
+  [ "$status" -ne 127 ]
+}
+
+@test "strut: env value with command substitution is not executed" {
+  local marker="$CLI_ROOT/.pwned-marker"
+  rm -f "$marker"
+  {
+    echo "VPS_HOST=example.invalid"
+    echo "EVIL=\$(touch $marker)"
+  } > "$CLI_ROOT/.prod.env"
+  run bash "$CLI" $TEST_STACK status --env prod
+  rm -f "$CLI_ROOT/.prod.env"
+  [ ! -f "$marker" ]
+  rm -f "$marker"
+}


### PR DESCRIPTION
## Summary
- The dispatcher ran `set -a; source "$ENV_FILE"` on every stack command, executing arbitrary shell in env values — the exact RCE `safe_load_env` was built to prevent — and dying with exit 127 on a legal `KEY=value with spaces` line under `set -e` with the diagnostic swallowed by `2>/dev/null`.
- Replaced with `safe_load_env "$ENV_FILE"`, which parses `KEY=value` safely without executing the file, matching the guarantee already documented for it in `lib/utils.sh`.

## Test plan
- [x] Reproduced both bugs pre-fix: an env value `EVIL=$(touch marker)` executed, and `MSG=hello world` caused exit 127.
- [x] Verified both are fixed post-fix (marker not created; no exit 127; dispatch proceeds to strut's normal error handling).
- [x] Added regression tests to `tests/test_cli_env_parsing.bats`.
- [x] Full `bats tests/` suite green (2015 tests; the only failures are pre-existing sandbox environment gaps — no `ssh-keygen`/openssh, `age` present where a test expects it absent, Docker daemon down — unrelated to this change).

Closes #370


---
_Generated by [Claude Code](https://claude.ai/code/session_01TAzX3TwkCPkFT1uGxNP7GH)_