### PR TITLE
fix(deploy): refuse to deploy when the Compose project name collides with a different stack

### DIFF
--- a/lib/deploy.sh
+++ b/lib/deploy.sh
@@ -72,6 +72,68 @@ _deploy_reclaim_named_containers() {
   done
 }
 
+# _deploy_guard_project_collision <compose_file> <project_name>
+#
+# Detects a distinct footgun from the one above: two entirely different
+# stacks resolving to the SAME Compose project name (most commonly because
+# they share one env file with a hardcoded COMPOSE_PROJECT_NAME — env files
+# are per-environment, not per-stack). Compose's orphan detection is
+# project-scoped, not compose-file-scoped: `down --remove-orphans` / `up -d
+# --remove-orphans` will delete ANY container labeled with that project that
+# isn't a service in the compose file about to be deployed — including a
+# completely unrelated sibling stack's live containers (strut#418).
+#
+# Every container Compose starts is labeled with the working directory of
+# the compose file that created it (com.docker.compose.project.working_dir).
+# Two unrelated stacks sharing a project name will have DIFFERENT working
+# directories; a stack's own prior deploy will always match. That's the
+# signal this checks: any running container under <project_name> whose
+# working_dir doesn't match <compose_file>'s directory means the resolved
+# project name is shared with another stack, and continuing would let
+# --remove-orphans delete it.
+_deploy_guard_project_collision() {
+  local compose_file="$1"
+  local project_name="$2"
+  local expected_working_dir
+  expected_working_dir="$(cd "$(dirname "$compose_file")" && pwd)"
+
+  local rows
+  rows=$(docker ps -a \
+    --filter "label=com.docker.compose.project=$project_name" \
+    --format '{{.Names}}|{{.Label "com.docker.compose.project.working_dir"}}' 2>/dev/null) || return 0
+  [ -n "$rows" ] || return 0
+
+  local -a collisions=()
+  local name working_dir
+  while IFS='|' read -r name working_dir; do
+    [ -n "$name" ] || continue
+    if [ -n "$working_dir" ] && [ "$working_dir" != "$expected_working_dir" ]; then
+      collisions+=("$name (from $working_dir)")
+    fi
+  done <<<"$rows"
+
+  [ "${#collisions[@]}" -eq 0 ] && return 0
+
+  error "Compose project '$project_name' already has containers from a DIFFERENT stack:"
+  local c
+  for c in "${collisions[@]}"; do
+    echo "    - $c" >&2
+  done
+  echo "" >&2
+  echo "  This stack's compose file is at: $expected_working_dir" >&2
+  echo "" >&2
+  echo "  The resolved project name is shared by more than one stack — usually" >&2
+  echo "  because COMPOSE_PROJECT_NAME is set in an env file used by multiple" >&2
+  echo "  stacks (env files are per-environment, not per-stack). Continuing" >&2
+  echo "  would let 'docker compose down/up --remove-orphans' delete the" >&2
+  echo "  containers listed above." >&2
+  echo "" >&2
+  echo "  Fix: give this stack its own env file (.<stack>-<env>.env, deployed" >&2
+  echo "  with --env <stack>-<env>) so it resolves to a distinct project name," >&2
+  echo "  or remove COMPOSE_PROJECT_NAME from the shared env file." >&2
+  return 1
+}
+
 # deploy_stack <stack> <env_file> [services_profile]
 #
 # Brings up the stack at stacks/<stack>/docker-compose.yml using the given
