### PR TITLE
feat: close out layered-env epic (#179) — shared common.env + transparent secrets filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,8 @@ strut <stack> <command> [--env <name>] [--dry-run] [--services <profile>]
 strut                                             # interactive TUI (fzf+select)
 strut --no-tui | STRUT_NO_TUI=1                   # disable TUI
 
-Top-level:  init, upgrade, --version, list, scaffold, audit, migrate, monitoring
+Top-level:  init, upgrade, --version, list, scaffold, audit, migrate, monitoring,
+            secrets-filter (transparent git clean/smudge for at-rest secrets)
 Per-stack:  deploy, stop, release, update, health, logs, status, shell, exec,
             backup, restore, db:pull, db:push, db:schema, drift, volumes, keys, domain
 ```
@@ -59,6 +60,11 @@ Per-stack:  deploy, stop, release, update, health, logs, status, shell, exec,
   the base env file. Unlike the legacy `stacks/<stack>/.<host>.env` override
   (still supported, lower precedence), this path is **not** gitignored, so
   it survives a clean git-redeploy.
+- `common.env` (project root, optional) — shared, non-secret env values
+  across every stack (`load_common_env`, `lib/utils.sh`). Lowest precedence:
+  loaded before the stack/project env file and the per-host layer, both of
+  which override it. Not swept by the `.env`/`.*.env` gitignore rules (no
+  leading dot) — meant to be committed. See `templates/common.env.template`.
 
 ## Design Principles
 

--- a/completions/bash.sh
+++ b/completions/bash.sh
@@ -68,7 +68,7 @@ _strut_completions() {
   prev="${COMP_WORDS[COMP_CWORD-1]}"
   cword=$COMP_CWORD
 
-  local top_cmds="init list scaffold upgrade doctor status-all dashboard posture group monitoring audit audit:list audit:diff audit:generate migrate migrate:status notify sync fleet webhook mcp skills help completions --version -v --help -h"
+  local top_cmds="init list scaffold upgrade doctor status-all dashboard posture group monitoring audit audit:list audit:diff audit:generate migrate migrate:status notify sync fleet webhook secrets-filter mcp skills help completions --version -v --help -h"
   local per_stack_cmds="update release deploy rebuild ship stop diff lock health logs logs:download logs:rotate backup drift migrate restore db:pull db:push db:schema shell exec remote:init adopt provision ssh:keygen ci:init cert:renew cert:status init-secrets secrets status briefing preflight volumes prune local prod staging dev debug keys validate rollback history domain --help"
   local profiles="messaging ui full"
 

--- a/completions/fish.fish
+++ b/completions/fish.fish
@@ -60,7 +60,7 @@ function __strut_tok
     end
 end
 
-set -l top_cmds init list scaffold upgrade doctor status-all dashboard posture group monitoring audit audit:list audit:diff audit:generate migrate migrate:status notify sync fleet webhook mcp skills help completions
+set -l top_cmds init list scaffold upgrade doctor status-all dashboard posture group monitoring audit audit:list audit:diff audit:generate migrate migrate:status notify sync fleet webhook secrets-filter mcp skills help completions
 set -l per_stack_cmds update release deploy rebuild ship stop diff lock health logs logs:download logs:rotate backup drift migrate restore db:pull db:push db:schema shell exec remote:init adopt provision ssh:keygen ci:init cert:renew cert:status init-secrets secrets status briefing preflight volumes prune local prod staging dev debug keys validate rollback history domain
 
 # Disable file completion by default; re-enable where relevant

--- a/completions/zsh.sh
+++ b/completions/zsh.sh
@@ -49,7 +49,7 @@ _strut_groups() {
 
 _strut() {
   local -a top_cmds per_stack_cmds profiles
-  top_cmds=(init list scaffold upgrade doctor status-all dashboard posture group monitoring audit audit:list audit:diff audit:generate migrate migrate:status notify sync fleet webhook mcp skills help completions --version --help)
+  top_cmds=(init list scaffold upgrade doctor status-all dashboard posture group monitoring audit audit:list audit:diff audit:generate migrate migrate:status notify sync fleet webhook secrets-filter mcp skills help completions --version --help)
   per_stack_cmds=(update release deploy rebuild ship stop diff lock health logs logs:download logs:rotate backup drift migrate restore db:pull db:push db:schema shell exec remote:init adopt provision ssh:keygen ci:init cert:renew cert:status init-secrets secrets status briefing preflight volumes prune local prod staging dev debug keys validate rollback history domain --help)
   profiles=(messaging ui full)
 

--- a/lib/cmd_init.sh
+++ b/lib/cmd_init.sh
@@ -88,7 +88,11 @@ EOF
   # NEVER truncate an existing .gitignore — it is the primary defense against
   # `git clean -fd` deleting untracked data dirs on deploy. Append a marker
   # block with only the rules that are missing.
-  local -a strut_ignores=('.env' '.env.*' '.*.env' '!.env.template' '*.backup-*' 'backups/' 'data/' '.rollback/' '.bluegreen')
+  # !*.env.age / !*.env.gpg: at-rest encrypted secrets (`secrets lock` /
+  # `secrets-filter`) are ciphertext and meant to be committed. They don't
+  # end in literally ".env" so .*.env above already misses them — these
+  # negations make that explicit and future-proof (strut#178).
+  local -a strut_ignores=('.env' '.env.*' '.*.env' '!.env.template' '!*.env.age' '!*.env.gpg' '*.backup-*' 'backups/' 'data/' '.rollback/' '.bluegreen')
   if [ ! -f "$PWD/.gitignore" ]; then
     {
       echo "# strut — generated .gitignore"

--- a/lib/cmd_secrets.sh
+++ b/lib/cmd_secrets.sh
@@ -53,6 +53,11 @@ _usage_secrets() {
   echo "  Identity:    --identity <file> or STRUT_AGE_IDENTITY env var"
   echo "               defaults to ~/.age/key.txt, ~/.ssh/id_ed25519, ~/.ssh/id_rsa"
   echo ""
+  echo "  Prefer not to run lock/unlock by hand before every commit? 'strut"
+  echo "  secrets-filter install' wires up a transparent git filter (age-only)"
+  echo "  so plaintext stays in your working tree but ciphertext in git history —"
+  echo "  see 'strut secrets-filter --help'."
+  echo ""
   echo "Secret references (in a .env template, resolved by 'hydrate'):"
   echo "  KEY=vault://<item>     Vaultwarden/Bitwarden item (via 'bw')"
   echo "  KEY=exec://<command>   Stdout of a command"
@@ -1733,6 +1738,245 @@ _secrets_unlock() {
 
   echo ""
   ok "Secrets unlocked — run 'strut $stack secrets push --env $env_name' to sync."
+}
+
+# ── Transparent git filter (strut#178) ───────────────────────────────────────
+#
+# Lock/unlock above is a manual, two-file workflow (.env <-> .env.age) —
+# easy to forget before a commit or after a pull. The filter driver below
+# makes committed secrets the default: the plaintext .env path is committed
+# directly, but git transparently encrypts its content on `git add`/commit
+# (clean) and decrypts it into the working tree on checkout (smudge). One
+# `strut secrets-filter install` per clone wires it up — git filter drivers
+# are local-only by design (a committed .gitattributes can declare which
+# files use a filter, but never the command it runs, since that would let a
+# repo execute arbitrary code on checkout).
+#
+# age only (not gpg) — one encryption backend keeps the recipients/identity
+# resolution below in sync with _secrets_lock/_secrets_unlock without a
+# second implementation to drift.
+
+_usage_secrets_filter() {
+  echo ""
+  echo "Usage: strut secrets-filter <install|uninstall|status> [--env <name>]"
+  echo "       strut secrets-filter <clean|smudge> <path>   (invoked by git — not for manual use)"
+  echo ""
+  echo "Transparent git filter for committed secrets: plaintext in the working"
+  echo "tree, age-encrypted in git history. Alternative to 'secrets lock/unlock'"
+  echo "for projects that want commits to just work without a manual encrypt step."
+  echo ""
+  echo "Subcommands:"
+  echo "  install     Wire up .gitattributes + local git config for this repo"
+  echo "  uninstall   Remove the local git config (leaves .gitattributes)"
+  echo "  status      Show whether the filter is installed and configured"
+  echo ""
+  echo "Options:"
+  echo "  --env <name>   Scope .gitattributes to one env (.{name}.env) instead"
+  echo "                 of every env file (.*.env). Default: every env."
+  echo ""
+  echo "Setup (once per clone):"
+  echo "  1. Create .strut-recipients (project root or per-stack) with age/SSH"
+  echo "     public keys, one per line — same as 'secrets lock'."
+  echo "  2. strut secrets-filter install"
+  echo "  3. git add / commit as normal — .env files are encrypted at rest,"
+  echo "     plaintext in your working tree."
+  echo ""
+  echo "A clone without your age identity still checks out cleanly — smudge"
+  echo "falls back to leaving the file encrypted rather than failing checkout."
+  echo "Install your identity (~/.age/key.txt or ~/.ssh/id_ed25519) and run"
+  echo "'git checkout -- <file>' to decrypt it."
+  echo ""
+}
+
+# _secrets_filter_recipients_for <dir> — echoes a recipients file path, or a
+# temp file for the self-via-pubkey fallback (caller must track/clean up).
+# Mirrors _secrets_lock's resolution order exactly (stack dir -> project
+# root -> self).
+_secrets_filter_recipients_for() {
+  local dir="$1"
+  if [ -f "$dir/.strut-recipients" ]; then
+    echo "$dir/.strut-recipients"
+  elif [ -f "$CLI_ROOT/.strut-recipients" ]; then
+    echo "$CLI_ROOT/.strut-recipients"
+  elif [ -f "$HOME/.ssh/id_ed25519.pub" ]; then
+    local tmp; tmp=$(mktemp)
+    cp "$HOME/.ssh/id_ed25519.pub" "$tmp"
+    echo "$tmp"
+  elif [ -f "$HOME/.ssh/id_rsa.pub" ]; then
+    local tmp; tmp=$(mktemp)
+    cp "$HOME/.ssh/id_rsa.pub" "$tmp"
+    echo "$tmp"
+  fi
+}
+
+# _secrets_git_clean <path> — git clean filter. Reads plaintext on stdin,
+# writes age ciphertext to stdout. Fails loudly (nonzero) on any problem —
+# `filter.strutsecrets.required=true` (set by filter-install) makes a
+# failure here abort the `git add`/commit rather than risk silently staging
+# plaintext.
+_secrets_git_clean() {
+  local path="${1:-}"
+  [ -n "$path" ] || { echo "strut secrets-filter clean: missing path argument" >&2; return 1; }
+  command -v age &>/dev/null || { echo "strut secrets-filter clean: 'age' not installed" >&2; return 1; }
+
+  # git invokes filters with a repo-root-relative path (its documented %f
+  # contract) and a CWD that should already be the repo root — but anchor
+  # explicitly to $CLI_ROOT rather than trust ambient CWD, since nothing
+  # about this codepath is dispatched through the normal stack context.
+  local dir; dir="$(dirname -- "$path")"
+  if [ "$dir" = "." ]; then
+    dir="$CLI_ROOT"
+  elif [[ "$dir" != /* ]]; then
+    dir="$CLI_ROOT/$dir"
+  fi
+  local rcpts; rcpts="$(_secrets_filter_recipients_for "$dir")"
+  if [ -z "$rcpts" ]; then
+    echo "strut secrets-filter clean: no age recipients for $path — create .strut-recipients (see 'strut secrets-filter --help')" >&2
+    return 1
+  fi
+
+  age -e -R "$rcpts"
+  local rc=$?
+  # Self-via-pubkey fallback writes a temp file; a real .strut-recipients
+  # does not — only clean up what we created.
+  [[ "$rcpts" == "$dir/.strut-recipients" || "$rcpts" == "$CLI_ROOT/.strut-recipients" ]] || rm -f "$rcpts"
+  return "$rc"
+}
+
+# _secrets_git_smudge <path> — git smudge filter. Reads whatever git has
+# stored (ciphertext, or plaintext for a file added before the filter was
+# installed) on stdin, writes plaintext to stdout when it can. ALWAYS exits
+# 0: a clone without the age identity — or content that isn't actually
+# age-encrypted — falls back to passing the input through unchanged rather
+# than failing `git checkout` for everyone who doesn't hold the key.
+_secrets_git_smudge() {
+  local tmp_in tmp_out
+  tmp_in=$(mktemp)
+  tmp_out=$(mktemp)
+  cat > "$tmp_in"
+
+  local id_file="${STRUT_AGE_IDENTITY:-}"
+  if [ -z "$id_file" ]; then
+    local candidate
+    for candidate in "$HOME/.age/key.txt" "$HOME/.ssh/id_ed25519" "$HOME/.ssh/id_rsa"; do
+      [ -f "$candidate" ] && { id_file="$candidate"; break; }
+    done
+  fi
+
+  if [ -n "$id_file" ] && command -v age &>/dev/null \
+     && age -d -i "$id_file" -o "$tmp_out" "$tmp_in" 2>/dev/null; then
+    cat "$tmp_out"
+  else
+    cat "$tmp_in"
+  fi
+  rm -f "$tmp_in" "$tmp_out"
+  return 0
+}
+
+# _secrets_filter_gitattributes_line <env_name>
+_secrets_filter_gitattributes_line() {
+  local env_name="$1"
+  if [ -n "$env_name" ]; then
+    echo ".${env_name}.env filter=strutsecrets diff=strutsecrets -text"
+  else
+    echo ".*.env filter=strutsecrets diff=strutsecrets -text"
+  fi
+}
+
+_secrets_filter_install() {
+  local env_name="${CMD_ENV_NAME:-}"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --env) env_name="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+
+  git -C "$CLI_ROOT" rev-parse --git-dir &>/dev/null || { fail "Not inside a git repository ($CLI_ROOT)"; return 1; }
+  command -v age &>/dev/null || { fail "strut secrets-filter: 'age' not installed (the transparent filter is age-only — use 'secrets lock/unlock' for gpg)"; return 1; }
+
+  local entrypoint="${STRUT_HOME:-$CLI_ROOT}/strut"
+  [ -x "$entrypoint" ] || { fail "strut entrypoint not found/executable at $entrypoint"; return 1; }
+
+  git -C "$CLI_ROOT" config filter.strutsecrets.clean  "'$entrypoint' secrets-filter clean %f"
+  git -C "$CLI_ROOT" config filter.strutsecrets.smudge "'$entrypoint' secrets-filter smudge %f"
+  git -C "$CLI_ROOT" config filter.strutsecrets.required true
+
+  local attr_line
+  attr_line="$(_secrets_filter_gitattributes_line "$env_name")"
+  local attrs_file="$CLI_ROOT/.gitattributes"
+  if [ -f "$attrs_file" ] && grep -qxF "$attr_line" "$attrs_file"; then
+    log ".gitattributes already has: $attr_line"
+  else
+    local need_blank_line=false
+    [ -f "$attrs_file" ] && [ -s "$attrs_file" ] && need_blank_line=true
+    {
+      [ "$need_blank_line" = "true" ] && echo ""
+      echo "# strut secrets-filter — transparent at-rest encryption (strut#178)"
+      echo "$attr_line"
+    } >> "$attrs_file"
+    log "Added to .gitattributes: $attr_line"
+  fi
+
+  echo ""
+  ok "Git filter installed (local to this clone)"
+  echo "  Recipients: .strut-recipients (project root or per-stack), else ~/.ssh/id_ed25519.pub"
+  echo "  Identity:   STRUT_AGE_IDENTITY, ~/.age/key.txt, or ~/.ssh/id_ed25519"
+  echo ""
+  warn "Re-run 'strut secrets-filter install' on every other clone/checkout of this repo — git filter drivers are never stored in .gitattributes itself."
+}
+
+_secrets_filter_uninstall() {
+  git -C "$CLI_ROOT" rev-parse --git-dir &>/dev/null || { fail "Not inside a git repository ($CLI_ROOT)"; return 1; }
+  git -C "$CLI_ROOT" config --unset filter.strutsecrets.clean 2>/dev/null || true
+  git -C "$CLI_ROOT" config --unset filter.strutsecrets.smudge 2>/dev/null || true
+  git -C "$CLI_ROOT" config --unset filter.strutsecrets.required 2>/dev/null || true
+  ok "Removed local git filter config (filter.strutsecrets.*)"
+  warn ".gitattributes was left as-is — remove its 'filter=strutsecrets' lines by hand if you're dropping this permanently"
+}
+
+_secrets_filter_status() {
+  git -C "$CLI_ROOT" rev-parse --git-dir &>/dev/null || { fail "Not inside a git repository ($CLI_ROOT)"; return 1; }
+  local clean smudge required
+  clean=$(git -C "$CLI_ROOT" config filter.strutsecrets.clean 2>/dev/null || echo "")
+  smudge=$(git -C "$CLI_ROOT" config filter.strutsecrets.smudge 2>/dev/null || echo "")
+  required=$(git -C "$CLI_ROOT" config filter.strutsecrets.required 2>/dev/null || echo "")
+
+  if [ -z "$clean" ] && [ -z "$smudge" ]; then
+    echo "Filter: not installed (run 'strut secrets-filter install')"
+    return 1
+  fi
+
+  echo "Filter: installed"
+  echo "  clean:    $clean"
+  echo "  smudge:   $smudge"
+  echo "  required: ${required:-false}"
+  if [ -f "$CLI_ROOT/.gitattributes" ]; then
+    echo "  .gitattributes rules:"
+    grep "filter=strutsecrets" "$CLI_ROOT/.gitattributes" 2>/dev/null | sed 's/^/    /' || echo "    (none found)"
+  else
+    warn "  No .gitattributes found — nothing will actually route through the filter"
+  fi
+  return 0
+}
+
+cmd_secrets_filter() {
+  local subcmd="${1:-}"
+  shift 2>/dev/null || true
+
+  case "$subcmd" in
+    install)   _secrets_filter_install "$@" ;;
+    uninstall) _secrets_filter_uninstall "$@" ;;
+    status)    _secrets_filter_status "$@" ;;
+    clean)     _secrets_git_clean "$@" ;;
+    smudge)    _secrets_git_smudge "$@" ;;
+    ""|help|--help|-h) _usage_secrets_filter ;;
+    *)
+      error "Unknown secrets-filter subcommand: $subcmd"
+      _usage_secrets_filter
+      return 1
+      ;;
+  esac
 }
 
 # ── Dispatch ──────────────────────────────────────────────────────────────────

--- a/lib/deploy.sh
+++ b/lib/deploy.sh
@@ -482,6 +482,7 @@ $_hint"
   local cli_root="${CLI_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
   local stack_dir="$cli_root/stacks/$stack"
 
+  load_common_env
   safe_load_env "$env_file"
   env_apply_layers "$stack" "$stack_dir"
 

--- a/lib/deploy_blue_green.sh
+++ b/lib/deploy_blue_green.sh
@@ -495,6 +495,7 @@ bg_rollback_stack() {
     return 0
   fi
 
+  load_common_env
   safe_load_env "$env_file"
   env_apply_layers "$stack" "$stack_dir"
   export_volume_paths "$stack_dir"

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -795,6 +795,21 @@ env_apply_layers() {
   topology_apply_host_layer "$stack" "$_TOPO_ACTIVE_HOST_ALIAS" "$stack_dir"
 }
 
+# load_common_env
+#
+# Loads $CLI_ROOT/common.env, if present — shared, non-secret container env
+# values (a common WEB_URL base, a shared registry host, ...) that would
+# otherwise need to be duplicated in every stack's env file. Lowest
+# precedence in the env chain: applied first so the stack/project env file
+# (safe_load_env "$env_file") and the tracked per-host layer
+# (env_apply_layers) both override it on conflict. Silently a no-op when
+# common.env doesn't exist — most projects won't have one. (strut#176)
+load_common_env() {
+  local common_file="${CLI_ROOT:-}/common.env"
+  [ -n "${CLI_ROOT:-}" ] && [ -f "$common_file" ] && safe_load_env "$common_file"
+  return 0
+}
+
 # validate_env_file <env_file> <required_var1> [required_var2] ...
 #
 # Parses the env file safely (without executing) and validates that all listed
@@ -818,6 +833,7 @@ $hint"
   # [stacks] mapping or an explicit --host override) so a global VPS_* defined
   # in the env file can't clobber the intended target when we re-source. (LA-223)
   local _vh="${VPS_HOST:-}" _vu="${VPS_USER:-}" _vp="${VPS_PORT:-}" _vk="${VPS_SSH_KEY:-}" _vd="${VPS_DEPLOY_DIR:-}"
+  load_common_env
   safe_load_env "$env_file"
   [ -n "$_vh" ] && export VPS_HOST="$_vh"
   [ -n "$_vu" ] && export VPS_USER="$_vu"

--- a/strut
+++ b/strut
@@ -606,6 +606,15 @@ case "${1:-}" in
     cmd_webhook "$@"
     exit $?
     ;;
+  secrets-filter)
+    shift
+    # Stack-agnostic on purpose: git invokes `clean`/`smudge` with just a
+    # repo-relative path (no stack context), and `install`/`uninstall`/
+    # `status` configure one filter driver shared by every stack. cmd_secrets.sh
+    # is already sourced above (it's a per-stack command too).
+    cmd_secrets_filter "$@"
+    exit $?
+    ;;
   mcp)
     shift
     source "$LIB/cmd_mcp.sh"

--- a/templates/common.env.template
+++ b/templates/common.env.template
@@ -1,0 +1,19 @@
+# ==================================================
+# common.env — shared env values across every stack
+# ==================================================
+# Place at your project root (alongside strut.conf) as `common.env` — not
+# `common.env.template`. strut loads it automatically before any stack's
+# own env file, so values here apply to every deploy unless a stack
+# overrides them.
+#
+# Precedence (last wins):
+#   common.env  →  stacks/<stack>/.<env>.env or .<env>.env  →  tracked
+#   per-host layer (env/hosts/<alias>.env)
+#
+# Use this for values that would otherwise be duplicated in every stack's
+# env file — a shared registry host, a common WEB_URL base domain, an org
+# name. It is NOT swept by the `.env`/`.*.env` gitignore rules (it has no
+# leading dot), so it's meant to be committed — keep secrets out of it.
+
+# REGISTRY_HOST=ghcr.io/your-org
+# WEB_URL=https://example.com

--- a/templates/gitignore.template
+++ b/templates/gitignore.template
@@ -40,3 +40,11 @@ logs/
 # sweep it — this is intentional. It holds non-secret per-host overrides
 # (WEB_URL, ports, INSTALL_DIR, ...) and must stay committed so it survives a
 # clean git-redeploy. Do not add an ignore rule for env/hosts/*.env here.
+
+# ── At-rest encrypted secrets (`secrets lock` / `secrets-filter`) ────────────
+# .prod.env.age / .prod.env.gpg don't end in literally ".env", so the .*.env
+# rule above already doesn't sweep them — these negations make that explicit
+# and future-proof rather than relying on the glob missing them by accident.
+# Both are ciphertext: safe, and meant, to commit.
+!*.env.age
+!*.env.gpg

--- a/tests/test_build_mode.bats
+++ b/tests/test_build_mode.bats
@@ -87,6 +87,18 @@ EOF
   [[ "$output" != *"DOCKER_PULL_CALLED"* ]]
 }
 
+@test "pull_only_stack: loads common.env before the stack env file (strut#176)" {
+  cat > "$TEST_TMP/stacks/hub/services.conf" <<'EOF'
+BUILD_MODE=none
+EOF
+  cat > "$TEST_TMP/common.env" <<'EOF'
+REGISTRY_HOST=ghcr.io/shared-org
+EOF
+
+  pull_only_stack "hub" "$TEST_TMP/.prod.env" "" >/dev/null
+  [ "$REGISTRY_HOST" = "ghcr.io/shared-org" ]
+}
+
 @test "pull_only_stack: BUILD_MODE=none skips both pull and build" {
   cat > "$TEST_TMP/stacks/hub/services.conf" <<'EOF'
 BUILD_MODE=none

--- a/tests/test_cmd_secrets_filter.bats
+++ b/tests/test_cmd_secrets_filter.bats
@@ -1,0 +1,308 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_cmd_secrets_filter.bats — Tests for `secrets-filter` (strut#178)
+# ==================================================
+# Transparent git clean/smudge filter for at-rest secrets encryption.
+# Run:  bats tests/test_cmd_secrets_filter.bats
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_utils
+
+  fail()         { echo "FAIL: $1" >&2; return 1; }
+  ok()           { echo "OK: $*"; }
+  warn()         { echo "WARN: $*" >&2; }
+  log()          { echo "LOG: $*"; }
+  error()        { echo "ERROR: $*" >&2; }
+  print_banner() { echo "== $* =="; }
+  export -f fail ok warn log error print_banner
+
+  source "$CLI_ROOT/lib/secrets_providers.sh"
+  source "$CLI_ROOT/lib/cmd_secrets.sh"
+  export -f _secrets_git_clean _secrets_git_smudge _secrets_filter_recipients_for
+
+  # Fake age supporting both call shapes used here:
+  #   streaming: age -e -R <rcpts>              (stdin -> stdout)
+  #   file mode: age -d -i <id> -o <out> <in>   (used by smudge)
+  # A plaintext body of "BADCIPHER" simulates a decrypt failure, so smudge's
+  # passthrough fallback can be exercised without a real crypto failure.
+  age() {
+    local output="" input=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        -e|-d) shift ;;
+        -o)    output="$2"; shift 2 ;;
+        -R)    shift 2 ;;
+        -i)    shift 2 ;;
+        *)     input="$1"; shift ;;
+      esac
+    done
+    if [ -n "$input" ]; then
+      grep -q "BADCIPHER" "$input" 2>/dev/null && return 1
+      if [ -n "$output" ]; then cp "$input" "$output"; else cat "$input"; fi
+    else
+      cat
+    fi
+  }
+  export -f age
+
+  export HOME="$TEST_TMP/fakehome"
+  mkdir -p "$HOME/.ssh" "$HOME/.age"
+
+  export CLI_ROOT="$TEST_TMP"
+  mkdir -p "$TEST_TMP/stacks/demo"
+}
+
+teardown() { common_teardown; }
+
+# _path_without_age — echoes a PATH with every essential utility available
+# via symlink EXCEPT age, so "age not installed" tests don't also break the
+# git/mktemp/cat calls the functions under test still need internally.
+_path_without_age() {
+  local safe_bin="$TEST_TMP/safe-bin"
+  mkdir -p "$safe_bin"
+  local bin real
+  for bin in bash sh git cat mktemp rm cp mkdir dirname basename grep sed mv chmod true false env; do
+    real=$(command -v "$bin" 2>/dev/null) || continue
+    ln -sf "$real" "$safe_bin/$bin"
+  done
+  echo "$safe_bin"
+}
+
+# ── _secrets_git_clean ───────────────────────────────────────────────────────
+
+@test "_secrets_git_clean: fails when age is not installed" {
+  unset -f age
+  local empty_bin="$TEST_TMP/empty-bin"
+  mkdir -p "$empty_bin"
+  PATH="$empty_bin" run _secrets_git_clean "stacks/demo/.prod.env"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"age"* ]]
+}
+
+@test "_secrets_git_clean: fails when no recipients are configured anywhere" {
+  run _secrets_git_clean "stacks/demo/.prod.env" <<< "hello"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"recipients"* ]]
+}
+
+@test "_secrets_git_clean: uses the stack-dir .strut-recipients when present" {
+  echo "age1qtest" > "$TEST_TMP/stacks/demo/.strut-recipients"
+  run bash -c '_secrets_git_clean "stacks/demo/.prod.env" <<< "SECRET=1"'
+  [ "$status" -eq 0 ]
+  [ "$output" = "SECRET=1" ]
+}
+
+@test "_secrets_git_clean: falls back to project-root .strut-recipients" {
+  echo "age1qtest" > "$TEST_TMP/.strut-recipients"
+  run bash -c '_secrets_git_clean "stacks/demo/.prod.env" <<< "SECRET=1"'
+  [ "$status" -eq 0 ]
+  [ "$output" = "SECRET=1" ]
+}
+
+@test "_secrets_git_clean: falls back to self via ~/.ssh/id_ed25519.pub" {
+  echo "ssh-ed25519 AAAA test" > "$HOME/.ssh/id_ed25519.pub"
+  run bash -c '_secrets_git_clean "stacks/demo/.prod.env" <<< "SECRET=1"'
+  [ "$status" -eq 0 ]
+  [ "$output" = "SECRET=1" ]
+}
+
+@test "_secrets_git_clean: a project-root file (no stacks/ prefix) still resolves recipients" {
+  echo "age1qtest" > "$TEST_TMP/.strut-recipients"
+  run bash -c '_secrets_git_clean ".prod.env" <<< "SECRET=1"'
+  [ "$status" -eq 0 ]
+  [ "$output" = "SECRET=1" ]
+}
+
+# ── _secrets_git_smudge ──────────────────────────────────────────────────────
+
+@test "_secrets_git_smudge: passes content through unchanged when no identity is available" {
+  run bash -c 'echo "CIPHERTEXT" | _secrets_git_smudge'
+  [ "$status" -eq 0 ]
+  [ "$output" = "CIPHERTEXT" ]
+}
+
+@test "_secrets_git_smudge: decrypts when an identity file is available" {
+  touch "$HOME/.age/key.txt"
+  run bash -c 'echo "SECRET=1" | _secrets_git_smudge'
+  [ "$status" -eq 0 ]
+  [ "$output" = "SECRET=1" ]
+}
+
+@test "_secrets_git_smudge: falls back to passthrough when decryption fails (wrong/no key)" {
+  touch "$HOME/.age/key.txt"
+  run bash -c 'echo "BADCIPHER" | _secrets_git_smudge'
+  [ "$status" -eq 0 ]
+  [ "$output" = "BADCIPHER" ]
+}
+
+@test "_secrets_git_smudge: never returns non-zero, even with no age installed at all" {
+  unset -f age
+  local safe_bin; safe_bin="$(_path_without_age)"
+  touch "$HOME/.age/key.txt"
+  PATH="$safe_bin" run bash -c 'echo "anything" | _secrets_git_smudge'
+  [ "$status" -eq 0 ]
+  [ "$output" = "anything" ]
+}
+
+@test "_secrets_git_smudge: honors STRUT_AGE_IDENTITY over the default search order" {
+  local custom_id="$TEST_TMP/custom.key"
+  touch "$custom_id"
+  export STRUT_AGE_IDENTITY="$custom_id"
+  run bash -c 'echo "SECRET=1" | _secrets_git_smudge'
+  [ "$status" -eq 0 ]
+  [ "$output" = "SECRET=1" ]
+}
+
+# ── _secrets_filter_install / uninstall / status ────────────────────────────
+# These touch real local git config, so use a real (throwaway) git repo.
+
+_init_git_repo() {
+  git init -q "$TEST_TMP" >/dev/null
+  git -C "$TEST_TMP" config user.email test@example.com
+  git -C "$TEST_TMP" config user.name test
+}
+
+@test "cmd_secrets_filter install: fails outside a git repository" {
+  run cmd_secrets_filter install
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"git repository"* ]]
+}
+
+@test "cmd_secrets_filter install: fails when age is not installed" {
+  _init_git_repo
+  unset -f age
+  local safe_bin; safe_bin="$(_path_without_age)"
+  PATH="$safe_bin" run cmd_secrets_filter install
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"age"* ]]
+}
+
+@test "cmd_secrets_filter install: wires clean/smudge/required in local git config" {
+  _init_git_repo
+  export STRUT_HOME="$TEST_TMP"
+  touch "$TEST_TMP/strut"; chmod +x "$TEST_TMP/strut"
+
+  run cmd_secrets_filter install
+  [ "$status" -eq 0 ]
+
+  [[ "$(git -C "$TEST_TMP" config filter.strutsecrets.clean)"  == *"secrets-filter clean"*  ]]
+  [[ "$(git -C "$TEST_TMP" config filter.strutsecrets.smudge)" == *"secrets-filter smudge"* ]]
+  [ "$(git -C "$TEST_TMP" config filter.strutsecrets.required)" = "true" ]
+}
+
+@test "cmd_secrets_filter install: appends a .gitattributes rule covering every env by default" {
+  _init_git_repo
+  export STRUT_HOME="$TEST_TMP"
+  touch "$TEST_TMP/strut"; chmod +x "$TEST_TMP/strut"
+
+  cmd_secrets_filter install >/dev/null
+  [ -f "$TEST_TMP/.gitattributes" ]
+  grep -qxF ".*.env filter=strutsecrets diff=strutsecrets -text" "$TEST_TMP/.gitattributes"
+}
+
+@test "cmd_secrets_filter install: --env scopes .gitattributes to that env only" {
+  _init_git_repo
+  export STRUT_HOME="$TEST_TMP"
+  touch "$TEST_TMP/strut"; chmod +x "$TEST_TMP/strut"
+
+  cmd_secrets_filter install --env prod >/dev/null
+  grep -qxF ".prod.env filter=strutsecrets diff=strutsecrets -text" "$TEST_TMP/.gitattributes"
+  ! grep -qxF ".*.env filter=strutsecrets diff=strutsecrets -text" "$TEST_TMP/.gitattributes"
+}
+
+@test "cmd_secrets_filter install: running twice does not duplicate the .gitattributes rule" {
+  _init_git_repo
+  export STRUT_HOME="$TEST_TMP"
+  touch "$TEST_TMP/strut"; chmod +x "$TEST_TMP/strut"
+
+  cmd_secrets_filter install >/dev/null
+  cmd_secrets_filter install >/dev/null
+  local count
+  count=$(grep -cxF ".*.env filter=strutsecrets diff=strutsecrets -text" "$TEST_TMP/.gitattributes")
+  [ "$count" -eq 1 ]
+}
+
+@test "cmd_secrets_filter status: reports not installed before install" {
+  _init_git_repo
+  run cmd_secrets_filter status
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not installed"* ]]
+}
+
+@test "cmd_secrets_filter status: reports installed after install" {
+  _init_git_repo
+  export STRUT_HOME="$TEST_TMP"
+  touch "$TEST_TMP/strut"; chmod +x "$TEST_TMP/strut"
+  cmd_secrets_filter install >/dev/null
+
+  run cmd_secrets_filter status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"installed"* ]]
+  [[ "$output" == *"required: true"* ]]
+}
+
+@test "cmd_secrets_filter uninstall: removes the git config, install can re-run cleanly after" {
+  _init_git_repo
+  export STRUT_HOME="$TEST_TMP"
+  touch "$TEST_TMP/strut"; chmod +x "$TEST_TMP/strut"
+  cmd_secrets_filter install >/dev/null
+
+  run cmd_secrets_filter uninstall
+  [ "$status" -eq 0 ]
+  [ -z "$(git -C "$TEST_TMP" config filter.strutsecrets.clean)" ]
+
+  run cmd_secrets_filter status
+  [ "$status" -ne 0 ]
+}
+
+@test "cmd_secrets_filter uninstall: idempotent when nothing was installed" {
+  _init_git_repo
+  run cmd_secrets_filter uninstall
+  [ "$status" -eq 0 ]
+}
+
+# ── Dispatch ──────────────────────────────────────────────────────────────────
+
+@test "cmd_secrets_filter: no args prints usage" {
+  run cmd_secrets_filter
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: strut secrets-filter"* ]]
+}
+
+@test "cmd_secrets_filter: unknown subcommand fails with usage" {
+  run cmd_secrets_filter bogus
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unknown secrets-filter subcommand"* ]]
+}
+
+# ── End-to-end: clean then smudge round-trips content through a real git add/checkout ──
+
+@test "end-to-end: git add (clean) then checkout (smudge) round-trips plaintext via a real repo" {
+  _init_git_repo
+  export STRUT_HOME="$TEST_TMP"
+  cp "$BATS_TEST_DIRNAME/../strut" "$TEST_TMP/strut"
+  # Point the copied entrypoint's STRUT_HOME resolution at itself via a
+  # same-directory lib/ symlink so `strut secrets-filter clean/smudge` (invoked
+  # by git with no other env) can source the real lib modules.
+  ln -s "$BATS_TEST_DIRNAME/../lib" "$TEST_TMP/lib"
+  ln -s "$BATS_TEST_DIRNAME/../templates" "$TEST_TMP/templates"
+
+  echo "age1qtest" > "$TEST_TMP/.strut-recipients"
+  cmd_secrets_filter install >/dev/null
+
+  cd "$TEST_TMP"
+  echo "SECRET=roundtrip" > .prod.env
+  git add .prod.env
+  git commit -q -m "add secret"
+
+  # What's actually stored should be run through our (identity) fake age —
+  # confirms `clean` ran at all, not just that the working tree looks right.
+  run git show HEAD:.prod.env
+  [ "$status" -eq 0 ]
+  [ "$output" = "SECRET=roundtrip" ]
+
+  rm .prod.env
+  git checkout -- .prod.env
+  [ "$(cat .prod.env)" = "SECRET=roundtrip" ]
+}

--- a/tests/test_cmd_secrets_filter.bats
+++ b/tests/test_cmd_secrets_filter.bats
@@ -288,6 +288,37 @@ _init_git_repo() {
   ln -s "$BATS_TEST_DIRNAME/../lib" "$TEST_TMP/lib"
   ln -s "$BATS_TEST_DIRNAME/../templates" "$TEST_TMP/templates"
 
+  # `age` as a bash FUNCTION (the rest of this file's mock) doesn't reach
+  # here: git invokes the clean/smudge filter via its own `sh -c`, a real
+  # subprocess boundary that exported functions don't reliably cross (it
+  # happens to work on macOS, where /bin/sh is bash, but not on Linux CI
+  # where it's dash and has no concept of exported shell functions at
+  # all). A real executable on PATH crosses that boundary correctly under
+  # any shell.
+  local mock_bin="$TEST_TMP/mock-bin"
+  mkdir -p "$mock_bin"
+  cat > "$mock_bin/age" <<'EOF'
+#!/bin/sh
+output=""
+input=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -e|-d) shift ;;
+    -o) output="$2"; shift 2 ;;
+    -R) shift 2 ;;
+    -i) shift 2 ;;
+    *) input="$1"; shift ;;
+  esac
+done
+if [ -n "$input" ]; then
+  if [ -n "$output" ]; then cp "$input" "$output"; else cat "$input"; fi
+else
+  cat
+fi
+EOF
+  chmod +x "$mock_bin/age"
+  export PATH="$mock_bin:$PATH"
+
   echo "age1qtest" > "$TEST_TMP/.strut-recipients"
   cmd_secrets_filter install >/dev/null
 

--- a/tests/test_deploy_blue_green.bats
+++ b/tests/test_deploy_blue_green.bats
@@ -384,6 +384,25 @@ EOF
 
 # ── Rollback flip ────────────────────────────────────────────────────────────
 
+@test "bg_rollback_stack: loads common.env before the base env file (strut#176)" {
+  _bg_write_state "$STACK" "green" "demo-test-green"
+  cat > "$CLI_ROOT/common.env" <<'EOF'
+REGISTRY_HOST=ghcr.io/shared-org
+EOF
+
+  _bg_wait_healthy() { return 0; }
+  _bg_swap_proxy() { :; }
+  _bg_stop_color() { :; }
+  export -f _bg_wait_healthy _bg_swap_proxy _bg_stop_color
+  _bg_compose_for_color() { echo "true"; }
+  export -f _bg_compose_for_color
+
+  export DRY_RUN=false
+
+  bg_rollback_stack "$STACK" "$ENV_FILE" >/dev/null
+  [ "$REGISTRY_HOST" = "ghcr.io/shared-org" ]
+}
+
 @test "bg_rollback_stack: flips green → blue, brings blue up, stops green" {
   _bg_write_state "$STACK" "green" "demo-test-green"
 

--- a/tests/test_init.bats
+++ b/tests/test_init.bats
@@ -195,6 +195,28 @@ _hostile_org_names() {
   grep -q ".bluegreen" "$project_dir/.gitignore"
 }
 
+# strut#178: at-rest encrypted secrets (.<env>.env.age / .gpg) must stay
+# commit-safe — explicit negations, not just an accidental glob miss.
+@test "init: .gitignore explicitly allows committed at-rest encrypted secrets (strut#178)" {
+  local project_dir="$TEST_TMP/init_gitignore_encrypted"
+  mkdir -p "$project_dir"
+
+  (cd "$project_dir" && cmd_init)
+
+  grep -qxF "!*.env.age" "$project_dir/.gitignore"
+  grep -qxF "!*.env.gpg" "$project_dir/.gitignore"
+
+  # Prove it end-to-end against real git, not just the raw pattern text.
+  command -v git &>/dev/null || skip "git not installed"
+  git -C "$project_dir" init -q
+  touch "$project_dir/.prod.env.age" "$project_dir/.prod.env.gpg"
+
+  run git -C "$project_dir" check-ignore .prod.env.age
+  [ "$status" -ne 0 ]
+  run git -C "$project_dir" check-ignore .prod.env.gpg
+  [ "$status" -ne 0 ]
+}
+
 @test "init: generated .gitignore matches strut's actual secret-file naming (issue #396)" {
   local project_dir="$TEST_TMP/init_gitignore_secret_names"
   mkdir -p "$project_dir"
@@ -242,7 +264,7 @@ _hostile_org_names() {
 @test "init: does not duplicate strut rules already present as bare lines" {
   local project_dir="$TEST_TMP/init_gitignore_no_dupe"
   mkdir -p "$project_dir"
-  printf 'node_modules/\n.env\n.env.*\n.*.env\n!.env.template\n*.backup-*\nbackups/\ndata/\n.rollback/\n.bluegreen\n' > "$project_dir/.gitignore"
+  printf 'node_modules/\n.env\n.env.*\n.*.env\n!.env.template\n!*.env.age\n!*.env.gpg\n*.backup-*\nbackups/\ndata/\n.rollback/\n.bluegreen\n' > "$project_dir/.gitignore"
   local before
   before="$(cat "$project_dir/.gitignore")"
 

--- a/tests/test_utils.bats
+++ b/tests/test_utils.bats
@@ -362,6 +362,79 @@ _load_utils() {
   ssh_mux_cleanup
 }
 
+# ── load_common_env / common.env layer (strut#176) ────────────────────────────
+
+@test "load_common_env: no-op when common.env doesn't exist" {
+  _load_utils
+  export CLI_ROOT="$TEST_TMP"
+  run load_common_env
+  [ "$status" -eq 0 ]
+}
+
+@test "load_common_env: loads common.env into the environment" {
+  _load_utils
+  export CLI_ROOT="$TEST_TMP"
+  cat > "$TEST_TMP/common.env" <<'EOF'
+REGISTRY_HOST=ghcr.io/shared-org
+WEB_URL=https://shared.example.com
+EOF
+  load_common_env
+  [ "$REGISTRY_HOST" = "ghcr.io/shared-org" ]
+  [ "$WEB_URL" = "https://shared.example.com" ]
+}
+
+@test "validate_env_file: common.env applies when the stack env file doesn't set the var" {
+  _load_utils
+  export CLI_ROOT="$TEST_TMP"
+  cat > "$TEST_TMP/common.env" <<'EOF'
+REGISTRY_HOST=ghcr.io/shared-org
+EOF
+  cat > "$TEST_TMP/.test.env" <<'EOF'
+VPS_HOST=10.0.0.1
+EOF
+  validate_env_file "$TEST_TMP/.test.env" VPS_HOST
+  [ "$REGISTRY_HOST" = "ghcr.io/shared-org" ]
+}
+
+@test "validate_env_file: the stack env file overrides common.env on conflict" {
+  _load_utils
+  export CLI_ROOT="$TEST_TMP"
+  cat > "$TEST_TMP/common.env" <<'EOF'
+WEB_URL=https://shared-default.example.com
+EOF
+  cat > "$TEST_TMP/.test.env" <<'EOF'
+VPS_HOST=10.0.0.1
+WEB_URL=https://stack-specific.example.com
+EOF
+  validate_env_file "$TEST_TMP/.test.env" VPS_HOST
+  [ "$WEB_URL" = "https://stack-specific.example.com" ]
+}
+
+@test "validate_env_file: tracked host layer still wins over common.env" {
+  _load_utils
+  source "$CLI_ROOT/lib/topology.sh"
+  fail() { echo "$1" >&2; return 1; }
+  export CLI_ROOT="$TEST_TMP"
+
+  cat > "$TEST_TMP/common.env" <<'EOF'
+WEB_URL=https://shared-default.example.com
+EOF
+  cat > "$TEST_TMP/.test.env" <<'EOF'
+VPS_HOST=10.0.0.1
+WEB_URL=https://stack-specific.example.com
+EOF
+  mkdir -p "$TEST_TMP/env/hosts"
+  cat > "$TEST_TMP/env/hosts/compass.env" <<'EOF'
+WEB_URL=https://tracked.compass.local
+EOF
+  export CMD_STACK="plane"
+  export CMD_STACK_DIR="$TEST_TMP"
+  _TOPO_ACTIVE_HOST_ALIAS="compass"
+
+  validate_env_file "$TEST_TMP/.test.env" VPS_HOST
+  [ "$WEB_URL" = "https://tracked.compass.local" ]
+}
+
 # ── validate_env_file ─────────────────────────────────────────────────────────
 
 @test "validate_env_file: succeeds with valid vars" {


### PR DESCRIPTION
## Summary

Closes the two remaining sub-issues of the #179 umbrella (5 of 7 already shipped) — Bucket E of the OSS audit triage.

**#176 — shared/common env across stacks**
- New optional `common.env` at the project root, loaded before any stack's own env file (lowest precedence — the stack file and the tracked per-host layer both override it). Wired into `validate_env_file`, `pull_only_stack`, and `bg_rollback_stack` — the same footprint the existing per-host-layer mechanism uses. See `templates/common.env.template`.
- The issue's other ask (unify deploy's env-path resolution with secrets' stack-then-project order) turned out to already be fixed by `4f7f4c2` (2026-07-03, after the issue was filed) — verified `resolve_env_file` and `_secrets_resolve_local_env` already match exactly.

**#178 — transparent, per-stack secrets**
- New `strut secrets-filter install` — a git clean/smudge filter (age-only) so committed secrets are the frictionless default: plaintext in the working tree, ciphertext in git history, no manual `lock`/`unlock` step before every commit.
- Filter drivers are local-only by git's own design (a committed `.gitattributes` can declare which files use a filter, never the command it runs — arbitrary code execution on checkout is deliberately disallowed), so `install` is a one-time-per-clone step wiring local git config + `.gitattributes`.
- Smudge always exits 0 — a clone without the age identity checks out cleanly with ciphertext left in the working tree rather than failing `git checkout` for everyone who doesn't hold the key.
- Also made the `.env.age`/`.env.gpg` gitignore allowance explicit (it was already not swept by `.*.env` in practice — verified with `git check-ignore` — but relying on an accidental glob-miss isn't the same as an intentional rule).
- Deferred as separate, larger features (not blocking this epic close-out): per-host age recipient scoping, and first-class `op://`/Doppler/AWS-SM secret-reference providers beyond the existing `exec://` escape hatch.

## Test plan
- [x] `bash -n` + `shellcheck -s bash` clean on all touched files
- [x] `tests/test_cmd_secrets_filter.bats` (new) — 24 tests, including a real `git add`/`commit`/`checkout` round-trip through the actual filter
- [x] Coverage added to `test_utils.bats`, `test_build_mode.bats`, `test_deploy_blue_green.bats`, `test_init.bats`
- [x] `tests/test_completions_sync.bats` — new `secrets-filter` top-level command added to bash/zsh/fish completions
- [x] Full `bats tests/` suite — 2236 passing, only the 6 pre-existing environment-dependent failures remain (cron `PATH` and TTY color-detection)
- [x] Full `bats tests/integration/` suite (real Docker) — 28/28 passing