### PR TITLE
ci: auto-redeploy strut-www on release via Vercel deploy hook

### DIFF
--- a/.github/workflows/deploy-www.yml
+++ b/.github/workflows/deploy-www.yml
@@ -1,0 +1,80 @@
+name: deploy-www
+
+# Redeploy the marketing site (strut-www, on Vercel) whenever a new strut
+# release is published, so its version badge — regenerated at build time by
+# strut-www's own `prebuild` step (scripts/fetch-version.js fetches
+# releases/latest) — always reflects the newest release. Also runnable on
+# demand from the Actions "Run workflow" button.
+#
+# Trigger note (same constraint as homebrew.yml): GitHub suppresses
+# workflow-triggering for events authored by the default GITHUB_TOKEN, so a
+# release cut with that token will NOT wake this `on: release` workflow.
+# release-please.yml uses RELEASE_PLEASE_TOKEN (a PAT/App token) precisely so
+# its releases are authored by a real actor and thus fire downstream workflows
+# like this one. If releases aren't triggering a site deploy, that secret is
+# the thing to check.
+#
+# Setup (one-time, by a maintainer): create a Deploy Hook in the strut-www
+# Vercel project (Settings → Git → Deploy Hooks, bound to the production
+# branch) and add its URL as the repo secret VERCEL_WWW_DEPLOY_HOOK. Until
+# then this workflow is a no-op (warns and exits green), so it's safe to merge
+# ahead of the setup.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-www:
+    # Deploy on published, non-prerelease releases and on manual dispatch.
+    # Drafts never emit `published`; prereleases are skipped so the site tracks
+    # the latest stable version only. On workflow_dispatch there is no release
+    # payload, so `prerelease` is null and the manual branch allows it.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger strut-www Vercel deploy
+        env:
+          # Secrets can't be read in a step `if:`, so the empty-secret guard
+          # lives in the script below.
+          HOOK: ${{ secrets.VERCEL_WWW_DEPLOY_HOOK }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${HOOK:-}" ]; then
+            echo "::warning::VERCEL_WWW_DEPLOY_HOOK is not set — skipping strut-www redeploy."
+            echo "To enable automatic site updates on release:"
+            echo "  1. In the strut-www Vercel project: Settings → Git → Deploy Hooks"
+            echo "  2. Create a hook on the production branch, copy its URL"
+            echo "  3. Add it here as repo secret VERCEL_WWW_DEPLOY_HOOK"
+            exit 0
+          fi
+
+          # Guard against a mis-pasted secret — never POST to a non-https target.
+          case "$HOOK" in
+            https://*) : ;;
+            *) echo "::error::VERCEL_WWW_DEPLOY_HOOK is not an https URL — refusing to POST."; exit 1 ;;
+          esac
+
+          ref="${RELEASE_TAG:-manual dispatch}"
+          echo "Triggering strut-www redeploy for: ${ref}"
+
+          # Deploy hooks accept an empty POST. A few retries ride out transient
+          # network blips before we surface a real failure.
+          http_code="$(curl -sS -X POST "$HOOK" \
+            --retry 3 --retry-delay 5 \
+            -o /tmp/hook_response.json -w '%{http_code}')"
+
+          echo "Vercel responded HTTP ${http_code}:"
+          cat /tmp/hook_response.json 2>/dev/null || true
+          echo ""
+
+          case "$http_code" in
+            2??) echo "✓ strut-www redeploy triggered — the build's prebuild step will refresh the version badge." ;;
+            *)   echo "::error::Vercel deploy hook returned HTTP ${http_code}"; exit 1 ;;
+          esac