@@ -137,6 +199,15 @@ deploy_stack() {
       run_cmd "Skip image pull/build (BUILD_MODE=$dry_build_mode)" echo "skipped"
     fi
     run_cmd "Create data directories" mkdir -p "$stack_dir/data/..."
+
+    # Read-only, so it runs for real even in dry-run — surfaces strut#418's
+    # cross-stack COMPOSE_PROJECT_NAME collision before an operator ever
+    # risks a live deploy.
+    local dry_project_name
+    dry_project_name=$(echo "$compose_cmd" | grep -oE '\-\-project\-name [^ ]+' | awk '{print $2}') || true
+    _deploy_guard_project_collision "$compose_file" "${dry_project_name:-$stack}" \
+      || { fail "[DRY-RUN] Would abort here — see above."; return 1; }
+
     run_cmd "Stop existing containers" $compose_cmd down --remove-orphans
     run_cmd "Start services" $compose_cmd up -d --remove-orphans
     local proxy="${REVERSE_PROXY:-nginx}"
@@ -209,6 +280,15 @@ deploy_stack() {
   done
   ok "Data directories ready"
 
+  local project_name
+  project_name=$(echo "$compose_cmd" | grep -oE '\-\-project\-name [^ ]+' | awk '{print $2}') || true
+
+  # Refuse to proceed if the resolved project name is shared with a
+  # different, unrelated stack (strut#418) — down/up --remove-orphans below
+  # would delete that stack's live containers.
+  _deploy_guard_project_collision "$compose_file" "${project_name:-$stack}" \
+    || { fail "Aborting deploy: the running stack was left untouched (see above)."; return 1; }
+
   # Stop any existing containers to free up ports
   log "[5/6] Stopping existing containers..."
   $compose_cmd down --remove-orphans 2>/dev/null || true  # may not be running yet
@@ -217,8 +297,6 @@ deploy_stack() {
   # docker compose down may have missed (e.g. from a previously failed deploy),
   # scoped to containers actually owned by this project — see
   # _deploy_reclaim_named_containers.
-  local project_name
-  project_name=$(echo "$compose_cmd" | grep -oE '\-\-project\-name [^ ]+' | awk '{print $2}') || true
   _deploy_reclaim_named_containers "$compose_file" "${project_name:-$stack}"
 
   ok "Existing containers stopped"

--- a/tests/test_deploy_orphan_scope.bats
+++ b/tests/test_deploy_orphan_scope.bats
@@ -107,3 +107,175 @@ _stub_docker_missing() {
   [ "$status" -eq 0 ]
   [ ! -f "$TEST_TMP/rm_calls" ]
 }
+
+# ── _deploy_guard_project_collision (strut#418) ─────────────────────────────
+# Two unrelated stacks sharing a Compose project name (typically via a
+# shared env file's COMPOSE_PROJECT_NAME) let `down/up --remove-orphans`
+# delete a sibling stack's live containers. The guard detects this by
+# comparing each running container's working_dir label against the compose
+# file about to be deployed.
+
+# _stub_docker_ps_rows <rows>
+# Stubs `docker ps -a --filter ... --format '{{.Names}}|{{.Label ...}}'` to
+# emit the given newline-separated "name|working_dir" rows.
+_stub_docker_ps_rows() {
+  local rows="$1"
+  # shellcheck disable=SC2317
+  docker() {
+    case "$1" in
+      ps) printf '%s' "$DOCKER_STUB_ROWS" ;;
+      *) return 0 ;;
+    esac
+  }
+  export DOCKER_STUB_ROWS="$rows"
+  export -f docker
+}
+
+@test "_deploy_guard_project_collision: no containers under the project — passes" {
+  _load_deploy
+  local compose_file; compose_file=$(_make_compose_file)
+  _stub_docker_ps_rows ""
+
+  run _deploy_guard_project_collision "$compose_file" "myapp-prod"
+  [ "$status" -eq 0 ]
+}
+
+@test "_deploy_guard_project_collision: containers all belong to this stack's own compose file — passes" {
+  _load_deploy
+  local compose_file; compose_file=$(_make_compose_file)
+  local own_dir; own_dir=$(dirname "$compose_file")
+  _stub_docker_ps_rows "myapp-web-1|$own_dir"
+
+  run _deploy_guard_project_collision "$compose_file" "myapp-prod"
+  [ "$status" -eq 0 ]
+}
+
+@test "_deploy_guard_project_collision: a container from a different working_dir aborts with diagnostics" {
+  _load_deploy
+  local compose_file; compose_file=$(_make_compose_file)
+  _stub_docker_ps_rows "octoprint-1|/home/gfargo/strut/stacks/octoprint"
+
+  run _deploy_guard_project_collision "$compose_file" "observability"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"octoprint-1"* ]]
+  [[ "$output" == *"/home/gfargo/strut/stacks/octoprint"* ]]
+  [[ "$output" == *"observability"* ]]
+  [[ "$output" == *"COMPOSE_PROJECT_NAME"* ]]
+}
+
+@test "_deploy_guard_project_collision: lists only the foreign containers, not the stack's own" {
+  _load_deploy
+  local compose_file; compose_file=$(_make_compose_file)
+  local own_dir; own_dir=$(dirname "$compose_file")
+  _stub_docker_ps_rows "myapp-web-1|$own_dir
+octoprint-1|/home/gfargo/strut/stacks/octoprint"
+
+  run _deploy_guard_project_collision "$compose_file" "myapp-prod"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"octoprint-1"* ]]
+  [[ "$output" != *"myapp-web-1 (from"* ]]
+}
+
+@test "_deploy_guard_project_collision: a container with no working_dir label is not flagged (unknown, not foreign)" {
+  _load_deploy
+  local compose_file; compose_file=$(_make_compose_file)
+  _stub_docker_ps_rows "legacy-container|"
+
+  run _deploy_guard_project_collision "$compose_file" "myapp-prod"
+  [ "$status" -eq 0 ]
+}
+
+@test "_deploy_guard_project_collision: docker query failure fails open (does not block deploy)" {
+  _load_deploy
+  local compose_file; compose_file=$(_make_compose_file)
+  # shellcheck disable=SC2317
+  docker() { return 1; }
+  export -f docker
+
+  run _deploy_guard_project_collision "$compose_file" "myapp-prod"
+  [ "$status" -eq 0 ]
+}
+
+# ── deploy_stack: guard is actually wired in before the destructive step ────
+
+@test "deploy_stack --dry-run: aborts before previewing teardown when a foreign container collides" {
+  _load_deploy
+  export CLI_ROOT="$TEST_TMP"
+  local stack="myapp"
+  local stack_dir="$TEST_TMP/stacks/$stack"
+  mkdir -p "$stack_dir"
+  cat > "$stack_dir/docker-compose.yml" <<'EOF'
+services:
+  web:
+    image: example/app:latest
+EOF
+  local env_file="$TEST_TMP/.prod.env"
+  echo "COMPOSE_PROJECT_NAME=observability" > "$env_file"
+
+  # shellcheck disable=SC2317
+  docker() {
+    case "$1" in
+      compose)
+        [[ "$*" == *"version"* ]] && return 0
+        return 0
+        ;;
+      ps) echo "octoprint-1|/home/gfargo/strut/stacks/octoprint" ;;
+      *) return 0 ;;
+    esac
+  }
+  export -f docker
+  deploy_run_pre_deploy_validation() { return 0; }
+  export -f deploy_run_pre_deploy_validation
+  deploy_prepare() { return 0; }
+  export -f deploy_prepare
+  load_services_conf() { return 0; }
+  export -f load_services_conf
+  print_banner() { :; }
+  export -f print_banner
+
+  DRY_RUN=true
+  run deploy_stack "$stack" "$env_file" ""
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"octoprint-1"* ]]
+  [[ "$output" != *"Stop existing containers"* ]]
+  [[ "$output" != *"No changes made"* ]]
+}
+
+@test "deploy_stack --dry-run: proceeds through the full plan when there's no collision" {
+  _load_deploy
+  export CLI_ROOT="$TEST_TMP"
+  local stack="myapp"
+  local stack_dir="$TEST_TMP/stacks/$stack"
+  mkdir -p "$stack_dir"
+  cat > "$stack_dir/docker-compose.yml" <<'EOF'
+services:
+  web:
+    image: example/app:latest
+EOF
+  local env_file="$TEST_TMP/.prod.env"
+  : > "$env_file"
+
+  # shellcheck disable=SC2317
+  docker() {
+    case "$1" in
+      compose) return 0 ;;
+      ps) : ;; # no containers under this project — nothing to collide with
+      *) return 0 ;;
+    esac
+  }
+  export -f docker
+  deploy_run_pre_deploy_validation() { return 0; }
+  export -f deploy_run_pre_deploy_validation
+  deploy_prepare() { return 0; }
+  export -f deploy_prepare
+  load_services_conf() { return 0; }
+  export -f load_services_conf
+  print_banner() { :; }
+  export -f print_banner
+
+  DRY_RUN=true
+  run deploy_stack "$stack" "$env_file" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Stop existing containers"* ]]
+  [[ "$output" == *"No changes made"* ]]
+}

