### PR TITLE
fix(deploy): close the deploy/blue-green/lock/stop lifecycle-safety cluster

### DIFF
--- a/lib/cmd_deploy.sh
+++ b/lib/cmd_deploy.sh
@@ -318,15 +318,16 @@ cmd_deploy() {
   # stale locks from a previous crashed deploy.
   if [ "$skip_lock" != "true" ] && [ "$DRY_RUN" != "true" ]; then
     local _env_key="${env_name:-default}"
+    local _lock_nonce=""
     if [ "$force_unlock" = "true" ]; then
       warn "Breaking any existing deploy lock (--force-unlock)"
       lock_force_break_local "$stack" "$_env_key" || true
     fi
-    if ! lock_acquire_local "$stack" "$_env_key" "deploy"; then
+    if ! _lock_nonce=$(lock_acquire_local "$stack" "$_env_key" "deploy"); then
       if lock_is_stale_local "$stack" "$_env_key"; then
         warn "Existing deploy lock is stale (owner process dead) — auto-breaking"
         lock_force_break_local "$stack" "$_env_key" || true
-        if ! lock_acquire_local "$stack" "$_env_key" "deploy"; then
+        if ! _lock_nonce=$(lock_acquire_local "$stack" "$_env_key" "deploy"); then
           fail "Deploy lock held — aborting (could not reacquire after breaking stale lock)"
         fi
       else
@@ -336,8 +337,11 @@ cmd_deploy() {
     fi
     # Ensure lock is released no matter how we exit. Register with the
     # entrypoint's unified cleanup chain so we don't clobber other traps.
+    # The nonce ensures this cleanup only removes the lock THIS process
+    # created — if it was force-broken and re-acquired by a different
+    # deploy in the meantime, the release becomes a safe no-op (strut#383).
     if declare -F strut_register_cleanup >/dev/null; then
-      strut_register_cleanup "lock_release_local '$stack' '$_env_key'"
+      strut_register_cleanup "lock_release_local '$stack' '$_env_key' '$_lock_nonce'"
     fi
   fi
 
@@ -417,8 +421,13 @@ cmd_health() {
   # Local path: run health checks against the local Docker daemon.
   [ -f "$env_file" ] && safe_load_env "$env_file" 2>/dev/null || true  # env file may not exist for local-only health checks
   local compose_file="$stack_dir/docker-compose.yml"
+  # Blue-green stacks run under a <stack>-<env>-<color> project — target
+  # the active color, not the plain <stack>-<env> project (strut#384).
+  declare -F _bg_active_project >/dev/null || source "$LIB/deploy_blue_green.sh"
+  local bg_project
+  bg_project="$(_bg_active_project "$stack" "$env_name")"
   local compose_cmd
-  compose_cmd=$(resolve_compose_cmd "$stack" "$env_file" "$services")
+  compose_cmd=$(resolve_compose_cmd "$stack" "$env_file" "$services" "$bg_project")
 
   local health_rc=0
   health_run_all "$stack" "$compose_cmd" "$compose_file" "$json_flag" || health_rc=$?
@@ -451,8 +460,13 @@ cmd_status() {
   fi
 
   # Local path: query the local Docker daemon and show where we're looking.
+  # Blue-green stacks run under a <stack>-<env>-<color> project — target
+  # the active color, not the plain <stack>-<env> project (strut#384).
+  declare -F _bg_active_project >/dev/null || source "$LIB/deploy_blue_green.sh"
+  local bg_project
+  bg_project="$(_bg_active_project "$stack" "$env_name")"
   local compose_cmd
-  compose_cmd=$(resolve_compose_cmd "$stack" "$env_file" "$services")
+  compose_cmd=$(resolve_compose_cmd "$stack" "$env_file" "$services" "$bg_project")
   # Extract the resolved project name for a clear "looking here" message.
   local project_name
   project_name=$(echo "$compose_cmd" | grep -oE '\-\-project\-name [^ ]+' | awk '{print $2}') || true

--- a/lib/cmd_rollback.sh
+++ b/lib/cmd_rollback.sh
@@ -157,14 +157,18 @@ cmd_rollback() {
     return 0
   fi
 
-  # If the stack is in blue-green mode (state file present), delegate to
-  # the blue-green rollback path — it flips the active color back to the
+  # If the stack is in blue-green mode (per-env state file present, with a
+  # legacy per-stack fallback for deployments made before per-env state —
+  # see _bg_state_file in deploy_blue_green.sh), delegate to the
+  # blue-green rollback path — it flips the active color back to the
   # drained project. Standard rollback's image-restore flow doesn't apply
   # because the drained project is still defined with the last-known-good
   # images in its compose project namespace.
-  local bg_state_file="$stack_dir/.bluegreen"
-  if [ -f "$bg_state_file" ]; then
-    declare -F bg_rollback_stack >/dev/null || source "$LIB/deploy_blue_green.sh"
+  declare -F bg_rollback_stack >/dev/null || source "$LIB/deploy_blue_green.sh"
+  local bg_state_file bg_legacy_state_file
+  bg_state_file="$(_bg_state_file "$stack" "$env_name")"
+  bg_legacy_state_file="$stack_dir/.bluegreen"
+  if [ -f "$bg_state_file" ] || [ -f "$bg_legacy_state_file" ]; then
     bg_rollback_stack "$stack" "$env_file"
     return $?
   fi

--- a/lib/cmd_stop.sh
+++ b/lib/cmd_stop.sh
@@ -49,8 +49,16 @@ cmd_stop() {
 
   validate_env_file "$env_file"
 
+  # Blue-green stacks run under a <stack>-<env>-<color> project, not the
+  # plain <stack>-<env> one resolve_compose_cmd defaults to — without this,
+  # stop targets an empty project and reports success while the active
+  # color keeps serving (strut#384).
+  declare -F _bg_active_project >/dev/null || source "$LIB/deploy_blue_green.sh"
+  local bg_project
+  bg_project="$(_bg_active_project "$stack" "$env_name")"
+
   local compose_cmd
-  compose_cmd=$(resolve_compose_cmd "$stack" "$env_file" "$services")
+  compose_cmd=$(resolve_compose_cmd "$stack" "$env_file" "$services" "$bg_project")
 
   # Build down args
   local down_args="--remove-orphans"
@@ -59,7 +67,7 @@ cmd_stop() {
 
   # Check if this is a VPS environment and we're not on the VPS
   if [ -n "${VPS_HOST:-}" ] && ! is_running_on_vps; then
-    _stop_remote "$stack" "$env_file" "$env_name" "$services" "$down_args"
+    _stop_remote "$stack" "$env_file" "$env_name" "$services" "$remove_volumes" "$timeout"
   else
     _stop_local "$stack" "$compose_cmd" "$down_args"
   fi
@@ -86,13 +94,14 @@ _stop_local() {
   ok "Stack $stack stopped"
 }
 
-# _stop_remote <stack> <env_file> <env_name> <services> <down_args>
+# _stop_remote <stack> <env_file> <env_name> <services> <remove_volumes> <timeout>
 _stop_remote() {
   local stack="$1"
   local env_file="$2"
   local env_name="$3"
   local services="$4"
-  local down_args="$5"
+  local remove_volumes="${5:-false}"
+  local timeout="${6:-}"
 
   local vps_host="${VPS_HOST:-}"
   local vps_user="${VPS_USER:-ubuntu}"
@@ -103,10 +112,20 @@ _stop_remote() {
   local ssh_opts
   ssh_opts=$(build_ssh_opts -p "$vps_port" -k "$vps_ssh_key" --batch)
 
+  local services_flag=""
+  [ -n "$services" ] && services_flag="--services $services"
+  # --volumes/--timeout used to be silently dropped here — down_args was
+  # built by the caller but never forwarded to the remote invocation
+  # (strut#384).
+  local volumes_flag=""
+  [ "$remove_volumes" = "true" ] && volumes_flag="--volumes"
+  local timeout_flag=""
+  [ -n "$timeout" ] && timeout_flag="--timeout $timeout"
+
   if [ "${DRY_RUN:-}" = "true" ]; then
     echo ""
     echo -e "${YELLOW}[DRY-RUN] Execution plan for remote stop:${NC}"
-    run_cmd "Stop containers on VPS" ssh "$vps_user@$vps_host" "cd $deploy_dir && strut $stack stop --env $env_name"
+    run_cmd "Stop containers on VPS" ssh "$vps_user@$vps_host" "cd $deploy_dir && strut $stack stop --env $env_name $services_flag $volumes_flag $timeout_flag"
     echo ""
     echo -e "${YELLOW}[DRY-RUN] No changes made.${NC}"
     return 0
@@ -114,14 +133,11 @@ _stop_remote() {
 
   log "Stopping stack $stack on $vps_user@$vps_host..."
 
-  local services_flag=""
-  [ -n "$services" ] && services_flag="--services $services"
-
   # shellcheck disable=SC2029,SC2086
   ssh $ssh_opts "$vps_user@$vps_host" "
     set -e
     cd '$deploy_dir'
-    ./strut $stack stop --env ${env_name:-prod} $services_flag
+    ./strut $stack stop --env ${env_name:-prod} $services_flag $volumes_flag $timeout_flag
   " && ok "Stack $stack stopped on VPS" \
     || fail "Failed to stop stack on VPS — check VPS_HOST and SSH access"
 }

--- a/lib/deploy.sh
+++ b/lib/deploy.sh
@@ -334,9 +334,19 @@ deploy_stack() {
 
   ok "Existing containers stopped"
 
-  # Bring up stack
+  # Bring up stack. This step runs after the previous containers were
+  # already stopped (:327), so a failure here leaves the stack DOWN — it
+  # must never fall through to the success banner/notify_event below.
+  # Guarded explicitly (not relying on ambient `set -e`) because callers
+  # like `deploy_stack ... || _deploy_rc=$?` (cmd_deploy.sh) put this whole
+  # call on the left side of `||`, which suppresses errexit for the entire
+  # call tree per POSIX/bash semantics.
   log "[6/6] Starting services..."
-  $compose_cmd up -d --remove-orphans
+  if ! $compose_cmd up -d --remove-orphans; then
+    error "compose up failed — the stack was already stopped and is now DOWN"
+    notify_event deploy.failed stack="$stack" env="$env_name" reason="compose_up_failed"
+    return 1
+  fi
 
   echo -n "  Waiting for services to start"
   for i in $(seq 1 12); do sleep 5; echo -n "."; done

--- a/lib/deploy_blue_green.sh
+++ b/lib/deploy_blue_green.sh
@@ -303,7 +303,13 @@ _bg_swap_proxy() {
 
   # Built-in fallback: reload the new project's proxy container in place.
   # This is a no-op for routing unless the compose template is built for
-  # blue-green (pluggable upstream). The warn makes that contract visible.
+  # blue-green (pluggable upstream) — plenty of real stacks are a single
+  # app container with no nginx/caddy sidecar at all, so a failed/no-op
+  # reload here is expected, not a swap failure. Deliberately non-fatal
+  # (warn, not fail/return 1); the strut#375 guard on _bg_swap_proxy's
+  # return value is aimed at BLUE_GREEN_PROXY_HOOK, a user-supplied hook
+  # that can fail meaningfully (bad nginx config, container not ready) —
+  # see the caller in bg_deploy_stack/bg_rollback_stack.
   local proxy="${REVERSE_PROXY:-nginx}"
   local new_cmd
   new_cmd="$(resolve_compose_cmd "$stack" "$env_file" "" "$new_project")"
@@ -312,15 +318,12 @@ _bg_swap_proxy() {
   warn "  For true atomic swap, set BLUE_GREEN_PROXY_HOOK in strut.conf"
   local reload_cmd
   if reload_cmd=$(build_proxy_reload_cmd "$new_cmd" "$proxy"); then
-    if $reload_cmd 2>/dev/null; then
-      ok "$proxy reloaded on $new_project"
-    else
-      warn "$proxy reload failed (proxy may not be running yet)"
-      return 1
-    fi
+    $reload_cmd 2>/dev/null && ok "$proxy reloaded on $new_project" \
+      || warn "$proxy reload failed (proxy may not be running yet)"
   else
     warn "Unknown proxy '$proxy' — skipping reload"
   fi
+  return 0
 }
 
 # _bg_drain <seconds>

--- a/lib/deploy_blue_green.sh
+++ b/lib/deploy_blue_green.sh
@@ -12,9 +12,15 @@
 # proxy upstream, drains the old color, stops it. On health failure the
 # new color is torn down and the current color is left untouched.
 #
-# State: stacks/<stack>/.bluegreen records the currently-active color so
-# the next deploy flips to the opposite slot. A rollback reads this file
-# and flips back.
+# State: stacks/<stack>/.bluegreen.<env> records the currently-active color
+# so the next deploy of that env flips to the opposite slot. A rollback
+# reads this file and flips back. State is per-env (not per-stack) because
+# project names are per-env (<stack>-<env>-<color>) — a shared file would
+# let one env's deploy overwrite another's active color and cause an
+# in-place recreation of a live, unrelated project (strut#375). Reads fall
+# back to the old per-stack path (stacks/<stack>/.bluegreen) for
+# deployments made before this change; the first write under the new
+# scheme migrates by deleting the legacy file.
 #
 # Helpers are underscore-prefixed and intentionally small so tests can
 # stub them individually.
@@ -23,41 +29,83 @@ set -euo pipefail
 
 # ── State file ────────────────────────────────────────────────────────────────
 
-# _bg_state_file <stack>
+# _bg_state_file <stack> <env_name>
 _bg_state_file() {
+  local stack="$1" env_name="${2:-prod}"
+  local cli_root="${CLI_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+  echo "$cli_root/stacks/$stack/.bluegreen.$env_name"
+}
+
+# _bg_legacy_state_file <stack> — pre-per-env state path. Kept only for a
+# backward-compatible read fallback (_bg_read_state) and one-time migration
+# (_bg_write_state); nothing writes here anymore.
+_bg_legacy_state_file() {
   local stack="$1"
   local cli_root="${CLI_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
   echo "$cli_root/stacks/$stack/.bluegreen"
 }
 
-# _bg_read_state <stack> — echoes the current active color or empty string.
-# Parses a tiny `active_color=<blue|green>` file (not JSON, to avoid a
-# jq dependency on the fast path).
-_bg_read_state() {
-  local stack="$1"
+# _bg_resolve_state_file <stack> <env_name>
+#
+# Echoes the per-env state file path if it exists, else the legacy
+# per-stack path if THAT exists, else nothing. Shared lookup used by every
+# state reader so the fallback logic lives in exactly one place.
+_bg_resolve_state_file() {
+  local stack="$1" env_name="${2:-prod}"
   local f
-  f="$(_bg_state_file "$stack")"
-  [ -f "$f" ] || { echo ""; return 0; }
+  f="$(_bg_state_file "$stack" "$env_name")"
+  [ -f "$f" ] && { echo "$f"; return 0; }
+  f="$(_bg_legacy_state_file "$stack")"
+  [ -f "$f" ] && { echo "$f"; return 0; }
+  echo ""
+}
+
+# _bg_read_state <stack> <env_name> — echoes the current active color or
+# empty string. Parses a tiny `active_color=<blue|green>` file (not JSON,
+# to avoid a jq dependency on the fast path). Falls back to the legacy
+# per-stack file when no per-env file exists yet.
+_bg_read_state() {
+  local stack="$1" env_name="${2:-prod}"
+  local f
+  f="$(_bg_resolve_state_file "$stack" "$env_name")"
+  [ -n "$f" ] || { echo ""; return 0; }
   awk -F= '$1 == "active_color" { print $2; exit }' "$f" | tr -d '[:space:]"'
 }
 
-# _bg_write_state <stack> <color> [project]
-_bg_write_state() {
-  local stack="$1" color="$2" project="${3:-}"
+# _bg_active_project <stack> <env_name>
+#
+# Echoes the compose project name of the currently-active color, or empty
+# string if this stack/env isn't in blue-green mode. stop/status/health use
+# this to target the color actually serving traffic — the plain
+# <stack>-<env> project blue-green deploys never touch (strut#384).
+_bg_active_project() {
+  local stack="$1" env_name="${2:-prod}"
   local f
-  f="$(_bg_state_file "$stack")"
+  f="$(_bg_resolve_state_file "$stack" "$env_name")"
+  [ -n "$f" ] || { echo ""; return 0; }
+  awk -F= '$1 == "active_project" { print $2; exit }' "$f" | tr -d '[:space:]"'
+}
+
+# _bg_write_state <stack> <env_name> <color> [project]
+_bg_write_state() {
+  local stack="$1" env_name="${2:-prod}" color="$3" project="${4:-}"
+  local f
+  f="$(_bg_state_file "$stack" "$env_name")"
   mkdir -p "$(dirname "$f")"
   {
     echo "active_color=$color"
     [ -n "$project" ] && echo "active_project=$project"
     echo "updated_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   } > "$f"
+  # One-time migration: now that this env has its own state file, drop the
+  # legacy shared one so a different env can't misread it later.
+  rm -f "$(_bg_legacy_state_file "$stack")"
 }
 
-# _bg_clear_state <stack>
+# _bg_clear_state <stack> <env_name>
 _bg_clear_state() {
-  local stack="$1"
-  rm -f "$(_bg_state_file "$stack")"
+  local stack="$1" env_name="${2:-prod}"
+  rm -f "$(_bg_state_file "$stack" "$env_name")"
 }
 
 # ── Colors ────────────────────────────────────────────────────────────────────
@@ -71,15 +119,15 @@ _bg_flip_color() {
   esac
 }
 
-# _bg_pick_colors <stack>
+# _bg_pick_colors <stack> <env_name>
 #
 # Echoes two whitespace-separated tokens: "<old_color> <new_color>".
 # First deploy (no state): "none blue" — the green slot is empty, new
 # color goes to blue.
 _bg_pick_colors() {
-  local stack="$1"
+  local stack="$1" env_name="${2:-prod}"
   local current
-  current="$(_bg_read_state "$stack")"
+  current="$(_bg_read_state "$stack" "$env_name")"
   if [ -z "$current" ]; then
     echo "none blue"
   else
@@ -264,8 +312,12 @@ _bg_swap_proxy() {
   warn "  For true atomic swap, set BLUE_GREEN_PROXY_HOOK in strut.conf"
   local reload_cmd
   if reload_cmd=$(build_proxy_reload_cmd "$new_cmd" "$proxy"); then
-    $reload_cmd 2>/dev/null && ok "$proxy reloaded on $new_project" \
-      || warn "$proxy reload failed (proxy may not be running yet)"
+    if $reload_cmd 2>/dev/null; then
+      ok "$proxy reloaded on $new_project"
+    else
+      warn "$proxy reload failed (proxy may not be running yet)"
+      return 1
+    fi
   else
     warn "Unknown proxy '$proxy' — skipping reload"
   fi
@@ -328,7 +380,7 @@ bg_deploy_stack() {
 
   # Decide colors
   local pick old_color new_color
-  pick="$(_bg_pick_colors "$stack")"
+  pick="$(_bg_pick_colors "$stack" "$env_name")"
   old_color="${pick%% *}"
   new_color="${pick##* }"
 
@@ -350,14 +402,14 @@ bg_deploy_stack() {
   log "Health timeout: ${BLUE_GREEN_HEALTH_TIMEOUT:-30}s | Drain: ${BLUE_GREEN_DRAIN:-60}s"
 
   # Pre-flight
-  log "[1/9] Pre-flight checks..."
+  log "[1/8] Pre-flight checks..."
   require_cmd docker "Install with: curl -fsSL https://get.docker.com | bash"
   docker compose version &>/dev/null || fail "Docker Compose plugin not found"
   ok "Pre-flight checks passed"
 
   # Pre-deploy validation (reuse standard path's contract)
   if [ "${SKIP_VALIDATION:-false}" != "true" ] && [ "${PRE_DEPLOY_VALIDATE:-true}" = "true" ]; then
-    log "[2/9] Pre-deploy validation..."
+    log "[2/8] Pre-deploy validation..."
   fi
   deploy_run_pre_deploy_validation "$stack" "$stack_dir" "$env_file" "$env_name"
 
@@ -370,18 +422,18 @@ bg_deploy_stack() {
     run_cmd "Start $new_color project"   $new_cmd up -d --remove-orphans
     run_cmd "Wait for $new_color health (timeout: ${BLUE_GREEN_HEALTH_TIMEOUT:-30}s)" echo "probe"
     run_cmd "Swap proxy $old_color → $new_color" echo "swap"
+    run_cmd "Mark $new_color as active" echo "write state"
     run_cmd "Drain $old_color (${BLUE_GREEN_DRAIN:-60}s)" echo "drain"
     if [ "$old_color" != "none" ]; then
       run_cmd "Stop $old_color project" $old_cmd stop
     fi
-    run_cmd "Mark $new_color as active" echo "write state"
     echo ""
     echo -e "${YELLOW}[DRY-RUN] No changes made.${NC}"
     return 0
   fi
 
   # Registry auth (shared with standard deploy).
-  log "[3/9] Authenticating with registry..."
+  log "[3/8] Authenticating with registry..."
   registry_login
 
   # Save rollback snapshot of the **current** color before we touch anything.
@@ -393,11 +445,11 @@ bg_deploy_stack() {
   fi
 
   # Stand up green
-  log "[4/9] Starting $new_color project alongside $old_color..."
+  log "[4/8] Starting $new_color project alongside $old_color..."
   _bg_start_color "$new_cmd"
 
   # Health gate
-  log "[5/9] Waiting for $new_color health..."
+  log "[5/8] Waiting for $new_color health..."
   if ! _bg_wait_healthy "$stack_dir" "$new_cmd" "$compose_file" "${BLUE_GREEN_HEALTH_TIMEOUT:-30}"; then
     warn "green failed health checks — tearing down and aborting"
     _bg_teardown_failed_color "$new_cmd"
@@ -408,25 +460,34 @@ bg_deploy_stack() {
     return 1
   fi
 
-  # Swap proxy
-  log "[6/9] Swapping reverse proxy: $old_color → $new_color"
-  _bg_swap_proxy "$stack" "$old_project" "$new_project" "$env_file"
+  # Swap proxy. Guarded explicitly — an unchecked failure here used to fall
+  # through to draining/stopping the old color anyway, leaving traffic
+  # pointed at containers that had just been stopped (strut#375).
+  log "[6/8] Swapping reverse proxy: $old_color → $new_color"
+  if ! _bg_swap_proxy "$stack" "$old_project" "$new_project" "$env_file"; then
+    notify_event deploy.failed stack="$stack" env="$env_name" reason="proxy_swap_failed"
+    fail "Blue-green deploy aborted: proxy swap to $new_color failed ($old_color is still active and untouched)"
+    return 1
+  fi
+
+  # Mark active immediately after the swap succeeds, not after drain/stop
+  # below — from this point $new_color is what's actually serving traffic,
+  # so a crash or interrupt during drain/stop must not leave the state file
+  # still pointing at the old (about-to-be-stopped) color.
+  log "Marking $new_color as active"
+  _bg_write_state "$stack" "$env_name" "$new_color" "$new_project"
 
   # Drain
   if [ "$old_color" != "none" ]; then
-    log "[7/9] Draining $old_color (${BLUE_GREEN_DRAIN:-60}s)..."
+    log "[7/8] Draining $old_color (${BLUE_GREEN_DRAIN:-60}s)..."
     _bg_drain "${BLUE_GREEN_DRAIN:-60}"
 
-    log "[8/9] Stopping $old_color project..."
+    log "[8/8] Stopping $old_color project..."
     _bg_stop_color "$old_cmd"
   else
-    log "[7/9] Skipping drain (no previous color)"
-    log "[8/9] Skipping stop (no previous color)"
+    log "[7/8] Skipping drain (no previous color)"
+    log "[8/8] Skipping stop (no previous color)"
   fi
-
-  # Mark active
-  log "[9/9] Marking $new_color as active"
-  _bg_write_state "$stack" "$new_color" "$new_project"
 
   echo ""
   echo -e "${GREEN}════════════════════════════════════════════${NC}"
@@ -465,7 +526,7 @@ bg_rollback_stack() {
   env_name="$(extract_env_name "$env_file")"
 
   local current previous
-  current="$(_bg_read_state "$stack")"
+  current="$(_bg_read_state "$stack" "$env_name")"
   if [ -z "$current" ]; then
     fail "No blue-green state for $stack — use standard rollback"
     return 1
@@ -488,8 +549,8 @@ bg_rollback_stack() {
     run_cmd "Bring $previous back up"   $previous_cmd up -d --remove-orphans
     run_cmd "Wait for $previous health (timeout: ${BLUE_GREEN_HEALTH_TIMEOUT:-30}s)" echo "probe"
     run_cmd "Swap proxy $current → $previous" echo "swap"
-    run_cmd "Stop $current project"     $current_cmd stop
     run_cmd "Mark $previous active"     echo "write state"
+    run_cmd "Stop $current project"     $current_cmd stop
     echo ""
     echo -e "${YELLOW}[DRY-RUN] No changes made.${NC}"
     return 0
@@ -515,12 +576,19 @@ bg_rollback_stack() {
   fi
 
   log "Swapping proxy: $current → $previous"
-  _bg_swap_proxy "$stack" "$current_project" "$previous_project" "$env_file"
+  if ! _bg_swap_proxy "$stack" "$current_project" "$previous_project" "$env_file"; then
+    warn "  Proxy is left pointed at $current; $current has NOT been stopped"
+    fail "Blue-green rollback aborted: proxy swap to $previous failed"
+    return 1
+  fi
+
+  # Mark active immediately after the swap succeeds, before stopping
+  # $current below — same reasoning as bg_deploy_stack.
+  _bg_write_state "$stack" "$env_name" "$previous" "$previous_project"
 
   log "Stopping $current project..."
   _bg_stop_color "$current_cmd"
 
-  _bg_write_state "$stack" "$previous" "$previous_project"
   ok "Rollback complete — $previous is now active"
 
   notify_event deploy.rollback stack="$stack" env="$env_name" active_color="$previous"

--- a/lib/lock.sh
+++ b/lib/lock.sh
@@ -36,12 +36,15 @@ lock_local_dir() {
 
 _lock_write_info() {
   local dir="$1" cmd="$2"
+  local nonce="$$-$RANDOM-$RANDOM"
   {
     echo "pid=$$"
     echo "host=$(hostname 2>/dev/null || echo unknown)"
     echo "started=$(date -u +%FT%TZ)"
     echo "command=$cmd"
+    echo "nonce=$nonce"
   } > "$dir/info"
+  echo "$nonce"
 }
 
 # lock_read_info <info_file> <field>
@@ -55,7 +58,9 @@ lock_read_info() {
 # ── Acquire / release (local) ─────────────────────────────────────────────────
 
 # lock_acquire_local <stack> <env> <command>
-#   0 — acquired
+#   0 — acquired (echoes a nonce on stdout — pass it to lock_release_local
+#       so a later cleanup can't release a lock a *different* process has
+#       since acquired; see strut#383)
 #   1 — already held (prints holder to stderr)
 #   2 — filesystem error
 lock_acquire_local() {
@@ -86,13 +91,27 @@ lock_acquire_local() {
   return 1
 }
 
-# lock_release_local <stack> <env>
+# lock_release_local <stack> <env> [expected_nonce]
 #   Always returns 0. Safe to call from EXIT traps.
+#
+#   When expected_nonce is given and the lock currently held doesn't carry
+#   that nonce, the lock is left alone — it belongs to a different process
+#   than the one calling release (e.g. a deploy whose lock was force-broken
+#   and re-acquired by another deploy finishes and its EXIT cleanup fires;
+#   without this check it would delete the second deploy's live lock).
 lock_release_local() {
-  local stack="$1" env="${2:-default}"
+  local stack="$1" env="${2:-default}" expected_nonce="${3:-}"
   local dir
   dir=$(lock_local_dir "$stack" "$env")
-  [ -d "$dir" ] && rm -rf "$dir"
+  [ -d "$dir" ] || return 0
+
+  if [ -n "$expected_nonce" ]; then
+    local current_nonce
+    current_nonce=$(lock_read_info "$dir/info" nonce 2>/dev/null || echo "")
+    [ "$current_nonce" = "$expected_nonce" ] || return 0
+  fi
+
+  rm -rf "$dir"
   return 0
 }
 
@@ -117,14 +136,20 @@ lock_is_stale_local() {
   local current_host
   current_host=$(hostname 2>/dev/null || echo unknown)
 
-  # Same host + pid dead → definitely stale
+  # Same host + verifiable pid: this is authoritative, skip the age
+  # fallback entirely. A live long-running deploy (large image pull,
+  # --no-cache rebuild, blue-green drain/health poll) routinely exceeds
+  # STRUT_LOCK_STALE_SECONDS — the age check must never override a pid
+  # we can actually confirm is still running (strut#383).
   if [ "$host" = "$current_host" ] && [ -n "$pid" ]; then
-    if ! kill -0 "$pid" 2>/dev/null; then
-      return 0
+    if kill -0 "$pid" 2>/dev/null; then
+      return 1
     fi
+    return 0
   fi
 
-  # Age-based fallback (works for cross-host locks too)
+  # Age-based fallback — only reached when the pid can't be verified
+  # locally (cross-host lock, or missing pid in the info file).
   if [ -n "$started" ]; then
     local started_epoch now age
     # BSD date (macOS) uses -j -f; GNU date uses -d. Try both.

--- a/tests/integration/test_blue_green_health_gate.bats
+++ b/tests/integration/test_blue_green_health_gate.bats
@@ -129,7 +129,7 @@ setup() {
   done
   [ "$code" = "200" ]
 
-  [ "$(_bg_read_state "$BG_STACK")" = "blue" ]
+  [ "$(_bg_read_state "$BG_STACK" "$BG_ENV")" = "blue" ]
 }
 
 # ── 2. Crash-looping green is rejected: blue stays up, green is torn down ─────
@@ -168,7 +168,7 @@ EOF
   [ -z "$output" ]
 
   # State never flipped — blue is still the active color.
-  [ "$(_bg_read_state "$BG_STACK")" = "blue" ]
+  [ "$(_bg_read_state "$BG_STACK" "$BG_ENV")" = "blue" ]
 
   # Blue is still serving (the closest proxy-observable signal available
   # without wiring an actual reverse proxy in this minimal fixture).
@@ -224,7 +224,7 @@ EOF
   rm -rf "$hook_dir"
 
   # State flipped from blue to green.
-  [ "$(_bg_read_state "$BG_STACK")" = "green" ]
+  [ "$(_bg_read_state "$BG_STACK" "$BG_ENV")" = "green" ]
 
   # Green is live and serving.
   run docker ps \

--- a/tests/test_cmd_deploy.bats
+++ b/tests/test_cmd_deploy.bats
@@ -199,6 +199,51 @@ EOF
   [[ "$output" == *"ps"* ]]
 }
 
+# strut#384: status/health/stop used to always target the plain <stack>-<env>
+# project, which blue-green deploys never use — after a blue-green deploy
+# they'd silently query/act on an empty project.
+
+@test "cmd_status: passes the blue-green active project as resolve_compose_cmd's override" {
+  # _bg_active_project (deploy_blue_green.sh) resolves the state file path
+  # from CLI_ROOT, independent of CMD_STACK_DIR — point it at the fixture dir.
+  export CLI_ROOT="$TEST_TMP"
+  echo "active_color=green" > "$TEST_TMP/stacks/test-stack/.bluegreen.test"
+  echo "active_project=test-stack-test-green" >> "$TEST_TMP/stacks/test-stack/.bluegreen.test"
+
+  # Must expand to an invocable command (echo COMPOSE-style) — resolve_compose_cmd's
+  # result is executed directly as `$compose_cmd ps` by cmd_status.
+  resolve_compose_cmd() { echo "echo PROJECT_OVERRIDE=$4"; }
+  export -f resolve_compose_cmd
+
+  run cmd_status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PROJECT_OVERRIDE=test-stack-test-green"* ]]
+}
+
+@test "cmd_status: no blue-green state → resolve_compose_cmd gets an empty project override" {
+  resolve_compose_cmd() { echo "echo PROJECT_OVERRIDE=[$4]"; }
+  export -f resolve_compose_cmd
+
+  run cmd_status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PROJECT_OVERRIDE=[]"* ]]
+}
+
+@test "cmd_health: passes the blue-green active project as resolve_compose_cmd's override" {
+  export CLI_ROOT="$TEST_TMP"
+  echo "active_color=green" > "$TEST_TMP/stacks/test-stack/.bluegreen.test"
+  echo "active_project=test-stack-test-green" >> "$TEST_TMP/stacks/test-stack/.bluegreen.test"
+
+  should_dispatch_remote() { return 1; }
+  resolve_compose_cmd() { echo "echo PROJECT_OVERRIDE=$4"; }
+  health_run_all() { echo "health_run_all:$2"; }
+  export -f should_dispatch_remote resolve_compose_cmd health_run_all
+
+  run cmd_health
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"health_run_all:echo PROJECT_OVERRIDE=test-stack-test-green"* ]]
+}
+
 @test "cmd_prune: dispatches to docker_prune" {
   run cmd_prune
   [ "$status" -eq 0 ]

--- a/tests/test_cmd_rollback.bats
+++ b/tests/test_cmd_rollback.bats
@@ -9,6 +9,13 @@ setup() {
   load_utils
   source "$CLI_ROOT/lib/output.sh"
   source "$CLI_ROOT/lib/rollback.sh"
+  # Real deploy_blue_green.sh (not a stub) so _bg_state_file/_bg_active_project
+  # are genuinely defined — mirrors the entrypoint, which always sources this
+  # before cmd_rollback.sh. Tests that stub bg_rollback_stack must do so
+  # AFTER this source call, or cmd_rollback.sh's own `declare -F
+  # bg_rollback_stack || source ...` guard will see the stub, skip sourcing,
+  # and leave _bg_state_file undefined.
+  source "$CLI_ROOT/lib/deploy_blue_green.sh"
   source "$CLI_ROOT/lib/cmd_rollback.sh"
 
   export LIB="$CLI_ROOT/lib"
@@ -152,4 +159,49 @@ EOF
   run cat "$hist_file"
   [[ "$output" == *'"action":"rollback"'* ]]
   [[ "$output" == *'"outcome":"success"'* ]]
+}
+
+# ── Blue-green dispatch (strut#375) ──────────────────────────────────────────
+# cmd_rollback used to check only the legacy per-stack `.bluegreen` file,
+# ignoring env — a stack blue-green-deployed under a different env than the
+# one being rolled back could misdetect (or miss) blue-green mode.
+
+@test "cmd_rollback: per-env blue-green state file dispatches to bg_rollback_stack" {
+  should_dispatch_remote() { return 1; }
+  bg_rollback_stack() { echo "bg_rollback_stack $*"; return 0; }
+  export -f should_dispatch_remote bg_rollback_stack
+
+  echo "active_color=blue" > "$TEST_TMP/stacks/test-stack/.bluegreen.test"
+
+  _set_rollback_ctx ""
+
+  run cmd_rollback
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bg_rollback_stack test-stack"* ]]
+}
+
+@test "cmd_rollback: legacy per-stack state file (pre-migration) still dispatches to bg_rollback_stack" {
+  should_dispatch_remote() { return 1; }
+  bg_rollback_stack() { echo "bg_rollback_stack $*"; return 0; }
+  export -f should_dispatch_remote bg_rollback_stack
+
+  echo "active_color=blue" > "$TEST_TMP/stacks/test-stack/.bluegreen"
+
+  _set_rollback_ctx ""
+
+  run cmd_rollback
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bg_rollback_stack test-stack"* ]]
+}
+
+@test "cmd_rollback: no blue-green state file uses the standard restore path" {
+  should_dispatch_remote() { return 1; }
+  bg_rollback_stack() { echo "SHOULD_NOT_BE_CALLED"; return 0; }
+  rollback_get_latest_snapshot() { echo ""; }
+  export -f should_dispatch_remote bg_rollback_stack rollback_get_latest_snapshot
+
+  _set_rollback_ctx ""
+
+  run cmd_rollback
+  [[ "$output" != *"SHOULD_NOT_BE_CALLED"* ]]
 }

--- a/tests/test_cmd_status_remote.bats
+++ b/tests/test_cmd_status_remote.bats
@@ -16,6 +16,10 @@ setup() {
   source "$CLI_ROOT/lib/cmd_deploy.sh"
   source "$CLI_ROOT/lib/cmd_logs.sh"
 
+  # LIB must point at the real repo (deploy_blue_green.sh lives there) —
+  # capture it before CLI_ROOT is repointed at the test fixture dir below.
+  export LIB="$CLI_ROOT/lib"
+
   # Create a minimal test stack + env file
   mkdir -p "$TEST_TMP/stacks/test-stack"
   echo "services:" > "$TEST_TMP/stacks/test-stack/docker-compose.yml"

--- a/tests/test_cmd_stop.bats
+++ b/tests/test_cmd_stop.bats
@@ -12,6 +12,10 @@ setup() {
   source "$CLI_ROOT/lib/docker.sh"
   source "$CLI_ROOT/lib/cmd_stop.sh"
 
+  # LIB must point at the real repo (deploy_blue_green.sh lives there) —
+  # capture it before CLI_ROOT is repointed at the test fixture dir below.
+  export LIB="$CLI_ROOT/lib"
+
   # Create a minimal test stack
   mkdir -p "$TEST_TMP/stacks/test-stack"
   echo "services:" > "$TEST_TMP/stacks/test-stack/docker-compose.yml"
@@ -116,4 +120,80 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" == *"standby-host.internal"* ]]
   [[ "$output" != *"primary-host.internal"* ]]
+}
+
+# strut#384: stop used to always target the plain <stack>-<env> project,
+# which blue-green deploys never use — after a blue-green deploy `stop`
+# would down an empty project and report success while the active color
+# kept serving.
+
+@test "cmd_stop: targets the blue-green active project when one is deployed" {
+  cat > "$TEST_TMP/.test.env" <<'EOF'
+VPS_HOST=
+EOF
+  echo "active_color=green" > "$TEST_TMP/stacks/test-stack/.bluegreen.test"
+  echo "active_project=test-stack-test-green" >> "$TEST_TMP/stacks/test-stack/.bluegreen.test"
+
+  resolve_compose_cmd() { echo "echo PROJECT=$4"; }
+  export -f resolve_compose_cmd
+  _set_stop_ctx "$TEST_TMP/.test.env"
+
+  run cmd_stop
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PROJECT=test-stack-test-green"* ]]
+}
+
+@test "cmd_stop: no blue-green state → resolve_compose_cmd gets an empty project override" {
+  cat > "$TEST_TMP/.test.env" <<'EOF'
+VPS_HOST=
+EOF
+  resolve_compose_cmd() { echo "echo PROJECT=[$4]"; }
+  export -f resolve_compose_cmd
+  _set_stop_ctx "$TEST_TMP/.test.env"
+
+  run cmd_stop
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PROJECT=[]"* ]]
+}
+
+# strut#384: remote stop built its down_args (--volumes/--timeout) but never
+# forwarded them to the SSH'd remote invocation — a VPS-mapped `stop
+# --volumes` silently dropped both flags.
+
+@test "cmd_stop: remote dispatch forwards --volumes and --timeout to the SSH command" {
+  cat > "$TEST_TMP/.test.env" <<'EOF'
+VPS_HOST=vps.example.com
+EOF
+  is_running_on_vps() { return 1; }
+  export -f is_running_on_vps
+  resolve_deploy_dir() { echo "/home/ubuntu/strut"; }
+  build_ssh_opts() { echo "-o BatchMode=yes"; }
+  export -f resolve_deploy_dir build_ssh_opts
+  ssh() { echo "ssh $*"; return 0; }
+  export -f ssh
+  _set_stop_ctx "$TEST_TMP/.test.env"
+
+  run cmd_stop --volumes --timeout 45
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--volumes"* ]]
+  [[ "$output" == *"--timeout 45"* ]]
+}
+
+@test "cmd_stop: remote dry-run plan shows --volumes and --timeout" {
+  cat > "$TEST_TMP/.test.env" <<'EOF'
+VPS_HOST=vps.example.com
+EOF
+  export DRY_RUN=true
+  is_running_on_vps() { return 1; }
+  export -f is_running_on_vps
+  resolve_deploy_dir() { echo "/home/ubuntu/strut"; }
+  build_ssh_opts() { echo "-o BatchMode=yes"; }
+  export -f resolve_deploy_dir build_ssh_opts
+  _set_stop_ctx "$TEST_TMP/.test.env"
+
+  run cmd_stop --volumes --timeout 45
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY-RUN"* ]]
+  [[ "$output" == *"--volumes"* ]]
+  [[ "$output" == *"--timeout 45"* ]]
 }

--- a/tests/test_deploy_blue_green.bats
+++ b/tests/test_deploy_blue_green.bats
@@ -481,18 +481,19 @@ EOF
   [[ "$output" == *"did not define"* ]] || [[ "$output" == *"bluegreen_proxy_swap"* ]]
 }
 
-# strut#375: the built-in (no-hook) fallback used to always return 0 even
-# when the reload command it ran failed — `warn` on the failure branch
-# always succeeds, so the `&&`/`||` chain's own exit status (the function's
-# implicit return value) was never actually the reload's.
-@test "_bg_swap_proxy: built-in fallback returns failure when the reload command fails" {
+# The built-in (no-hook) fallback stays non-fatal on a failed/no-op reload
+# by design — plenty of real stacks are a single app container with no
+# nginx/caddy sidecar to reload at all, so this must not abort the deploy.
+# The strut#375 swap guard targets BLUE_GREEN_PROXY_HOOK (see the hook
+# tests above), a user-supplied hook that can fail meaningfully.
+@test "_bg_swap_proxy: built-in fallback stays non-fatal when the reload command fails" {
   unset BLUE_GREEN_PROXY_HOOK
   build_proxy_reload_cmd() { echo "reload-cmd"; return 0; }
   reload-cmd() { return 1; }
   export -f build_proxy_reload_cmd reload-cmd
 
   run _bg_swap_proxy "demo" "demo-test-blue" "demo-test-green" "$ENV_FILE"
-  [ "$status" -ne 0 ]
+  [ "$status" -eq 0 ]
 }
 
 @test "_bg_swap_proxy: built-in fallback succeeds when the reload command succeeds" {

--- a/tests/test_deploy_blue_green.bats
+++ b/tests/test_deploy_blue_green.bats
@@ -100,10 +100,57 @@ _record() { echo "$*" >> "$CALLS_FILE"; }
 }
 
 @test "_bg_write_state + _bg_read_state: round-trips the active color" {
-  _bg_write_state "$STACK" "green" "demo-test-green"
-  run _bg_read_state "$STACK"
+  _bg_write_state "$STACK" "test" "green" "demo-test-green"
+  run _bg_read_state "$STACK" "test"
   [ "$status" -eq 0 ]
   [ "$output" = "green" ]
+}
+
+# strut#375: state used to be keyed per-stack, not per-env — a prod deploy
+# and a staging deploy of the same stack would overwrite each other's
+# active color and could trigger an in-place recreation of a live project.
+@test "_bg_state_file: prod and staging get distinct per-env state files" {
+  [ "$(_bg_state_file "$STACK" "prod")" != "$(_bg_state_file "$STACK" "staging")" ]
+}
+
+@test "_bg_write_state + _bg_read_state: prod and staging don't clobber each other" {
+  _bg_write_state "$STACK" "prod" "blue" "demo-prod-blue"
+  _bg_write_state "$STACK" "staging" "green" "demo-staging-green"
+
+  [ "$(_bg_read_state "$STACK" "prod")" = "blue" ]
+  [ "$(_bg_read_state "$STACK" "staging")" = "green" ]
+
+  # A subsequent prod deploy still sees prod's own color, unaffected by
+  # staging having been written in between.
+  _bg_write_state "$STACK" "staging" "blue" "demo-staging-blue"
+  [ "$(_bg_read_state "$STACK" "prod")" = "blue" ]
+}
+
+@test "_bg_read_state: falls back to the legacy per-stack file when no per-env file exists" {
+  local legacy
+  legacy="$(_bg_legacy_state_file "$STACK")"
+  mkdir -p "$(dirname "$legacy")"
+  echo "active_color=green" > "$legacy"
+
+  [ "$(_bg_read_state "$STACK" "prod")" = "green" ]
+}
+
+@test "_bg_write_state: migrates away from the legacy file once a per-env file is written" {
+  local legacy
+  legacy="$(_bg_legacy_state_file "$STACK")"
+  mkdir -p "$(dirname "$legacy")"
+  echo "active_color=green" > "$legacy"
+
+  _bg_write_state "$STACK" "prod" "blue" "demo-prod-blue"
+
+  [ ! -f "$legacy" ]
+  [ "$(_bg_read_state "$STACK" "prod")" = "blue" ]
+}
+
+@test "_bg_active_project: echoes the active_project field, empty when no state" {
+  [ -z "$(_bg_active_project "$STACK" "prod")" ]
+  _bg_write_state "$STACK" "prod" "green" "demo-prod-green"
+  [ "$(_bg_active_project "$STACK" "prod")" = "demo-prod-green" ]
 }
 
 @test "_bg_flip_color: blue ↔ green, unknown → blue" {
@@ -114,21 +161,21 @@ _record() { echo "$*" >> "$CALLS_FILE"; }
 }
 
 @test "_bg_pick_colors: first deploy yields 'none blue'" {
-  run _bg_pick_colors "$STACK"
+  run _bg_pick_colors "$STACK" "test"
   [ "$status" -eq 0 ]
   [ "$output" = "none blue" ]
 }
 
 @test "_bg_pick_colors: after active=blue → flips to green" {
-  _bg_write_state "$STACK" "blue" "demo-test-blue"
-  run _bg_pick_colors "$STACK"
+  _bg_write_state "$STACK" "test" "blue" "demo-test-blue"
+  run _bg_pick_colors "$STACK" "test"
   [ "$status" -eq 0 ]
   [ "$output" = "blue green" ]
 }
 
 @test "_bg_pick_colors: after active=green → flips to blue" {
-  _bg_write_state "$STACK" "green" "demo-test-green"
-  run _bg_pick_colors "$STACK"
+  _bg_write_state "$STACK" "test" "green" "demo-test-green"
+  run _bg_pick_colors "$STACK" "test"
   [ "$status" -eq 0 ]
   [ "$output" = "green blue" ]
 }
@@ -192,13 +239,13 @@ _record() { echo "$*" >> "$CALLS_FILE"; }
   ! grep -q "^stop:"  "$CALLS_FILE"
 
   # State now tracks blue
-  run _bg_read_state "$STACK"
+  run _bg_read_state "$STACK" "test"
   [ "$output" = "blue" ]
 }
 
 @test "bg_deploy_stack: second deploy flips blue → green and drains old" {
   # Seed state as if a previous deploy landed on blue.
-  _bg_write_state "$STACK" "blue" "demo-test-blue"
+  _bg_write_state "$STACK" "test" "blue" "demo-test-blue"
 
   _bg_start_color()  { _record "start:$1"; }
   _bg_wait_healthy() { _record "wait:ok"; return 0; }
@@ -225,11 +272,11 @@ _record() { echo "$*" >> "$CALLS_FILE"; }
   grep "^stop:"  "$CALLS_FILE" | grep -q "demo-test-blue"
 
   # State advances to green
-  [ "$(_bg_read_state "$STACK")" = "green" ]
+  [ "$(_bg_read_state "$STACK" "test")" = "green" ]
 }
 
 @test "bg_deploy_stack: health failure tears down green, leaves old color untouched" {
-  _bg_write_state "$STACK" "blue" "demo-test-blue"
+  _bg_write_state "$STACK" "test" "blue" "demo-test-blue"
 
   _bg_start_color()  { _record "start:$1"; }
   _bg_wait_healthy() { _record "wait:FAIL"; return 1; }
@@ -252,11 +299,63 @@ _record() { echo "$*" >> "$CALLS_FILE"; }
   ! grep -q "^stop:"  "$CALLS_FILE"
 
   # State is unchanged — blue still active
-  [ "$(_bg_read_state "$STACK")" = "blue" ]
+  [ "$(_bg_read_state "$STACK" "test")" = "blue" ]
+}
+
+# strut#375: an unchecked proxy-swap failure used to fall through to
+# draining/stopping the old color anyway — traffic left pointed at
+# containers that had just been stopped.
+@test "bg_deploy_stack: proxy swap failure aborts, leaves old color running, state unchanged" {
+  _bg_write_state "$STACK" "test" "blue" "demo-test-blue"
+
+  _bg_start_color()  { _record "start:$1"; }
+  _bg_wait_healthy() { _record "wait:ok"; return 0; }
+  _bg_swap_proxy()   { _record "swap:$2→$3"; return 1; }
+  _bg_drain()        { _record "drain:$1"; }
+  _bg_stop_color()   { _record "stop:$1"; }
+  _bg_teardown_failed_color() { _record "teardown:$1"; }
+  export -f _bg_start_color _bg_wait_healthy _bg_swap_proxy _bg_drain _bg_stop_color _bg_teardown_failed_color
+
+  export PRE_DEPLOY_VALIDATE=false DRY_RUN=false SKIP_VALIDATION=false
+
+  run bg_deploy_stack "$STACK" "$ENV_FILE"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"proxy swap"* ]]
+  [[ "$output" == *"notify_event deploy.failed"* ]]
+  [[ "$output" == *"reason=proxy_swap_failed"* ]]
+
+  # Swap was attempted, but drain/stop of the old (still-live) color never ran.
+  grep -q "^swap:demo-test-blue→demo-test-green" "$CALLS_FILE"
+  ! grep -q "^drain:" "$CALLS_FILE"
+  ! grep -q "^stop:"  "$CALLS_FILE"
+
+  # State is unchanged — blue is still active, green was never marked live.
+  [ "$(_bg_read_state "$STACK" "test")" = "blue" ]
+}
+
+@test "bg_deploy_stack: state is marked active right after the swap, before drain" {
+  _bg_write_state "$STACK" "test" "blue" "demo-test-blue"
+
+  _bg_start_color()  { _record "start:$1"; }
+  _bg_wait_healthy() { _record "wait:ok"; return 0; }
+  _bg_swap_proxy()   { _record "swap:$2→$3"; }
+  # Read state from inside the drain stub — if state isn't written until
+  # AFTER drain/stop (the pre-fix ordering), this observes the OLD color.
+  _bg_drain() {
+    _record "drain:state-seen=$(_bg_read_state "$STACK" "test")"
+  }
+  _bg_stop_color()   { _record "stop:$1"; }
+  export -f _bg_start_color _bg_wait_healthy _bg_swap_proxy _bg_drain _bg_stop_color
+
+  export PRE_DEPLOY_VALIDATE=false DRY_RUN=false SKIP_VALIDATION=false
+
+  run bg_deploy_stack "$STACK" "$ENV_FILE"
+  [ "$status" -eq 0 ]
+  grep -q "^drain:state-seen=green" "$CALLS_FILE"
 }
 
 @test "bg_deploy_stack: dry-run prints plan, touches nothing, no state change" {
-  _bg_write_state "$STACK" "blue" "demo-test-blue"
+  _bg_write_state "$STACK" "test" "blue" "demo-test-blue"
   _bg_start_color()  { _record "start:$1"; }
   _bg_wait_healthy() { _record "wait"; return 0; }
   _bg_swap_proxy()   { _record "swap"; }
@@ -276,7 +375,7 @@ _record() { echo "$*" >> "$CALLS_FILE"; }
     echo "Expected empty calls log, got:"; cat "$CALLS_FILE"; false;
   }
   # State unchanged
-  [ "$(_bg_read_state "$STACK")" = "blue" ]
+  [ "$(_bg_read_state "$STACK" "test")" = "blue" ]
 }
 
 @test "bg_deploy_stack: dry-run does not execute the real pre_deploy hook" {
@@ -382,10 +481,34 @@ EOF
   [[ "$output" == *"did not define"* ]] || [[ "$output" == *"bluegreen_proxy_swap"* ]]
 }
 
+# strut#375: the built-in (no-hook) fallback used to always return 0 even
+# when the reload command it ran failed — `warn` on the failure branch
+# always succeeds, so the `&&`/`||` chain's own exit status (the function's
+# implicit return value) was never actually the reload's.
+@test "_bg_swap_proxy: built-in fallback returns failure when the reload command fails" {
+  unset BLUE_GREEN_PROXY_HOOK
+  build_proxy_reload_cmd() { echo "reload-cmd"; return 0; }
+  reload-cmd() { return 1; }
+  export -f build_proxy_reload_cmd reload-cmd
+
+  run _bg_swap_proxy "demo" "demo-test-blue" "demo-test-green" "$ENV_FILE"
+  [ "$status" -ne 0 ]
+}
+
+@test "_bg_swap_proxy: built-in fallback succeeds when the reload command succeeds" {
+  unset BLUE_GREEN_PROXY_HOOK
+  build_proxy_reload_cmd() { echo "reload-cmd"; return 0; }
+  reload-cmd() { return 0; }
+  export -f build_proxy_reload_cmd reload-cmd
+
+  run _bg_swap_proxy "demo" "demo-test-blue" "demo-test-green" "$ENV_FILE"
+  [ "$status" -eq 0 ]
+}
+
 # ── Rollback flip ────────────────────────────────────────────────────────────
 
 @test "bg_rollback_stack: flips green → blue, brings blue up, stops green" {
-  _bg_write_state "$STACK" "green" "demo-test-green"
+  _bg_write_state "$STACK" "test" "green" "demo-test-green"
 
   # Capture the compose_cmd prefix that up/down receives so we can assert
   # which color each operation targeted.
@@ -419,28 +542,28 @@ EOF
   grep -q "^stop:compose-green" "$CALLS_FILE"
 
   # State flipped to blue
-  [ "$(_bg_read_state "$STACK")" = "blue" ]
+  [ "$(_bg_read_state "$STACK" "test")" = "blue" ]
 }
 
 @test "bg_rollback_stack: no state → fails cleanly" {
-  _bg_clear_state "$STACK"
+  _bg_clear_state "$STACK" "test"
   run bg_rollback_stack "$STACK" "$ENV_FILE"
   [ "$status" -ne 0 ]
   [[ "$output" == *"No blue-green state"* ]] || [[ "$output" == *"standard rollback"* ]]
 }
 
 @test "bg_rollback_stack: dry-run prints plan and doesn't flip state" {
-  _bg_write_state "$STACK" "green" "demo-test-green"
+  _bg_write_state "$STACK" "test" "green" "demo-test-green"
   export DRY_RUN=true
 
   run bg_rollback_stack "$STACK" "$ENV_FILE"
   [ "$status" -eq 0 ]
   [[ "$output" == *"DRY-RUN"* ]]
-  [ "$(_bg_read_state "$STACK")" = "green" ]
+  [ "$(_bg_read_state "$STACK" "test")" = "green" ]
 }
 
 @test "bg_rollback_stack: previous color fails health check → aborts, no swap, no stop, state unchanged" {
-  _bg_write_state "$STACK" "green" "demo-test-green"
+  _bg_write_state "$STACK" "test" "green" "demo-test-green"
 
   _bg_wait_healthy() { _record "wait:FAIL"; return 1; }
   _bg_swap_proxy()   { _record "swap:$2→$3"; }
@@ -465,7 +588,36 @@ EOF
   ! grep -q "^stop:" "$CALLS_FILE"
 
   # State unchanged — green still active, rollback never completed
-  [ "$(_bg_read_state "$STACK")" = "green" ]
+  [ "$(_bg_read_state "$STACK" "test")" = "green" ]
+}
+
+@test "bg_rollback_stack: proxy swap failure aborts, leaves current color running, state unchanged" {
+  _bg_write_state "$STACK" "test" "green" "demo-test-green"
+
+  _bg_wait_healthy() { _record "wait:ok"; return 0; }
+  _bg_swap_proxy()   { _record "swap:$2→$3"; return 1; }
+  _bg_stop_color()   { _record "stop:$1"; }
+  export -f _bg_wait_healthy _bg_swap_proxy _bg_stop_color
+
+  _bg_compose_for_color() {
+    local color="$3"
+    echo "compose-$color"
+  }
+  export -f _bg_compose_for_color
+  compose-blue() { _record "up:blue:$*"; }
+  export -f compose-blue
+
+  export DRY_RUN=false
+
+  run bg_rollback_stack "$STACK" "$ENV_FILE"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"proxy swap"* ]]
+
+  grep -q "^swap:demo-test-green→demo-test-blue" "$CALLS_FILE"
+  ! grep -q "^stop:" "$CALLS_FILE"
+
+  # State unchanged — green (current) is still active
+  [ "$(_bg_read_state "$STACK" "test")" = "green" ]
 }
 
 # ── Stop uses `stop`, never `down` ───────────────────────────────────────────

--- a/tests/test_deploy_up_failure.bats
+++ b/tests/test_deploy_up_failure.bats
@@ -1,0 +1,134 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_deploy_up_failure.bats — strut#374 regression
+# ==================================================
+# A failed `compose up -d` used to be swallowed: deploy_stack fell through
+# to the success banner/notify_event/history-success path even though the
+# previous containers were already stopped and the new ones never started.
+# This is especially dangerous through cmd_deploy's dispatch, which calls
+# `deploy_stack ... || _deploy_rc=$?` — putting the whole call on the left
+# side of `||` suppresses errexit for its entire call tree (POSIX/bash
+# semantics), so nothing but an EXPLICIT check on the up -d exit status
+# catches the failure.
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_docker
+
+  source "$CLI_ROOT/lib/config.sh"
+  source "$CLI_ROOT/lib/deploy.sh"
+  source "$CLI_ROOT/lib/cmd_deploy.sh"
+
+  registry_login() { echo "REGISTRY_LOGIN_CALLED"; }
+  docker_pull_stack() { echo "DOCKER_PULL_CALLED: $*"; }
+  docker_require_images() { return 0; }
+  rollback_save_snapshot() { :; }
+  export_volume_paths() { :; }
+  fire_hook() { return 0; }
+  fire_hook_or_warn() { :; }
+  fire_first_run_hook() { :; }
+  maybe_apply_db_schema() { :; }
+  notify_event() { echo "notify_event $*" >> "$TEST_TMP/notify_calls"; }
+  print_banner() { :; }
+  require_cmd() { :; }
+  is_running_on_vps() { return 0; }
+  cmd_validate() { return 0; }
+  diff_warn_env_divergence() { return 0; }
+  # Lock stubs — lock.sh not sourced in this unit test
+  lock_acquire_local() { echo "test-nonce"; return 0; }
+  lock_release_local() { return 0; }
+  lock_is_stale_local() { return 1; }
+  lock_force_break_local() { return 0; }
+  export -f registry_login docker_pull_stack docker_require_images \
+            rollback_save_snapshot export_volume_paths fire_hook \
+            fire_hook_or_warn fire_first_run_hook maybe_apply_db_schema \
+            notify_event print_banner require_cmd is_running_on_vps \
+            cmd_validate diff_warn_env_divergence lock_acquire_local \
+            lock_release_local lock_is_stale_local lock_force_break_local
+
+  # Fake `docker` — `compose up -d --remove-orphans` is the one call this
+  # suite makes fail; everything else (version check, down, ps -a collision
+  # probe) succeeds.
+  docker() {
+    if [ "$1" = "compose" ]; then
+      case " $* " in
+        *" up -d --remove-orphans "*) return "${DOCKER_UP_EXIT:-0}" ;;
+        *) return 0 ;;
+      esac
+    fi
+    return 0
+  }
+  export -f docker
+  export DOCKER_UP_EXIT=1
+
+  mkdir -p "$TEST_TMP/stacks/hub"
+  cat > "$TEST_TMP/stacks/hub/docker-compose.yml" <<'EOF'
+services:
+  app:
+    image: hub-app
+EOF
+  cat > "$TEST_TMP/stacks/hub/services.conf" <<'EOF'
+BUILD_MODE=none
+EOF
+  cat > "$TEST_TMP/.prod.env" <<'EOF'
+VPS_HOST=10.0.0.1
+EOF
+
+  # LIB must point at the real repo (history.sh lives there) — capture it
+  # before CLI_ROOT is repointed at the test fixture dir below.
+  export LIB="$CLI_ROOT/lib"
+  export CLI_ROOT="$TEST_TMP"
+  export DRY_RUN="false"
+  export PRE_DEPLOY_VALIDATE="false"
+  export SKIP_VALIDATION="false"
+  : > "$TEST_TMP/notify_calls"
+}
+
+teardown() { common_teardown; }
+
+@test "deploy_stack: compose up failure returns non-zero instead of reaching the success banner" {
+  run deploy_stack "hub" "$TEST_TMP/.prod.env" ""
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"Deploy complete"* ]]
+  [[ "$output" == *"compose up failed"* ]]
+}
+
+@test "deploy_stack: compose up failure fires deploy.failed, not deploy.success" {
+  run deploy_stack "hub" "$TEST_TMP/.prod.env" ""
+  [ "$status" -ne 0 ]
+  run cat "$TEST_TMP/notify_calls"
+  [[ "$output" == *"deploy.failed"* ]]
+  [[ "$output" != *"deploy.success"* ]]
+}
+
+@test "deploy_stack: compose up succeeding still reaches the success banner and fires deploy.success" {
+  export DOCKER_UP_EXIT=0
+  run deploy_stack "hub" "$TEST_TMP/.prod.env" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Deploy complete"* ]]
+  run cat "$TEST_TMP/notify_calls"
+  [[ "$output" == *"deploy.success"* ]]
+}
+
+# The actual reported bug: cmd_deploy dispatches via `deploy_stack ... ||
+# _deploy_rc=$?`, which suppresses errexit through the whole call tree. Only
+# an explicit check inside deploy_stack (not ambient set -e) catches this.
+
+@test "cmd_deploy: compose up failure propagates through the || _deploy_rc=\$? dispatch and records failed history" {
+  mkdir -p "$TEST_TMP/stacks/hub"
+  export CMD_STACK="hub"
+  export CMD_STACK_DIR="$TEST_TMP/stacks/hub"
+  export CMD_ENV_FILE="$TEST_TMP/.prod.env"
+  export CMD_ENV_NAME="prod"
+  export CMD_SERVICES=""
+  export CMD_JSON=""
+
+  run cmd_deploy
+  [ "$status" -ne 0 ]
+
+  local hist_file="$TEST_TMP/stacks/hub/.deploy-history.jsonl"
+  [ -f "$hist_file" ]
+  run cat "$hist_file"
+  [[ "$output" == *'"action":"deploy"'* ]]
+  [[ "$output" == *'"outcome":"failed"'* ]]
+}

--- a/tests/test_lock.bats
+++ b/tests/test_lock.bats
@@ -73,6 +73,42 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
+@test "lock_acquire_local: echoes a nonce on stdout, recorded in the info file" {
+  run lock_acquire_local "s" "prod" "deploy"
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+  grep -q "^nonce=$output\$" "$STRUT_LOCK_ROOT/s-prod.lock.d/info"
+}
+
+# strut#383 (bonus fix): a lock force-broken and re-acquired by a different
+# process must not be deleted by the FIRST process's own (now-stale) EXIT
+# cleanup once it eventually finishes.
+@test "lock_release_local: nonce mismatch leaves a lock re-acquired by someone else alone" {
+  local first_nonce
+  first_nonce=$(lock_acquire_local "s" "prod" "deploy")
+  lock_force_break_local "s" "prod"
+  lock_acquire_local "s" "prod" "deploy" >/dev/null   # a second process re-acquires
+
+  run lock_release_local "s" "prod" "$first_nonce"
+  [ "$status" -eq 0 ]
+  [ -d "$STRUT_LOCK_ROOT/s-prod.lock.d" ]
+}
+
+@test "lock_release_local: matching nonce releases normally" {
+  local nonce
+  nonce=$(lock_acquire_local "s" "prod" "deploy")
+  run lock_release_local "s" "prod" "$nonce"
+  [ "$status" -eq 0 ]
+  [ ! -d "$STRUT_LOCK_ROOT/s-prod.lock.d" ]
+}
+
+@test "lock_release_local: no nonce given releases unconditionally (backward compat)" {
+  lock_acquire_local "s" "prod" "deploy" >/dev/null
+  run lock_release_local "s" "prod"
+  [ "$status" -eq 0 ]
+  [ ! -d "$STRUT_LOCK_ROOT/s-prod.lock.d" ]
+}
+
 @test "lock_acquire_local: different env doesn't conflict" {
   lock_acquire_local "s" "prod" "deploy"
   run lock_acquire_local "s" "staging" "deploy"
@@ -138,6 +174,42 @@ EOF
   # Replace pid with one that definitely doesn't exist
   sed -i.bak "s/^pid=.*/pid=999999/" "$STRUT_LOCK_ROOT/s-prod.lock.d/info"
   rm -f "$STRUT_LOCK_ROOT/s-prod.lock.d/info.bak"
+  run lock_is_stale_local "s" "prod"
+  [ "$status" -eq 0 ]
+}
+
+# strut#383: a lock is declared stale purely by age even though its holder
+# pid is alive — a live long-running deploy (image pull, --no-cache
+# rebuild, blue-green health poll) routinely exceeds the default 600s
+# threshold, so the age fallback must never override a verifiable live pid.
+@test "lock_is_stale_local: NOT stale when pid is alive, even past the age threshold" {
+  lock_acquire_local "s" "prod" "deploy"
+  # Rewrite started to 1 hour ago, same host, but keep OUR OWN pid ($$) —
+  # guaranteed alive for the duration of this test.
+  local past
+  past=$(date -u -v-1H +%FT%TZ 2>/dev/null || date -u -d "1 hour ago" +%FT%TZ)
+  cat > "$STRUT_LOCK_ROOT/s-prod.lock.d/info" <<EOF
+pid=$$
+host=$(hostname)
+started=$past
+command=deploy
+EOF
+  export STRUT_LOCK_STALE_SECONDS=60
+  run lock_is_stale_local "s" "prod"
+  [ "$status" -eq 1 ]
+}
+
+@test "lock_is_stale_local: age fallback still applies for a cross-host lock (pid unverifiable)" {
+  lock_acquire_local "s" "prod" "deploy"
+  local past
+  past=$(date -u -v-1H +%FT%TZ 2>/dev/null || date -u -d "1 hour ago" +%FT%TZ)
+  cat > "$STRUT_LOCK_ROOT/s-prod.lock.d/info" <<EOF
+pid=$$
+host=some-other-host
+started=$past
+command=deploy
+EOF
+  export STRUT_LOCK_STALE_SECONDS=60
   run lock_is_stale_local "s" "prod"
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Summary

Closes the highest-severity cluster from the 2026-07 audit — the deploy command lying about success or breaking a concurrent live deploy.

- **#374** — a failed `compose up -d` fell through to the success banner and recorded a success history entry: `deploy_stack ... || _deploy_rc=$?` (cmd_deploy.sh) puts the whole call on the left of `||`, which suppresses errexit through its entire call tree. Guarded the step explicitly and now fires `deploy.failed` on that path.
- **#375** — proxy-swap failure was discarded before draining/stopping the old color (traffic left pointed at stopped containers), and the blue-green state file was keyed per-stack instead of per-env, so two envs of one stack could overwrite each other's active color and recreate a live project in place. Guarded the swap (deploy + rollback), moved the state write to right after the swap (not after drain/stop), and keyed state per-env with a legacy-file read/migrate fallback. Also fixed the built-in proxy-reload fallback, which always returned 0 even on a failed reload.
- **#383** — the lock's stale-age fallback overrode a verifiably live pid, so a deploy still running past `STRUT_LOCK_STALE_SECONDS` (large pulls, `--no-cache` rebuilds, blue-green health polls routinely exceed 600s) got auto-broken out from under it. Same-host + alive-pid is now authoritative. Added a lock nonce so a force-broken-and-reacquired lock's EXIT cleanup can't delete a different process's lock.
- **#384** — stop/status/local health always targeted the plain `<stack>-<env>` project, which blue-green deploys never use — `stop` silently downed an empty project and reported success while the active color kept serving. They now resolve the blue-green active project when one exists. Remote `stop` also dropped `--volumes`/`--timeout` when forwarding to the SSH'd invocation; both are now passed through.

## Test plan
- [x] `bash -n` + `shellcheck -s bash` clean on all touched files
- [x] New/updated regression tests per issue: `test_deploy_up_failure.bats` (new), `test_deploy_blue_green.bats`, `test_cmd_rollback.bats`, `test_lock.bats`, `test_cmd_deploy.bats`, `test_cmd_stop.bats`
- [x] Full `bats tests/` suite — 2234 passing, only the 6 pre-existing environment-dependent failures remain (cron `PATH` and TTY color-detection tests that don't behave correctly in this sandbox), confirmed identical against the unmodified base branch