### PR TITLE
fix(webhook): _all_stacks always returns 0

### DIFF
--- a/lib/cmd_webhook.sh
+++ b/lib/cmd_webhook.sh
@@ -162,6 +162,7 @@ _all_stacks() {
   ls "$cli_root/stacks" 2>/dev/null | while read -r d; do
     [ -d "$cli_root/stacks/$d" ] && echo "$d"
   done
+  return 0
 }
 
 _webhook_release_stack() {

--- a/tests/test_cmd_webhook.bats
+++ b/tests/test_cmd_webhook.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_cmd_webhook.bats — Tests for lib/cmd_webhook.sh
+# ==================================================
+# Run:  bats tests/test_cmd_webhook.bats
+# Covers: _all_stacks
+
+# ── Setup ─────────────────────────────────────────────────────────────────────
+
+setup() {
+  export CLI_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  TEST_TMP="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+}
+
+_load_webhook() {
+  source "$CLI_ROOT/lib/cmd_webhook.sh"
+}
+
+# ── _all_stacks: trailing non-directory entry must not fail the function ─────
+# Regression: ls sorts alphabetically, so a stray non-directory file sorting
+# after all real stack dirs (e.g. a README, .DS_Store, editor swap file) made
+# the loop's final `[ -d ... ]` test fail, which was the function's last
+# executed command — returning exit 1 even though the stack list on stdout
+# was correct. Under `set -euo pipefail`, the plain assignment
+# `changed_stacks=$(_all_stacks "$cli_root")` in `_poll_cycle` would then
+# abort the whole poll cycle via errexit.
+
+@test "_all_stacks: returns 0 and lists only dirs when a non-dir file sorts last" {
+  _load_webhook
+
+  local root="$TEST_TMP/proj"
+  mkdir -p "$root/stacks/alpha" "$root/stacks/beta"
+  touch "$root/stacks/zzz-not-a-dir.txt"
+
+  run _all_stacks "$root"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf 'alpha\nbeta')" ]
+}
+
+@test "_all_stacks: returns 0 and empty output when stacks dir is missing" {
+  _load_webhook
+
+  run _all_stacks "$TEST_TMP/nonexistent"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "_all_stacks: returns 0 and lists only dirs when stacks dir has no non-dir entries" {
+  _load_webhook
+
+  local root="$TEST_TMP/proj2"
+  mkdir -p "$root/stacks/alpha" "$root/stacks/beta"
+
+  run _all_stacks "$root"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf 'alpha\nbeta')" ]
+}


### PR DESCRIPTION
## Summary
- `_all_stacks()` in `lib/cmd_webhook.sh` returned the exit code of its last executed command, which was the `[ -d ... ]` test on the final `ls` entry. If a stray non-directory file (e.g. `.DS_Store`, a README) sorted alphabetically after all real stack directories, that test evaluated false and the function returned 1 even though it printed the correct stack list.
- Under `set -euo pipefail`, the caller in `_poll_cycle` (`changed_stacks=$(_all_stacks "$cli_root")`) would then trip errexit and silently abort the entire poll cycle.
- Added `return 0` at the end of `_all_stacks` so its exit status no longer depends on the last loop iteration.

## Test plan
- [x] `bash -n lib/cmd_webhook.sh` and `shellcheck -s bash lib/cmd_webhook.sh` pass
- [x] New `tests/test_cmd_webhook.bats` covers: trailing non-dir file sorting last, missing `stacks/` dir, and the normal all-dirs case
- [x] Confirmed the regression test fails against the pre-fix code and passes with the fix
- [x] Full `bats tests/` suite (2213 tests) run — no regressions; 6 pre-existing failures reproduce identically on baseline (unrelated: cron PATH sandboxing, dashboard cache timing, TTY color detection)