### PR TITLE
fix(backup): validate Neo4j .dump before restore wipes the live database

### DIFF
--- a/lib/backup.sh
+++ b/lib/backup.sh
@@ -239,6 +239,23 @@ restore_neo4j() {
   warn "This will STOP Neo4j, restore from dump, then restart it."
   confirm "Continue?" || { ok "Restore cancelled"; return 0; }
 
+  # Validate the dump BEFORE any destructive action, so a zero-byte or
+  # truncated dump (e.g. left by a failed backup or a partial rsync) can't
+  # wipe the live database with --overwrite-destination=true and then fail
+  # the load mid-stream, leaving nothing restored. Loads into a disposable
+  # scratch volume via neo4j-admin — the live container is never touched by
+  # this step.
+  [ -s "$dump_file" ] || fail "Refusing to restore: dump file is empty: $dump_file"
+
+  log "Validating dump before touching the live database..."
+  local verify_result
+  verify_result=$(_neo4j_verify_load_dump "$stack" "$dump_file") ||
+    fail "Refusing to restore: dump failed structural validation (corrupt or truncated): $dump_file"
+  local _verify_scratch_vol
+  read -r _ _verify_scratch_vol <<<"$verify_result"
+  docker volume rm "$_verify_scratch_vol" >/dev/null 2>&1 || true
+  ok "Dump validated — proceeding with restore"
+
   local neo4j_service="${BACKUP_NEO4J_SERVICE:-neo4j}"
 
   # Get container name for direct docker operations

--- a/tests/test_backup_restore_safety.bats
+++ b/tests/test_backup_restore_safety.bats
@@ -44,14 +44,25 @@ setup() {
   DOCKER_CALL_LOG="$TEST_TMP/docker_calls.log"
   : > "$DOCKER_CALL_LOG"
 
-  # fake docker for restore_neo4j_from_targz — no real Docker in CI.
+  # fake docker for restore_neo4j_from_targz / restore_neo4j — no real
+  # Docker in CI.
   # FAKE_TAR_OK controls whether the pre-wipe `tar -tzf` integrity check
-  # (run inside the fake container) passes.
+  # (run inside the fake container) passes (restore_neo4j_from_targz).
+  # FAKE_NEO4J_LOAD_OK controls whether the neo4j-admin structural-load
+  # check (both the scratch-volume verification in restore_neo4j and its
+  # live restore step) reports success.
   docker() {
     echo "$*" >> "$DOCKER_CALL_LOG"
     case "$1" in
       ps)
-        echo "test-stack-neo4j-1"
+        # The post-restart "wait for healthy" loop polls `{{.Status}}`;
+        # answer it immediately instead of letting the poll run its full
+        # ~60s timeout on every happy-path test.
+        if [[ "$*" == *"{{.Status}}"* ]]; then
+          echo "Up 2 seconds (healthy)"
+        else
+          echo "test-stack-neo4j-1"
+        fi
         ;;
       stop|start)
         return 0
@@ -61,11 +72,20 @@ setup() {
           echo "exited"
         elif [[ "$*" == *"Mounts"* ]]; then
           echo "fake-data-volume"
+        elif [[ "$*" == *"Config.Image"* ]]; then
+          echo "fake-neo4j-image:5.15"
         fi
         ;;
       run)
         if [[ "$*" == *"tar -tzf"* ]]; then
           [ "${FAKE_TAR_OK:-1}" = "1" ]
+        elif [[ "$*" == *"neo4j-admin"* && "$*" == *"database load"* ]]; then
+          if [ "${FAKE_NEO4J_LOAD_OK:-1}" = "1" ]; then
+            echo "Load completed successfully"
+            return 0
+          else
+            return 1
+          fi
         else
           return 0
         fi
@@ -222,4 +242,65 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"restore from tar.gz complete"* ]]
   grep -q "rm -rf /data" "$DOCKER_CALL_LOG"
