### PR TITLE
refactor(deploy): address #419 review feedback on STACK_DATA_DIRS

### DIFF
--- a/lib/deploy.sh
+++ b/lib/deploy.sh
@@ -134,6 +134,44 @@ _deploy_guard_project_collision() {
   return 1
 }
 
+# _deploy_resolve_data_dirs
+#
+# Resolves which data directories deploy_stack should create for the stack
+# currently being deployed. Reads STACK_DATA_DIRS and the DB_* flags from
+# the environment — callers must load_services_conf first.
+#
+# Precedence (strut#417):
+#   1. STACK_DATA_DIRS explicitly set, including to an empty string —
+#      honoured verbatim. An empty value creates NO directories at all; use
+#      this for stacks whose data dirs are managed externally or are
+#      root-owned by the container. The no-colon ${var+x} test is what
+#      distinguishes "explicitly set to empty" from "never set" —
+#      ${STACK_DATA_DIRS:-default} treats both the same, which was the bug.
+#   2. STACK_DATA_DIRS unset — derive from the same DB_* flags in
+#      services.conf that health.sh reads, falling back to a single generic
+#      "data" dir when none are set.
+#
+# Echoes a space-separated list of paths relative to the stack directory
+# (possibly empty). Callers loop `for dir in $(...)`.
+_deploy_resolve_data_dirs() {
+  if [ -n "${STACK_DATA_DIRS+x}" ]; then
+    echo "$STACK_DATA_DIRS"
+    return 0
+  fi
+
+  local -a dirs=()
+  [ "${DB_POSTGRES:-false}" = "true" ] && dirs+=("data/postgres")
+  [ "${DB_REDIS:-false}" = "true" ]   && dirs+=("data/redis")
+  [ "${DB_NEO4J:-false}" = "true" ]   && dirs+=("data/neo4j")
+  [ "${DB_MYSQL:-false}" = "true" ]   && dirs+=("data/mysql")
+
+  if [ "${#dirs[@]}" -eq 0 ]; then
+    echo "data"
+  else
+    echo "${dirs[*]}"
+  fi
+}
+
 # deploy_stack <stack> <env_file> [services_profile]
 #
 # Brings up the stack at stacks/<stack>/docker-compose.yml using the given