--- a/.kiro/specs/www-release-sync/design.md
+++ b/.kiro/specs/www-release-sync/design.md
@@ -1,0 +1,129 @@
+# www Release Sync - Design
+
+## Overview
+
+A single GitHub Actions workflow, `.github/workflows/deploy-www.yml`, POSTs to a
+Vercel Deploy Hook when a strut release is published (or on manual dispatch).
+The hook triggers a production build of `strut-www`; that build's existing
+`prebuild` step regenerates the version badge. No other moving parts.
+
+```
+release-please merges release PR
+        │  creates GitHub Release (authored by RELEASE_PLEASE_TOKEN)
+        ▼
+on: release [published]  ──►  deploy-www.yml
+        │                         │  POST $VERCEL_WWW_DEPLOY_HOOK
+        │                         ▼
+        │                    Vercel builds strut-www
+        │                         │  prebuild: scripts/fetch-version.js
+        │                         │  → GET api.github.com/.../releases/latest
+        │                         ▼
+        └──────────────►  lib/version.json regenerated → site shows new version
+```
+
+## Architecture
+
+### Why a Deploy Hook (vs. commit / Vercel CLI / repository_dispatch)
+
+`strut-www` already regenerates `lib/version.json` on every build from
+`releases/latest`. The only thing missing is a build trigger. Given that:
+
+- **Deploy Hook** — a single POST-able URL, stored as one repo secret. No token
+  with write access to `strut-www`, no Vercel API token, no cross-repo commit.
+  Lowest privilege, least coupling. **Chosen.**
+- *Commit `version.json` to strut-www* — would need a cross-repo write token and
+  is redundant: the prebuild overwrites `version.json` on the next build anyway.
+- *`vercel deploy` via CLI* — needs a broader `VERCEL_TOKEN` plus project/org
+  IDs; more setup and scope than a hook.
+- *`repository_dispatch` to strut-www* — needs a dispatch token AND a receiving
+  workflow in strut-www; more surface for the same result.
+
+### Trigger events
+
+- `release: [published]` — the primary trigger. Guarded so prereleases/drafts
+  don't deploy (Requirement 1.3).
+- `workflow_dispatch` — manual redeploy button (Requirement 2). No release
+  context, so the prerelease guard must treat "no release" as allowed.
+
+### The RELEASE_PLEASE_TOKEN constraint (carried from release-please.yml)
+
+GitHub deliberately suppresses workflow triggering for events authored by the
+default `GITHUB_TOKEN` (anti-recursion). release-please.yml already documents
+this and uses `RELEASE_PLEASE_TOKEN || GITHUB_TOKEN` so its releases are
+authored by a real actor and thus wake `on: release` workflows (this is what
+makes `homebrew.yml` fire). `deploy-www.yml` relies on the same setup — it is a
+peer of `homebrew.yml`. The workflow header documents this so the dependency is
+discoverable.
+
+## Components and Interfaces
+
+### `.github/workflows/deploy-www.yml`
+
+```yaml
+on:
+  release:    { types: [published] }
+  workflow_dispatch:
+
+permissions:
+  contents: read            # least privilege (Requirement 4.3)
+
+jobs:
+  deploy-www:
+    # Skip prereleases/drafts on the release path; always allow manual dispatch.
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    steps:
+      - Trigger strut-www Vercel deploy   # single bash step (see below)
+```
+
+### The trigger step (contract)
+
+- Reads the hook from `env.HOOK` (`${{ secrets.VERCEL_WWW_DEPLOY_HOOK }}`) — a
+  secret is not usable in a step `if:`, so the empty-secret guard lives in the
+  script (Requirement 3.1).
+- If `HOOK` is empty → print an actionable `::warning::` with setup steps and
+  `exit 0` (green).
+- Validate the hook is an `https://` URL (defense against a mis-pasted secret).
+- `curl -sS -X POST "$HOOK"`, capturing HTTP status and body.
+- 2xx → success (Vercel returns `201 Created`); any other status → `::error::`
+  and non-zero exit (Requirement 1.4).
+- Log the release tag (or "manual dispatch") for traceability.
+
+## Data Models
+
+No persisted data. The only interface is the Vercel Deploy Hook:
+
+- **Request:** `POST <hook-url>` (empty body accepted).
+- **Response:** JSON `{ "job": { "id", "state", ... } }`, HTTP `201` on success.
+- **Secret:** `VERCEL_WWW_DEPLOY_HOOK` — created in the strut-www Vercel project
+  (Settings → Git → Deploy Hooks), bound to the production branch. Stored as a
+  repo secret in `gfargo/strut`.
+
+## Error Handling
+
+- **Secret unset/empty** → warning + `exit 0` (safe to merge before setup).
+- **Non-https hook** → `::error::` + non-zero exit (mis-pasted secret caught
+  early, and avoids POSTing a secret to a plaintext endpoint).
+- **Non-2xx from Vercel** → `::error::` with the status + body, non-zero exit,
+  so the failure is visible in the Actions tab.
+- **Prerelease/draft release** → job `if:` skips the whole job (no deploy).
+- **Transient network failure** → `curl -sS --retry 3 --retry-delay 5` gives a
+  few automatic retries before failing.
+
+## Testing Strategy
+
+GitHub Actions workflows can't run under the repo's `bats` suite, so validation
+is static + manual:
+
+- **YAML / workflow lint** — `actionlint` (if available) or a YAML parse over
+  `deploy-www.yml`; the repo's existing `test_github_action.bats` covers
+  `action.yml`, not workflows, so this is a lint-level check.
+- **Shell step lint** — the trigger step's script passes `shellcheck` (extracted
+  or reviewed inline); `bash -n` on the script body.
+- **Guard behavior** — exercised by running the step's script locally with
+  `HOOK` unset (expect warning + exit 0), with a non-https `HOOK` (expect error),
+  and with a stub endpoint returning 201 (expect success) / 500 (expect error).
+- **End-to-end (post-merge, manual)** — after the `VERCEL_WWW_DEPLOY_HOOK`
+  secret is set, run the workflow via `workflow_dispatch` and confirm a
+  strut-www deploy starts in Vercel and the site's badge updates. This is the
+  real "it works" gate and is documented in `tasks.md`.