+}
+
+# ── restore_neo4j (strut#373) ───────────────────────────────────────────────
+# The modern .dump restore path previously validated only `[ -f ]` before
+# `--overwrite-destination=true`, so a zero-byte or truncated dump wiped the
+# live database and then failed to load — data destroyed, nothing restored.
+
+@test "restore_neo4j: refuses an empty dump without touching the live container" {
+  local dump_file="$TEST_TMP/empty.dump"
+  : > "$dump_file"
+
+  run restore_neo4j "test-stack" "fake_compose" "$dump_file"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"empty"* ]]
+  [ ! -s "$DOCKER_CALL_LOG" ]
+}
+
+@test "restore_neo4j: refuses a missing dump file without touching the live container" {
+  run restore_neo4j "test-stack" "fake_compose" "$TEST_TMP/does-not-exist.dump"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+  [ ! -s "$DOCKER_CALL_LOG" ]
+}
+
+@test "restore_neo4j: refuses a dump that fails structural validation, without stopping or overwriting the live database" {
+  local dump_file="$TEST_TMP/corrupt.dump"
+  echo "not actually a neo4j dump" > "$dump_file"
+
+  FAKE_NEO4J_LOAD_OK=0 run restore_neo4j "test-stack" "fake_compose" "$dump_file"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"structural validation"* ]]
+
+  # The live container must never be touched: no stop, and no live
+  # overwrite-destination load against /var/lib/neo4j/import/restore.dump.
+  ! grep -q "^stop " "$DOCKER_CALL_LOG"
+  ! grep -q "restore.dump /var/lib/neo4j/import/neo4j.dump" "$DOCKER_CALL_LOG"
+}
+
+@test "restore_neo4j: validates via a disposable scratch volume, not the live data volume" {
+  local dump_file="$TEST_TMP/valid.dump"
+  echo "valid dump contents" > "$dump_file"
+
+  run restore_neo4j "test-stack" "fake_compose" "$dump_file"
+  [ "$status" -eq 0 ]
+
+  # Verification's scratch volume is created and cleaned up (docker volume
+  # create/rm), independently of the live restore's data volume mounts.
+  grep -q "^volume create" "$DOCKER_CALL_LOG"
+  grep -q "^volume rm" "$DOCKER_CALL_LOG"
+}
+
+@test "restore_neo4j: restores the live database once the dump passes structural validation" {
+  local dump_file="$TEST_TMP/valid.dump"
+  echo "valid dump contents" > "$dump_file"
+
+  run restore_neo4j "test-stack" "fake_compose" "$dump_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"restore complete"* ]]
+
+  grep -q "^stop " "$DOCKER_CALL_LOG"
+  grep -q "restore.dump /var/lib/neo4j/import/neo4j.dump" "$DOCKER_CALL_LOG"
 }


### PR DESCRIPTION
## Summary
- `restore_neo4j` (the modern `.dump` restore path) validated the artifact with only `[ -f ]`, then ran `neo4j-admin database load --overwrite-destination=true` against the **live** database. A zero-byte or truncated dump — left behind by a failed backup or a partial rsync — passed that check, the live database was overwritten, and the load then failed mid-stream: data destroyed, nothing restored. This is exactly what `db:pull neo4j` feeds it.
- `restore_postgres` and the sibling `restore_neo4j_from_targz` (old backup format) both already validate before touching data (`[ -s ]` / gzip / tar integrity checks) — only the `.dump` path was missing this.
- Fixed by reusing the existing `_neo4j_verify_load_dump` helper (`lib/backup/verify.sh`), which loads the dump into a disposable scratch volume via `neo4j-admin` — a real structural check that never touches the live container or its data volume — and refusing to proceed if it fails.

## Test plan
- [x] Extended `tests/test_backup_restore_safety.bats` (which already covers this exact bug class — #209 — for `restore_postgres`/`restore_neo4j_from_targz`) with the `restore_neo4j` case: empty dump, missing dump, structurally-invalid dump (all refused, live container never stopped/touched), and a valid dump (restores normally, scratch volume created and cleaned up).
- [x] No real Docker available in this environment — extended the file's existing fake-`docker` harness to answer the `neo4j-admin database load` structural check and `{{.Config.Image}}` inspect query, matching the pattern the file already uses for `restore_neo4j_from_targz`'s fake `tar -tzf` check.
- [x] Also sped up the shared fake `docker ps` health-poll response (answers "healthy" immediately instead of letting the ~60s poll loop run to timeout) — this benefits the pre-existing `restore_neo4j_from_targz` happy-path test too, cutting the file's runtime from >60s to ~5s.
- [x] Full `bats tests/` suite: same 4 pre-existing environmental failures as the `main` baseline (Docker daemon down for `doctor`, `age`/`gpg` backend detection) — no regressions, all new tests green.

Closes #373


---
_Generated by [Claude Code](https://claude.ai/code/session_01TAzX3TwkCPkFT1uGxNP7GH)_