--- a/tests/test_dry_run.bats
+++ b/tests/test_dry_run.bats
@@ -251,6 +251,11 @@ YAML
       echo "Docker Compose version v2.20.0"
       return 0
     fi
+    # No running containers in this scenario — needed so
+    # _deploy_guard_project_collision's `docker ps ...` sees nothing rather
+    # than the generic echo-back below, which it would otherwise misparse
+    # as a colliding container.
+    [ "$1" = "ps" ] && return 0
     echo "docker $*"
     return 0
   }
@@ -359,6 +364,11 @@ EOF
       echo "Docker Compose version v2.20.0"
       return 0
     fi
+    # No running containers in this scenario — needed so
+    # _deploy_guard_project_collision's `docker ps ...` sees nothing rather
+    # than the generic echo-back below, which it would otherwise misparse
+    # as a colliding container.
+    [ "$1" = "ps" ] && return 0
     echo "docker $*"
     return 0
   }
@@ -418,6 +428,11 @@ EOF
       echo "Docker Compose version v2.20.0"
       return 0
     fi
+    # No running containers in this scenario — needed so
+    # _deploy_guard_project_collision's `docker ps ...` sees nothing rather
+    # than the generic echo-back below, which it would otherwise misparse
+    # as a colliding container.
+    [ "$1" = "ps" ] && return 0
     echo "docker $*"
     return 0
   }