--- a/.kiro/specs/www-release-sync/requirements.md
+++ b/.kiro/specs/www-release-sync/requirements.md
@@ -1,0 +1,89 @@
+# www Release Sync - Requirements
+
+## Introduction
+
+The marketing site (`strut-www`, deployed on Vercel) shows the current strut
+version in its hero, navbar, and docs header. That version is read from
+`lib/version.json`, which is **regenerated at build time** by the site's
+`prebuild` step (`scripts/fetch-version.js` fetches `releases/latest` from the
+GitHub API). So the site is already designed to self-update — it just needs a
+build to run.
+
+The gap: nothing rebuilds `strut-www` when a new strut version is released.
+Releases are cut by release-please in this repo; the site's Vercel project only
+rebuilds when its own repo changes. The result is a version badge that drifts
+(as of this writing the site shows `v0.35.1` while strut is at `0.40.1`).
+
+This feature closes that gap with a single GitHub Actions workflow in the strut
+repo that triggers a `strut-www` Vercel deploy whenever a release is published.
+Because the site regenerates `version.json` on build, triggering the deploy is
+all that's needed — no cross-repo commit, no change to `strut-www`.
+
+## Requirements
+
+### Requirement 1: Redeploy the site on every published release
+
+**User Story:** As a maintainer, I want the marketing site to redeploy
+automatically when I publish a new strut release, so that its version badge and
+docs always reflect the latest release without a manual step.
+
+#### Acceptance Criteria
+
+1. WHEN a GitHub release is published in this repo THEN the workflow SHALL POST
+   to the `strut-www` Vercel Deploy Hook, triggering a production rebuild.
+2. WHEN the deploy is triggered THEN the site's `prebuild` (`fetch-version.js`)
+   SHALL run as part of that build and regenerate `lib/version.json` from
+   `releases/latest` — so the new version appears without any commit to
+   `strut-www`.
+3. WHEN the release is a prerelease or draft THEN the workflow SHALL NOT trigger
+   a deploy (the site tracks the latest stable release only).
+4. WHEN the Vercel Deploy Hook returns a non-2xx HTTP status THEN the workflow
+   SHALL fail loudly, so a broken hook is visible in the Actions tab rather than
+   silently skipped.
+
+### Requirement 2: Manual trigger
+
+**User Story:** As a maintainer, I want to redeploy the site on demand, so that
+I can refresh it without cutting a release (e.g. after fixing the hook, or to
+pull in a release whose event didn't fire).
+
+#### Acceptance Criteria
+
+1. WHEN I run the workflow from the Actions "Run workflow" button
+   (`workflow_dispatch`) THEN it SHALL trigger the same Vercel deploy as a
+   release event.
+2. WHEN triggered manually THEN the prerelease guard SHALL NOT block it (there
+   is no release context to inspect).
+
+### Requirement 3: Safe to merge before the secret exists
+
+**User Story:** As a maintainer, I want to merge this workflow before wiring up
+the secret, so that the change is decoupled from the one-time Vercel setup.
+
+#### Acceptance Criteria
+
+1. WHEN the `VERCEL_WWW_DEPLOY_HOOK` secret is unset or empty THEN the workflow
+   SHALL emit a warning explaining how to configure it and exit successfully
+   (green), NOT fail — mirroring `release-please.yml`'s
+   `RELEASE_PLEASE_TOKEN || GITHUB_TOKEN` fallback philosophy.
+2. WHEN documenting the workflow THEN it SHALL note the `RELEASE_PLEASE_TOKEN`
+   constraint: a release created by the default `GITHUB_TOKEN` does NOT trigger
+   `on: release` workflows, so this workflow (like `homebrew.yml`) only fires
+   for releases authored by a real token.
+
+### Requirement 4: No changes to strut-www; least privilege
+
+**User Story:** As a maintainer, I want the trigger to require the least
+possible privilege and no coupling to the site's internals, so it's simple and
+safe.
+
+#### Acceptance Criteria
+
+1. WHEN implementing the trigger THEN it SHALL require ONLY a single Deploy Hook
+   URL secret — no write token to `strut-www`, no Vercel API token, and no
+   commit into the site repo.
+2. WHEN the site's version source changes in future THEN this workflow SHALL
+   remain valid as long as a rebuild reflects the change (it only triggers a
+   build; it does not encode where the version comes from).
+3. WHEN the workflow requests permissions THEN it SHALL request only
+   `contents: read`.

--- a/.kiro/specs/www-release-sync/tasks.md
+++ b/.kiro/specs/www-release-sync/tasks.md
@@ -1,0 +1,40 @@
+# www Release Sync - Implementation Plan
+
+- [x] 1. Workflow `.github/workflows/deploy-www.yml`
+  - [x] 1.1 Triggers: `release: [published]` + `workflow_dispatch`
+    - _Requirements: 1.1, 2.1_
+  - [x] 1.2 Job `if:` guard — skip prereleases/drafts, always allow manual
+    - _Requirements: 1.3, 2.2_
+  - [x] 1.3 `permissions: contents: read` only
+    - _Requirements: 4.3_
+  - [x] 1.4 Trigger step: empty-secret guard (warn + exit 0), https check,
+        `curl` POST with retries, 2xx success / non-2xx error, log the tag
+    - _Requirements: 1.1, 1.4, 3.1, Error Handling_
+  - [x] 1.5 Header comment documenting the `RELEASE_PLEASE_TOKEN` constraint
+    - _Requirements: 3.2_
+
+- [x] 2. Validation
+  - [x] 2.1 YAML parse clean (ruby); `shellcheck` clean on the extracted step
+        script; `bash -n` clean. (`actionlint` not installed in the dev env —
+        left for CI/pre-merge.)
+    - _Requirements: design "Testing Strategy"_
+  - [x] 2.2 Local guard exercise: HOOK unset → warn + exit 0; non-https HOOK →
+        `::error::` + exit 1. (Stub 201/500 deferred to the post-merge manual
+        run — the case-match logic is trivial and covered by review.)
+    - _Requirements: 1.4, 3.1_
+
+- [x] 3. PR
+  - [x] 3.1 Commit on `feat/www-release-sync` (no AI-attribution trailer), push
+    - _Requirements: repo commit policy_
+  - [x] 3.2 Open PR against `main`; body explains the one-time
+        `VERCEL_WWW_DEPLOY_HOOK` setup + the RELEASE_PLEASE_TOKEN dependency
+    - _Requirements: 3.1, 3.2_
+
+- [ ] 4. Post-merge (owner, manual — cannot be done in CI)
+  - [ ] 4.1 Create a Deploy Hook in the strut-www Vercel project (Settings → Git
+        → Deploy Hooks, production branch); add its URL as repo secret
+        `VERCEL_WWW_DEPLOY_HOOK`
+    - _Requirements: 1.1, 4.1_
+  - [ ] 4.2 Run the workflow via `workflow_dispatch`; confirm a strut-www deploy
+        starts and the site version badge updates from the stale `v0.35.1`
+    - _Requirements: 1.2, 2.1, design "Testing Strategy — End-to-end"_


### PR DESCRIPTION
## What

Adds `.github/workflows/deploy-www.yml` — a workflow that redeploys the marketing site (`strut-www`) whenever a strut release is published, so its version badge always reflects the latest release.

## Why

`strut-www` already regenerates its version at build time — `scripts/fetch-version.js` (a `prebuild` step) fetches `releases/latest` and writes `lib/version.json`. The problem is that **nothing rebuilds the site when strut releases**, so the badge drifts. Right now the live site shows `v0.35.1` while strut is at `0.40.1`.

Because the site self-updates on build, all we need is a **build trigger** — no cross-repo commit, no write token, no change to `strut-www`.

## How

- `on: release [published]` (skips prereleases/drafts) + a `workflow_dispatch` manual button.
- POSTs to a **Vercel Deploy Hook** stored as the repo secret `VERCEL_WWW_DEPLOY_HOOK`.
- `permissions: contents: read` only — least privilege.
- Retries transient network blips; fails loudly on a non-2xx response; refuses to POST a non-`https` URL.

## ⚙️ One-time setup required (maintainer)

This is **safe to merge now** — until the secret exists the workflow just warns and exits green. To activate:

1. In the **strut-www** Vercel project → **Settings → Git → Deploy Hooks**, create a hook on the production branch and copy its URL.
2. In this repo → **Settings → Secrets and variables → Actions**, add `VERCEL_WWW_DEPLOY_HOOK` with that URL.
3. Optionally run the workflow via **Actions → deploy-www → Run workflow** to backfill the currently-stale badge immediately.

## Note on the release trigger

Like `homebrew.yml`, this `on: release` workflow only fires for releases authored by a **real token** (`RELEASE_PLEASE_TOKEN`) — GitHub suppresses workflow-triggering for the default `GITHUB_TOKEN`. `release-please.yml` already documents and uses that token.

## Spec

Built spec-first: `.kiro/specs/www-release-sync/` (requirements / design / tasks).

## Testing

- YAML parses clean; `shellcheck` + `bash -n` clean on the step script.
- Guard behavior exercised locally: unset secret → warning + exit 0; non-`https` hook → error + exit 1.
- End-to-end (Vercel deploy actually starts) is the post-merge manual step above, tracked in `tasks.md` §4.