@@ -265,28 +303,11 @@ deploy_stack() {
 
   # Data directories — explicit STACK_DATA_DIRS wins; otherwise derive from
   # the same DB_* flags in services.conf that health.sh reads, falling back
-  # to a single generic "data" dir when none are set.
-  #
-  # Setting STACK_DATA_DIRS="" (empty string) suppresses all directory creation
-  # entirely — use this for stacks whose data dirs are managed externally or
-  # are root-owned by the container.  The no-colon ${var+x} test distinguishes
-  # "explicitly set to empty" from "never set".
+  # to a single generic "data" dir when none are set. See
+  # _deploy_resolve_data_dirs for the full precedence rules.
   log "[4/5] Creating data directories..."
   local data_dirs
-  if [ -n "${STACK_DATA_DIRS+x}" ]; then
-    # Explicitly set (even to empty string) — honour it verbatim.
-    # Empty STACK_DATA_DIRS → no directories created → loop is a no-op.
-    data_dirs="$STACK_DATA_DIRS"
-  else
-    # Not set at all — derive from the DB_* flags loaded from services.conf,
-    # falling back to a single "data" dir when no databases are declared.
-    data_dirs=""
-    [ "${DB_POSTGRES:-false}" = "true" ] && data_dirs="$data_dirs data/postgres"
-    [ "${DB_REDIS:-false}" = "true" ]   && data_dirs="$data_dirs data/redis"
-    [ "${DB_NEO4J:-false}" = "true" ]   && data_dirs="$data_dirs data/neo4j"
-    [ "${DB_MYSQL:-false}" = "true" ]   && data_dirs="$data_dirs data/mysql"
-    data_dirs="${data_dirs:-data}"
-  fi
+  data_dirs=$(_deploy_resolve_data_dirs)
   for dir in $data_dirs; do
     mkdir -p "$stack_dir/$dir"
   done

--- a/templates/services.conf.template
+++ b/templates/services.conf.template
@@ -47,3 +47,18 @@
 # A "_PRIVILEGED" suffix is appended for the privileged tier.
 #
 # API_KEY_ENV_VAR=API_KEYS
+#
+# ── Data Directories ───────────────────────────────
+# Controls which host-side directories `deploy` creates under the stack dir
+# before bringing containers up ("Creating data directories" step).
+#
+# Unset (default) — derived from the DB_* flags above: data/postgres,
+# data/redis, data/neo4j, data/mysql as applicable, or a single generic
+# "data" dir if no DB_* flags are set.
+#
+# STACK_DATA_DIRS="data/uploads data/cache"   # explicit list — creates only these
+# STACK_DATA_DIRS=                            # empty — creates NONE at all;
+#                                              # use when data dirs are root-owned
+#                                              # by the container or managed
+#                                              # externally (e.g. a bind mount
+#                                              # the container itself populates)

--- a/tests/test_deploy_data_dirs.bats
+++ b/tests/test_deploy_data_dirs.bats
@@ -7,18 +7,23 @@
 #   2. STACK_DATA_DIRS="" (empty) must suppress all directory creation
 #   3. Derive dirs from DB_* flags in services.conf when STACK_DATA_DIRS unset
 #   4. Fall back to "data" when no DB_* flags and STACK_DATA_DIRS unset
-
-# We test the data-directory logic in isolation by extracting just the logic
-# under test from deploy_stack into a helper function that mirrors the exact
-# code path, rather than calling the full deploy_stack (which needs docker,
-# SSH, etc.).
+#
+# Exercises the real _deploy_resolve_data_dirs function from lib/deploy.sh
+# directly — not a copy of its logic — so these tests can't silently drift
+# from the production code path the way a duplicated-logic helper could.
 
 setup() {
   source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
   load_utils
+  source "$CLI_ROOT/lib/config.sh"
   source "$CLI_ROOT/lib/output.sh"
+  source "$CLI_ROOT/lib/docker.sh"
+  source "$CLI_ROOT/lib/deploy.sh"
 
-  # Build a minimal stack dir for each test
+  # Build a minimal stack dir for each test (some tests use it directly;
+  # _deploy_resolve_data_dirs itself is stack-dir-agnostic — it only echoes
+  # relative paths — but keeping it around lets tests also assert mkdir -p
+  # behavior end-to-end where useful).
   export STACK_DIR="$TEST_TMP/stacks/mystack"
   mkdir -p "$STACK_DIR"
 
@@ -31,24 +36,13 @@ teardown() {
   common_teardown
 }
 
-# ── Helper: replicate the deploy_stack data-dir logic verbatim ────────────────
-#
-# This function is a direct copy of the logic in deploy_stack (lib/deploy.sh)
-# under the "# Data directories" comment.  If the implementation changes,
-# update this copy to match.
-_run_data_dir_logic() {
+# _apply_data_dirs <stack_dir>
+# Runs the real resolver and actually creates the directories, mirroring
+# what deploy_stack's "[4/5] Creating data directories..." step does.
+_apply_data_dirs() {
   local stack_dir="$1"
   local data_dirs
-  if [ -n "${STACK_DATA_DIRS+x}" ]; then
-    data_dirs="$STACK_DATA_DIRS"
-  else
-    data_dirs=""
-    [ "${DB_POSTGRES:-false}" = "true" ] && data_dirs="$data_dirs data/postgres"
-    [ "${DB_REDIS:-false}" = "true" ]   && data_dirs="$data_dirs data/redis"
-    [ "${DB_NEO4J:-false}" = "true" ]   && data_dirs="$data_dirs data/neo4j"
-    [ "${DB_MYSQL:-false}" = "true" ]   && data_dirs="$data_dirs data/mysql"
-    data_dirs="${data_dirs:-data}"
-  fi
+  data_dirs=$(_deploy_resolve_data_dirs)
   for dir in $data_dirs; do
     mkdir -p "$stack_dir/$dir"
   done
@@ -58,8 +52,11 @@ _run_data_dir_logic() {
 
 @test "deploy data dirs: STACK_DATA_DIRS='' suppresses all directory creation" {
   export STACK_DATA_DIRS=""
-  run _run_data_dir_logic "$STACK_DIR"
+  run _deploy_resolve_data_dirs
   [ "$status" -eq 0 ]
+  [ -z "$output" ]
+
+  _apply_data_dirs "$STACK_DIR"
   # data/ must NOT be created
   [ ! -d "$STACK_DIR/data" ]
   # postgres/redis must NOT be created either
@@ -71,8 +68,11 @@ _run_data_dir_logic() {
 
 @test "deploy data dirs: STACK_DATA_DIRS with custom path creates only that path" {
   export STACK_DATA_DIRS="volumes/app"
-  run _run_data_dir_logic "$STACK_DIR"
+  run _deploy_resolve_data_dirs
   [ "$status" -eq 0 ]
+  [ "$output" = "volumes/app" ]
+
+  _apply_data_dirs "$STACK_DIR"
   [ -d "$STACK_DIR/volumes/app" ]
   [ ! -d "$STACK_DIR/data" ]
   [ ! -d "$STACK_DIR/data/postgres" ]
@@ -80,8 +80,11 @@ _run_data_dir_logic() {
 
 @test "deploy data dirs: STACK_DATA_DIRS with multiple paths creates all of them" {
   export STACK_DATA_DIRS="vol/a vol/b"
-  run _run_data_dir_logic "$STACK_DIR"
+  run _deploy_resolve_data_dirs
   [ "$status" -eq 0 ]
+  [ "$output" = "vol/a vol/b" ]
+
+  _apply_data_dirs "$STACK_DIR"
   [ -d "$STACK_DIR/vol/a" ]
   [ -d "$STACK_DIR/vol/b" ]
   [ ! -d "$STACK_DIR/data" ]
@@ -91,8 +94,11 @@ _run_data_dir_logic() {
 
 @test "deploy data dirs: DB_POSTGRES=true creates data/postgres (no gdrive or redis)" {
   export DB_POSTGRES=true
-  run _run_data_dir_logic "$STACK_DIR"
+  run _deploy_resolve_data_dirs
   [ "$status" -eq 0 ]
+  [ "$output" = "data/postgres" ]
+
+  _apply_data_dirs "$STACK_DIR"
   [ -d "$STACK_DIR/data/postgres" ]
   [ ! -d "$STACK_DIR/data/redis" ]
   [ ! -d "$STACK_DIR/data/gdrive" ]
@@ -100,8 +106,11 @@ _run_data_dir_logic() {
 
 @test "deploy data dirs: DB_REDIS=true creates data/redis only" {
   export DB_REDIS=true
-  run _run_data_dir_logic "$STACK_DIR"
+  run _deploy_resolve_data_dirs
   [ "$status" -eq 0 ]
+  [ "$output" = "data/redis" ]
+
+  _apply_data_dirs "$STACK_DIR"
   [ -d "$STACK_DIR/data/redis" ]
   [ ! -d "$STACK_DIR/data/postgres" ]
   [ ! -d "$STACK_DIR/data/gdrive" ]
@@ -109,25 +118,34 @@ _run_data_dir_logic() {
 
 @test "deploy data dirs: DB_NEO4J=true creates data/neo4j only" {
   export DB_NEO4J=true
-  run _run_data_dir_logic "$STACK_DIR"
+  run _deploy_resolve_data_dirs
   [ "$status" -eq 0 ]
+  [ "$output" = "data/neo4j" ]
+
+  _apply_data_dirs "$STACK_DIR"
   [ -d "$STACK_DIR/data/neo4j" ]
   [ ! -d "$STACK_DIR/data/postgres" ]
 }
 
 @test "deploy data dirs: DB_MYSQL=true creates data/mysql only" {
   export DB_MYSQL=true
-  run _run_data_dir_logic "$STACK_DIR"
+  run _deploy_resolve_data_dirs
   [ "$status" -eq 0 ]
+  [ "$output" = "data/mysql" ]
+
+  _apply_data_dirs "$STACK_DIR"
   [ -d "$STACK_DIR/data/mysql" ]
   [ ! -d "$STACK_DIR/data/postgres" ]
 }
 
-@test "deploy data dirs: multiple DB_* flags create all corresponding dirs" {
+@test "deploy data dirs: multiple DB_* flags create all corresponding dirs, no leading/double spaces" {
   export DB_POSTGRES=true
   export DB_REDIS=true
-  run _run_data_dir_logic "$STACK_DIR"
+  run _deploy_resolve_data_dirs
   [ "$status" -eq 0 ]
+  [ "$output" = "data/postgres data/redis" ]
+
+  _apply_data_dirs "$STACK_DIR"
   [ -d "$STACK_DIR/data/postgres" ]
   [ -d "$STACK_DIR/data/redis" ]
   [ ! -d "$STACK_DIR/data/gdrive" ]
@@ -137,8 +155,11 @@ _run_data_dir_logic() {
 
 @test "deploy data dirs: no DB_* flags and STACK_DATA_DIRS unset creates only data/" {
   # All DB_* flags already unset in setup()
-  run _run_data_dir_logic "$STACK_DIR"
+  run _deploy_resolve_data_dirs
   [ "$status" -eq 0 ]
+  [ "$output" = "data" ]
+
+  _apply_data_dirs "$STACK_DIR"
   [ -d "$STACK_DIR/data" ]
   [ ! -d "$STACK_DIR/data/postgres" ]
   [ ! -d "$STACK_DIR/data/redis" ]
@@ -149,14 +170,71 @@ _run_data_dir_logic() {
 
 @test "deploy data dirs: gdrive directory is never created by default (unset STACK_DATA_DIRS)" {
   # Simulate a plain stack with all DB_* flags unset
-  run _run_data_dir_logic "$STACK_DIR"
+  run _deploy_resolve_data_dirs
   [ "$status" -eq 0 ]
+  [[ "$output" != *"gdrive"* ]]
+
+  _apply_data_dirs "$STACK_DIR"
   [ ! -d "$STACK_DIR/data/gdrive" ]
 }
 
 @test "deploy data dirs: gdrive directory not created when only DB_POSTGRES is set" {
   export DB_POSTGRES=true
-  run _run_data_dir_logic "$STACK_DIR"
+  run _deploy_resolve_data_dirs
   [ "$status" -eq 0 ]
+  [[ "$output" != *"gdrive"* ]]
+
+  _apply_data_dirs "$STACK_DIR"
   [ ! -d "$STACK_DIR/data/gdrive" ]
+}
+
+# ── services.conf → _deploy_resolve_data_dirs wiring ─────────────────────────
+# load_services_conf is how STACK_DATA_DIRS actually reaches deploy_stack in
+# production (via safe_source_config, not a manually-exported env var like
+# the tests above) — worth proving that path specifically, since it's the
+# one an operator's services.conf file actually exercises.
+
+@test "services.conf: STACK_DATA_DIRS= (empty) loaded via load_services_conf suppresses all directory creation" {
+  local stack_dir="$TEST_TMP/stacks/confstack"
+  mkdir -p "$stack_dir"
+  cat > "$stack_dir/services.conf" <<'EOF'
+STACK_DATA_DIRS=
+EOF
+
+  unset STACK_DATA_DIRS
+  load_services_conf "$stack_dir"
+
+  run _deploy_resolve_data_dirs
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "services.conf: STACK_DATA_DIRS=volumes/app loaded via load_services_conf creates only that path" {
+  local stack_dir="$TEST_TMP/stacks/confstack2"
+  mkdir -p "$stack_dir"
+  cat > "$stack_dir/services.conf" <<'EOF'
+STACK_DATA_DIRS=volumes/app
+EOF
+
+  unset STACK_DATA_DIRS
+  load_services_conf "$stack_dir"
+
+  run _deploy_resolve_data_dirs
+  [ "$status" -eq 0 ]
+  [ "$output" = "volumes/app" ]
+}
+
+@test "services.conf: DB_POSTGRES=true loaded via load_services_conf derives data/postgres" {
+  local stack_dir="$TEST_TMP/stacks/confstack3"
+  mkdir -p "$stack_dir"
+  cat > "$stack_dir/services.conf" <<'EOF'
+DB_POSTGRES=true
+EOF
+
+  unset STACK_DATA_DIRS DB_POSTGRES
+  load_services_conf "$stack_dir"
+
+  run _deploy_resolve_data_dirs
+  [ "$status" -eq 0 ]
+  [ "$output" = "data/postgres" ]
 }


### PR DESCRIPTION
## What

Follow-up to #419 (which fixed #417 and already merged). The automated review on #419 left **CONCERNS** with three points; this PR addresses all three.

## Review feedback addressed

1. **⚠️ Tests duplicated production logic verbatim instead of calling real code** (`tests/test_deploy_data_dirs.bats:36`) — the review noted the test suite's `_run_data_dir_logic` helper was "a direct copy of the logic in deploy_stack" with a comment acknowledging "if the implementation changes, update this copy to match" — a real drift risk.

   Fix: extracted the STACK_DATA_DIRS/DB_* resolution into a standalone `_deploy_resolve_data_dirs` function in `lib/deploy.sh`, which `deploy_stack` now calls. The test suite calls the same real function directly — no copy. Also added tests exercising the actual `load_services_conf` → `_deploy_resolve_data_dirs` wiring (i.e. via a real `services.conf` file, not just a manually-exported env var), since that's the path an operator's config actually goes through.

2. **⚠️ `STACK_DATA_DIRS` opt-out undocumented in `services.conf.template`** (`templates/services.conf.template:44`) — the original bug report said the override was undiscoverable short of reading source; the fix addressed the runtime behavior but not the docs gap.

   Fix: added a "Data Directories" section to the template documenting both forms — an explicit list (`STACK_DATA_DIRS="data/uploads data/cache"`) and the empty opt-out (`STACK_DATA_DIRS=`), with a one-line explanation of when to use the opt-out (root-owned or externally-managed data dirs).

3. **🧹 Unquoted `$data_dirs` in the for loop / leading-space latent fragility** (`lib/deploy.sh:219`) — the review noted the DB_*-derived string-concatenation (`data_dirs="$data_dirs data/postgres"` starting from `""`) leaves a leading space, harmless today only because `for dir in $data_dirs` word-splits it away.

   Fix: `_deploy_resolve_data_dirs` builds the DB_*-derived list via a bash array (`dirs+=(...)`) and joins with `"${dirs[*]}"`, which has no leading space by construction. No behavior change for any input that worked before.

## Test plan
- [x] `tests/test_deploy_data_dirs.bats` rewritten: original 11 cases now assert against `_deploy_resolve_data_dirs`'s actual output (not just directory side-effects) and call the real function; added 3 new cases proving the `services.conf` → `load_services_conf` → resolver path specifically (the earlier "dry-run end-to-end" approach I tried first turned out to be vacuous — `deploy_stack --dry-run` never actually calls `mkdir`, so I replaced it with this more meaningful integration point).
- [x] `shellcheck -s bash strut` and `find lib -name '*.sh' | xargs shellcheck -s bash` (CI's exact commands) — clean.
- [x] Full `bats tests/` suite: same 4 pre-existing environmental failures as the `main` baseline (Docker daemon down for `doctor --json`, `age`/`gpg` backend detection) — no regressions, all touched/new tests green (14/14 in the rewritten file).

Addresses the review feedback on #419.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TAzX3TwkCPkFT1uGxNP7GH)_