--- a/tests/test_proxy_config.bats
+++ b/tests/test_proxy_config.bats
@@ -162,6 +162,11 @@ YAML
       echo "Docker Compose version v2.20.0"
       return 0
     fi
+    # No running containers in this scenario — needed so
+    # _deploy_guard_project_collision's `docker ps ...` sees nothing rather
+    # than the generic echo-back below, which it would otherwise misparse
+    # as a colliding container.
+    [ "$1" = "ps" ] && return 0
     echo "docker $*"
     return 0
   }


### PR DESCRIPTION
## Summary

Fixes the production incident in #418: two unrelated stacks sharing a Compose project name — most commonly because they share one env file with a hardcoded `COMPOSE_PROJECT_NAME` (env files are per-environment, not per-stack) — let `docker compose down --remove-orphans` / `up -d --remove-orphans` delete the **other** stack's live containers. Compose's orphan detection is scoped to the project name alone, not to which compose file actually owns a container. This destroyed a live, in-progress 3D print in production.

- Added `_deploy_guard_project_collision(compose_file, project_name)`, called right before the destructive teardown step in `deploy_stack` (and in `--dry-run`, since it's entirely read-only — an operator can catch this before ever risking a live deploy).
- It compares each running container's `com.docker.compose.project.working_dir` label (a standard Compose label) against the directory of the compose file about to be deployed. Any container under the resolved project name whose working_dir points somewhere else means the project name is shared with an unrelated stack — the deploy aborts with a clear diagnostic (which containers, which directory, and how to fix it) before `down`/`up --remove-orphans` can touch anything.
- Scope note: blue-green deploys aren't affected by this bug — they always pass an explicit `<stack>-<env>-<color>` project override, which takes precedence over `COMPOSE_PROJECT_NAME` in `resolve_compose_cmd`'s resolution order, so they can't collide with a sibling stack this way.
- The guard fails open (returns success) if the `docker ps` query itself fails, so it can't turn into a new way to block a legitimate deploy on transient Docker flakiness — it only blocks when it positively identifies a foreign container.

## Test plan
- [x] New unit tests for `_deploy_guard_project_collision` in `tests/test_deploy_orphan_scope.bats` (thematically the existing project-scope-safety file): passes with no containers, passes when all containers belong to the stack's own compose file, aborts with correct diagnostics when a foreign container is found, lists only the foreign containers (not the stack's own), doesn't flag containers with no working_dir label (older Compose / unrelated containers), fails open on a `docker` query error.
- [x] Two integration-level tests exercising `deploy_stack` itself end-to-end under `--dry-run`, reproducing the exact #418 scenario (env file with `COMPOSE_PROJECT_NAME=observability`, a foreign `octoprint` container already running under that project) and proving the plan aborts before the "Stop existing containers" preview line is ever printed — plus a happy-path counterpart proving the normal plan still completes when there's no collision.
- [x] Fixed three pre-existing test fixtures (`test_dry_run.bats` ×2 call sites, `test_proxy_config.bats` ×1) whose blanket `docker() { ...; echo "docker $*"; }` stub didn't have a `ps` branch — my new `docker ps` call was hitting their generic echo-back fallback and being misparsed as a false collision. Added an explicit `ps) return 0 ;;` branch (no containers) to each, matching their existing "nothing running" test scenarios.
- [x] `shellcheck -s bash strut` and `find lib -name '*.sh' | xargs shellcheck -s bash` (the exact commands CI's ShellCheck job runs) — clean, no findings.
- [x] Full `bats tests/` suite: same 4 pre-existing environmental failures as the `main` baseline (Docker daemon down for `doctor --json`, `age`/`gpg` backend detection) — no regressions, all new/touched tests green.
- [ ] Real-Docker integration suite (`tests/integration/`) — I don't have a Docker daemon in this environment to run it locally; relying on CI's "Integration (bats, Docker)" job, which uses a real daemon, to validate the `docker ps --format '{{.Label "..."}}'` templating against real Compose-labeled containers. Will watch and fix promptly if it surfaces anything.

Closes #418


---
_Generated by [Claude Code](https://claude.ai/code/session_01TAzX3TwkCPkFT1uGxNP7GH)_