### PR TITLE
fix: standalone infra bugs — webhook (dash), monitor (compose v1), domain/ssl

### DIFF
--- a/lib/cmd_webhook.sh
+++ b/lib/cmd_webhook.sh
@@ -223,10 +223,22 @@ _webhook_serve() {
   export _WEBHOOK_BRANCH="$branch"
   export _WEBHOOK_CLI_ROOT="${CLI_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 
-  local handler_script
-  handler_script=$(_webhook_handler_script)
+  # Write the handler to a real, executable file rather than passing its
+  # text directly as socat's SYSTEM: command. socat runs SYSTEM: via
+  # `/bin/sh -c "<text>"` — on stock Debian/Ubuntu /bin/sh is dash, which
+  # chokes on this script's bash-only syntax (${line,,}, $'\r') before it
+  # ever validates a request. Pointing SYSTEM: at a file with a bash
+  # shebang instead makes the KERNEL exec it via #!/usr/bin/env bash,
+  # sidestepping dash entirely (strut#393).
+  local handler_file
+  handler_file=$(mktemp "${TMPDIR:-/tmp}/strut-webhook-handler.XXXXXX")
+  _webhook_handler_script > "$handler_file"
+  chmod +x "$handler_file"
+  if declare -F strut_register_cleanup >/dev/null; then
+    strut_register_cleanup "rm -f '$handler_file'"
+  fi
 
-  socat "TCP-LISTEN:$port,fork,reuseaddr" "SYSTEM:$handler_script"
+  socat "TCP-LISTEN:$port,fork,reuseaddr" "SYSTEM:$handler_file"
 }
 
 _webhook_handler_script() {
@@ -241,9 +253,19 @@ signature=""
 while IFS= read -r line; do
   line="${line%%$'\r'}"
   [ -z "$line" ] && break
+  # Strip up to the first colon, then any leading whitespace — tolerant of
+  # a missing space after ':' (a reformatting proxy can drop it, which
+  # would otherwise leave content_length non-numeric and silently zero the
+  # body read below).
   case "${line,,}" in
-    content-length:*) content_length="${line#*: }" ;;
-    x-hub-signature-256:*) signature="${line#*: }" ;;
+    content-length:*)
+      content_length="${line#*:}"
+      content_length="$(echo "$content_length" | sed 's/^[[:space:]]*//')"
+      ;;
+    x-hub-signature-256:*)
+      signature="${line#*:}"
+      signature="$(echo "$signature" | sed 's/^[[:space:]]*//')"
+      ;;
   esac
 done
 

--- a/lib/domain/cmd.sh
+++ b/lib/domain/cmd.sh
@@ -70,8 +70,8 @@ domain_command() {
     esac
     if ! $skip_ssl; then
       run_cmd "Commit SSL config to git" git commit -m "[SSL] Configure HTTPS for $domain"
-      run_cmd "Push to git" git push origin main
-      run_cmd "Update VPS repo" ssh "$vps_user@$vps_host" "git pull origin main"
+      run_cmd "Push to git" git push
+      run_cmd "Update VPS repo" ssh "$vps_user@$vps_host" "git pull origin ${DEFAULT_BRANCH:-main}"
       run_cmd "Restart $proxy on VPS" ssh "$vps_user@$vps_host" "docker compose restart $proxy"
     fi
     echo ""
@@ -132,7 +132,7 @@ domain_command() {
         ok "SSL config committed and pushed to git"
         log "Updating VPS repo to sync SSL config..."
         ssh $ssh_opts "$vps_user@$vps_host" \
-          "cd '$deploy_dir' && git pull origin main"
+          "cd '$deploy_dir' && git pull origin ${DEFAULT_BRANCH:-main}"
         log "Restarting $proxy to load updated config..."
         ssh $ssh_opts "$vps_user@$vps_host" \
           "cd '$deploy_dir' && docker compose --project-name ${env_name:-prod} restart $proxy"

--- a/lib/monitor.sh
+++ b/lib/monitor.sh
@@ -58,7 +58,7 @@ wait_for_service() {
 # monitoring_deploy [env]
 #
 # Deploys the self-hosted monitoring stack (Prometheus, Grafana, Alertmanager)
-# using docker-compose in the monitoring stack directory.
+# using `docker compose` in the monitoring stack directory.
 #
 # Args:
 #   env — Environment name (default: "prod")
@@ -97,20 +97,28 @@ monitoring_deploy() {
     fi
   fi
 
+  # The engine elsewhere uses the `docker compose` v2 plugin exclusively
+  # (via resolve_compose_cmd); this stack still shelled out to the EOL v1
+  # `docker-compose` binary. On any host without it, `docker-compose
+  # config` fails with a swallowed command-not-found and the operator sees
+  # a misleading "Invalid docker-compose.yml" instead of the real problem
+  # (strut#394).
+  docker compose version &>/dev/null || fail "Docker Compose plugin not found — install: https://docs.docker.com/compose/install/"
+
   # Validate docker-compose.yml
   log "Validating docker-compose.yml..."
-  if ! docker-compose config > /dev/null 2>&1; then
+  if ! docker compose config > /dev/null 2>&1; then
     fail "Invalid docker-compose.yml"
   fi
   ok "Configuration valid"
 
   # Pull images
   log "Pulling Docker images..."
-  docker-compose pull || fail "Failed to pull images"
+  docker compose pull || fail "Failed to pull images"
 
   # Start services
   log "Starting monitoring services..."
-  docker-compose up -d || fail "Failed to start services"
+  docker compose up -d || fail "Failed to start services"
 
   # Load monitoring services config
   local monitoring_conf="$MONITORING_STACK_DIR/services.conf"
@@ -382,7 +390,7 @@ monitoring_alert_channel_add_email() {
   # Restart Alertmanager if running
   if docker ps | grep -q alertmanager; then
     log "Restarting Alertmanager..."
-    docker-compose -f "$MONITORING_STACK_DIR/docker-compose.yml" restart alertmanager
+    docker compose -f "$MONITORING_STACK_DIR/docker-compose.yml" restart alertmanager
     ok "Alertmanager restarted"
   fi
 
@@ -442,7 +450,7 @@ monitoring_alert_channel_add_slack() {
   # Restart Alertmanager if running
   if docker ps | grep -q alertmanager; then
     log "Restarting Alertmanager..."
-    docker-compose -f "$MONITORING_STACK_DIR/docker-compose.yml" restart alertmanager
+    docker compose -f "$MONITORING_STACK_DIR/docker-compose.yml" restart alertmanager
     ok "Alertmanager restarted"
   fi
 
@@ -495,7 +503,7 @@ monitoring_alert_channel_add_webhook() {
   # Restart Alertmanager if running
   if docker ps | grep -q alertmanager; then
     log "Restarting Alertmanager..."
-    docker-compose -f "$MONITORING_STACK_DIR/docker-compose.yml" restart alertmanager
+    docker compose -f "$MONITORING_STACK_DIR/docker-compose.yml" restart alertmanager
     ok "Alertmanager restarted"
   fi
 

--- a/lib/ssl/auto.sh
+++ b/lib/ssl/auto.sh
@@ -70,15 +70,23 @@ _ssl_detect_domains() {
 
   local domains=""
 
-  # Source 1: compose labels (strut.domain)
+  # Source 1: compose labels (strut.domain). `docker compose config`
+  # renders labels inline on one line (`strut.domain: example.com`, or
+  # `"strut.domain": "example.com"` under --format json, or
+  # `strut.domain=example.com` for list-form labels) — the value is never
+  # on the line AFTER the key. Match "strut.domain" plus the run of
+  # non-alphanumeric separator chars after it (quotes/colon/equals/space,
+  # in any combination), then capture the trailing domain-shaped token.
+  # This intentionally avoids matching quote characters literally, which
+  # would need escaping across two more layers of quoting (this local
+  # double-quoted string, then the remote shell) (strut#395).
   # shellcheck disable=SC2029
   local label_domains
   label_domains=$(ssh $ssh_opts "$vps_user@$vps_host" "
     cd '$deploy_dir' 2>/dev/null || exit 0
     docker compose -f 'stacks/$stack/docker-compose.yml' config 2>/dev/null \
-      | grep -A1 'strut.domain' \
-      | grep -v 'strut.domain' \
-      | tr -d ' \"' || true
+      | grep -oE 'strut\.domain[^A-Za-z0-9]*[A-Za-z0-9.-]+' \
+      | grep -oE '[A-Za-z0-9.-]+\$' || true
   " 2>/dev/null) || true
   [ -n "$label_domains" ] && domains="$label_domains"
 
@@ -160,12 +168,21 @@ _ssl_provision_one() {
     return 0
   fi
 
-  # Provision the certificate
+  # Provision the certificate. The --webroot attempt used to omit -d/
+  # --email/--non-interactive/--agree-tos entirely, so it never actually
+  # succeeded (certbot either prompts interactively or refuses outright
+  # without a domain) — every provision silently fell through to
+  # --standalone, which needs port 80 free and so conflicts with a proxy
+  # that's already bound to it (strut#395).
   log "auto-ssl: provisioning cert for $domain..."
   # shellcheck disable=SC2029
   if ssh $ssh_opts "$vps_user@$vps_host" "
     certbot certonly --webroot \
-      -w /var/www/certbot 2>/dev/null || \
+      -w /var/www/certbot \
+      --non-interactive --agree-tos \
+      --email '$email' \
+      -d '$domain' \
+      2>/dev/null || \
     certbot certonly --standalone \
       --non-interactive --agree-tos \
       --email '$email' \

--- a/tests/test_cmd_webhook.bats
+++ b/tests/test_cmd_webhook.bats
@@ -1,0 +1,237 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_cmd_webhook.bats — Tests for `webhook serve`'s HTTP handler (strut#393)
+# ==================================================
+# socat's SYSTEM: runs its command via `/bin/sh -c`. On stock Debian/Ubuntu
+# /bin/sh is dash, which chokes on this handler's bash-only syntax
+# (${line,,}, $'\r') if the raw script text is handed to `sh -c` directly.
+# The fix writes the handler to a real executable file with a bash shebang
+# so the KERNEL execs it via #!/usr/bin/env bash, sidestepping dash's
+# parser entirely — these tests exercise the handler under a real `dash`
+# (skipped where unavailable) exactly the way socat invokes it: `sh -c
+# "<path>"`, piping a fake HTTP request on stdin.
+#
+# Run:  bats tests/test_cmd_webhook.bats
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_utils
+
+  fail()  { echo "FAIL: $1" >&2; return 1; }
+  ok()    { echo "OK: $*"; }
+  warn()  { echo "WARN: $*" >&2; }
+  log()   { echo "LOG: $*"; }
+  export -f fail ok warn log
+
+  source "$CLI_ROOT/lib/cmd_webhook.sh"
+}
+
+teardown() { common_teardown; }
+
+_write_handler() {
+  CLI_ROOT="$TEST_TMP" _WEBHOOK_CLI_ROOT="$TEST_TMP" _webhook_handler_script > "$TEST_TMP/handler.sh"
+  chmod +x "$TEST_TMP/handler.sh"
+  echo "$TEST_TMP/handler.sh"
+}
+
+_skip_without_dash() {
+  command -v dash &>/dev/null || skip "dash not installed"
+}
+
+# ── Handler script is valid, portable-to-invoke bash ────────────────────────
+
+@test "_webhook_handler_script: emits a bash shebang" {
+  run _webhook_handler_script
+  [ "$status" -eq 0 ]
+  [[ "$(echo "$output" | head -1)" == "#!/usr/bin/env bash" ]]
+}
+
+@test "_webhook_handler_script: output is syntactically valid bash" {
+  local handler; handler="$(_write_handler)"
+  run bash -n "$handler"
+  [ "$status" -eq 0 ]
+}
+
+# ── strut#393: crashes under dash when passed as raw sh -c text ────────────
+
+@test "regression: the handler text (pre-fix invocation style) is NOT valid dash — proves the bug this fix addresses" {
+  _skip_without_dash
+  local handler; handler="$(_write_handler)"
+  # This is exactly the broken pattern replaced: `socat ... SYSTEM:"$(cat
+  # script)"` hands the raw TEXT to `sh -c`, instead of a file path. Needs
+  # at least one real header line so the loop reaches `${line,,}` — empty
+  # stdin hits EOF before the loop body ever runs, masking the bug.
+  run dash -c "$(cat "$handler")" <<'REQ'
+POST /webhook HTTP/1.1
+Content-Length: 2
+
+{}
+REQ
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Bad substitution"* ]] || [[ "$output" == *"substitution"* ]]
+}
+
+# ── The actual fix: invoking the FILE (as socat's SYSTEM: now does) works ──
+
+@test "_webhook_serve's fix: invoking the handler FILE under dash -c works (matches socat SYSTEM: semantics)" {
+  _skip_without_dash
+  local handler; handler="$(_write_handler)"
+  export _WEBHOOK_SECRET=""
+  export _WEBHOOK_BRANCH="main"
+  export _WEBHOOK_CLI_ROOT="$TEST_TMP"
+
+  run dash -c "$handler" <<'REQ'
+POST /webhook HTTP/1.1
+Content-Length: 47
+
+{"ref":"refs/heads/staging","other":"ignored"}
+REQ
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"200 OK"* ]]
+  [[ "$output" == *"skipped"* ]]
+}
+
+@test "handler: matching branch triggers the deploy response" {
+  _skip_without_dash
+  local handler; handler="$(_write_handler)"
+  export _WEBHOOK_SECRET=""
+  export _WEBHOOK_BRANCH="main"
+  export _WEBHOOK_CLI_ROOT="$TEST_TMP"
+  git -C "$TEST_TMP" init -q 2>/dev/null || true
+
+  run dash -c "$handler" <<'REQ'
+POST /webhook HTTP/1.1
+Content-Length: 43
+
+{"ref":"refs/heads/main","other":"ignored"}
+REQ
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"200 OK"* ]]
+  [[ "$output" == *"deployed"* ]]
+}
+
+# ── strut#393: Content-Length tolerant of a missing space after ':' ────────
+
+@test "handler: Content-Length without a space after the colon still reads the body" {
+  _skip_without_dash
+  local handler; handler="$(_write_handler)"
+  export _WEBHOOK_SECRET=""
+  export _WEBHOOK_BRANCH="main"
+  export _WEBHOOK_CLI_ROOT="$TEST_TMP"
+
+  run bash -c 'printf "POST /webhook HTTP/1.1\r\nContent-Length:47\r\n\r\n{\"ref\":\"refs/heads/staging\",\"other\":\"ignored\"}" | dash -c "'"$handler"'"'
+  [ "$status" -eq 0 ]
+  # If Content-Length failed to parse, content_length stays "0" and the
+  # body/ref is never read — push_branch would be empty, still != "main",
+  # so this alone wouldn't prove much. Assert the actual body length
+  # instead, by checking the ref DID get extracted (empty body => empty ref
+  # => "skipped" too, so cross-check via the matching-branch case below).
+  [[ "$output" == *"200 OK"* ]]
+}
+
+@test "handler: Content-Length without a space, matching branch, proves the body was actually read" {
+  _skip_without_dash
+  local handler; handler="$(_write_handler)"
+  export _WEBHOOK_SECRET=""
+  export _WEBHOOK_BRANCH="main"
+  export _WEBHOOK_CLI_ROOT="$TEST_TMP"
+  git -C "$TEST_TMP" init -q 2>/dev/null || true
+
+  run bash -c 'printf "POST /webhook HTTP/1.1\r\nContent-Length:43\r\n\r\n{\"ref\":\"refs/heads/main\",\"other\":\"ignored\"}" | dash -c "'"$handler"'"'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"deployed"* ]]
+}
+
+# ── HMAC signature validation ───────────────────────────────────────────────
+
+@test "handler: rejects a request with no/wrong signature when a secret is configured" {
+  _skip_without_dash
+  local handler; handler="$(_write_handler)"
+  export _WEBHOOK_SECRET="topsecret"
+  export _WEBHOOK_BRANCH="main"
+  export _WEBHOOK_CLI_ROOT="$TEST_TMP"
+
+  run dash -c "$handler" <<'REQ'
+POST /webhook HTTP/1.1
+Content-Length: 43
+X-Hub-Signature-256: sha256=deadbeef
+
+{"ref":"refs/heads/main","other":"ignored"}
+REQ
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"401 Unauthorized"* ]]
+}
+
+@test "handler: accepts a request with a correct HMAC signature" {
+  _skip_without_dash
+  command -v openssl &>/dev/null || skip "openssl not installed"
+  local handler; handler="$(_write_handler)"
+  export _WEBHOOK_SECRET="topsecret"
+  export _WEBHOOK_BRANCH="main"
+  export _WEBHOOK_CLI_ROOT="$TEST_TMP"
+  git -C "$TEST_TMP" init -q 2>/dev/null || true
+
+  local body='{"ref":"refs/heads/main","other":"ignored"}'
+  local sig
+  sig="sha256=$(printf '%s' "$body" | openssl dgst -sha256 -hmac "$_WEBHOOK_SECRET" | sed 's/^.* //')"
+
+  run bash -c "printf 'POST /webhook HTTP/1.1\r\nContent-Length: ${#body}\r\nX-Hub-Signature-256: $sig\r\n\r\n$body' | dash -c '$handler'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"200 OK"* ]]
+  [[ "$output" == *"deployed"* ]]
+}
+
+# ── _webhook_serve writes an executable file and registers cleanup ─────────
+
+@test "_webhook_serve: writes an executable handler file and registers its cleanup" {
+  socat() { echo "socat $*" > "$TEST_TMP/socat_call"; }
+  export -f socat
+  local cleanups_run=""
+  strut_register_cleanup() { cleanups_run="$cleanups_run $1"; }
+  export -f strut_register_cleanup
+
+  CLI_ROOT="$TEST_TMP" run _webhook_serve --port 9999 --secret shh
+  [ "$status" -eq 0 ]
+
+  local systemarg
+  systemarg=$(grep -oE 'SYSTEM:[^ ]+' "$TEST_TMP/socat_call")
+  local handler_path="${systemarg#SYSTEM:}"
+  [ -x "$handler_path" ]
+  [[ "$(head -1 "$handler_path")" == "#!/usr/bin/env bash" ]]
+}
+
+# ── Poll-mode pure helpers (unaffected by this fix, quick smoke coverage) ──
+
+@test "_all_stacks: lists stack directories" {
+  mkdir -p "$TEST_TMP/stacks/alpha" "$TEST_TMP/stacks/beta"
+  # A non-directory entry deliberately NOT last alphabetically — a known,
+  # separately-tracked bug makes _all_stacks return the last `ls` entry's
+  # own [ -d ] result as its exit code, so a stray file sorting after every
+  # real stack dir currently makes the function report failure even though
+  # its output is correct. Not this test's concern; just avoid tripping it.
+  touch "$TEST_TMP/stacks/00-not-a-dir.txt"
+  run _all_stacks "$TEST_TMP"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"alpha"* ]]
+  [[ "$output" == *"beta"* ]]
+  [[ "$output" != *"00-not-a-dir.txt"* ]]
+}
+
+@test "_detect_changed_stacks: maps changed files under stacks/ to stack names" {
+  git -C "$TEST_TMP" init -q
+  git -C "$TEST_TMP" config user.email t@example.com
+  git -C "$TEST_TMP" config user.name t
+  mkdir -p "$TEST_TMP/stacks/alpha"
+  echo one > "$TEST_TMP/stacks/alpha/file.txt"
+  git -C "$TEST_TMP" add -A
+  git -C "$TEST_TMP" commit -q -m first
+  local from_sha; from_sha=$(git -C "$TEST_TMP" rev-parse HEAD)
+
+  echo two >> "$TEST_TMP/stacks/alpha/file.txt"
+  git -C "$TEST_TMP" commit -qam second
+  local to_sha; to_sha=$(git -C "$TEST_TMP" rev-parse HEAD)
+
+  run _detect_changed_stacks "$TEST_TMP" "$from_sha" "$to_sha"
+  [ "$status" -eq 0 ]
+  [ "$output" = "alpha" ]
+}

--- a/tests/test_deploy_blue_green.bats
+++ b/tests/test_deploy_blue_green.bats
@@ -509,7 +509,7 @@ EOF
 # ── Rollback flip ────────────────────────────────────────────────────────────
 
 @test "bg_rollback_stack: loads common.env before the base env file (strut#176)" {
-  _bg_write_state "$STACK" "green" "demo-test-green"
+  _bg_write_state "$STACK" "test" "green" "demo-test-green"
   cat > "$CLI_ROOT/common.env" <<'EOF'
 REGISTRY_HOST=ghcr.io/shared-org
 EOF

--- a/tests/test_monitor.bats
+++ b/tests/test_monitor.bats
@@ -149,6 +149,83 @@ teardown() {
   [[ "$output" == *"not found"* ]]
 }
 
+# strut#394: monitoring_deploy shelled out to the EOL `docker-compose` v1
+# binary while every other command in the engine uses the `docker compose`
+# v2 plugin — on a host with only v2, config-check failed with a swallowed
+# command-not-found and the operator saw a misleading "Invalid
+# docker-compose.yml" instead of the real problem.
+
+@test "monitoring_deploy: uses 'docker compose' (v2), never the standalone 'docker-compose' v1 binary" {
+  echo "REGISTRY_TYPE=none" > "$MONITORING_STACK_DIR/.env"
+  curl() { return 0; }
+  export -f curl
+  docker() { echo "docker $*" >> "$TEST_TMP/docker_calls"; return 0; }
+  export -f docker
+  # If monitor.sh regresses to the v1 binary, this stub makes that failure
+  # loud and attributable instead of just "command not found" from the
+  # missing real binary.
+  # shellcheck disable=SC2317
+  docker-compose() { echo "DEPRECATED v1 docker-compose invoked: $*" >&2; return 127; }
+  export -f docker-compose
+
+  run monitoring_deploy
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"DEPRECATED"* ]]
+
+  grep -q "^docker compose version" "$TEST_TMP/docker_calls"
+  grep -q "^docker compose config" "$TEST_TMP/docker_calls"
+  grep -q "^docker compose pull" "$TEST_TMP/docker_calls"
+  grep -q "^docker compose up -d" "$TEST_TMP/docker_calls"
+}
+
+@test "monitoring_deploy: missing docker compose plugin fails with a clear message, not 'Invalid docker-compose.yml'" {
+  echo "REGISTRY_TYPE=none" > "$MONITORING_STACK_DIR/.env"
+  docker() {
+    [ "$1" = "compose" ] && [ "$2" = "version" ] && return 1
+    return 0
+  }
+  export -f docker
+
+  run monitoring_deploy
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Docker Compose plugin not found"* ]]
+  [[ "$output" != *"Invalid docker-compose.yml"* ]]
+}
+
+@test "monitoring_deploy: invalid docker-compose.yml still reports the config error distinctly" {
+  echo "REGISTRY_TYPE=none" > "$MONITORING_STACK_DIR/.env"
+  docker() {
+    [ "$1" = "compose" ] && [ "$2" = "version" ] && return 0
+    [ "$1" = "compose" ] && [ "$2" = "config" ] && return 1
+    return 0
+  }
+  export -f docker
+
+  run monitoring_deploy
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid docker-compose.yml"* ]]
+}
+
+# ── Alertmanager restart also switched from `docker-compose` to `docker compose` ──
+
+@test "monitoring_alert_channel_add_email: restarts a running Alertmanager via 'docker compose', not v1" {
+  echo "" > "$MONITORING_STACK_DIR/.env"
+  docker() {
+    echo "docker $*" >> "$TEST_TMP/docker_calls"
+    [ "$1" = "ps" ] && { echo "alertmanager"; return 0; }
+    return 0
+  }
+  export -f docker
+  # shellcheck disable=SC2317
+  docker-compose() { echo "DEPRECATED v1 docker-compose invoked: $*" >&2; return 127; }
+  export -f docker-compose
+
+  run monitoring_alert_channel_add_email --to a@example.com --from b@example.com --resend-api-key key123
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"DEPRECATED"* ]]
+  grep -q "^docker compose -f .*restart alertmanager$" "$TEST_TMP/docker_calls"
+}
+
 # ── monitoring_add_target ─────────────────────────────────────────────────────
 
 @test "monitoring_add_target: fails without stack name" {

--- a/tests/test_ssl_auto.bats
+++ b/tests/test_ssl_auto.bats
@@ -1,0 +1,267 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_ssl_auto.bats — Tests for lib/ssl/auto.sh (strut#395)
+# ==================================================
+# `_ssl_detect_domains` used to grab the line AFTER "strut.domain" (grep
+# -A1), which only worked for a block-scalar rendering `docker compose
+# config` doesn't actually produce — the real (inline) rendering
+# `strut.domain: example.com` made it capture an unrelated following line
+# instead. `_ssl_provision_one`'s --webroot certbot attempt was also
+# missing -d/--email/--non-interactive/--agree-tos, so it could never
+# actually succeed and silently always fell through to --standalone.
+#
+# `ssh` is stubbed to actually run the remote script LOCALLY via `bash -c`
+# (the last positional arg is always the remote command string) — this
+# exercises the real grep/sed pipeline against realistic `docker compose
+# config` output instead of just asserting on the ssh call's raw text.
+#
+# Run:  bats tests/test_ssl_auto.bats
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_utils
+
+  fail()  { echo "FAIL: $1" >&2; return 1; }
+  ok()    { echo "OK: $*"; }
+  warn()  { echo "WARN: $*" >&2; }
+  log()   { echo "LOG: $*"; }
+  export -f fail ok warn log
+
+  source "$CLI_ROOT/lib/ssl/auto.sh"
+
+  # Runs the "remote" script locally — the last positional arg is always
+  # the command string passed to `ssh $opts user@host "<script>"`.
+  ssh() { local cmd="${*: -1}"; bash -c "$cmd"; }
+  export -f ssh
+}
+
+teardown() { common_teardown; }
+
+# ── _ssl_detect_domains: compose-label parsing (the core strut#395 bug) ────
+
+@test "_ssl_detect_domains: extracts the domain from an inline YAML label rendering" {
+  docker() {
+    if [ "$1" = "compose" ]; then
+      cat <<'EOF'
+services:
+  web:
+    image: nginx:alpine
+    labels:
+      strut.domain: example.com
+      other.label: something-unrelated
+EOF
+    fi
+  }
+  export -f docker
+
+  run _ssl_detect_domains "demo" "" "" "user" "host" "$TEST_TMP"
+  [ "$status" -eq 0 ]
+  [ "$output" = "example.com" ]
+}
+
+@test "_ssl_detect_domains: does NOT mangle the value into the following unrelated line (regression)" {
+  docker() {
+    if [ "$1" = "compose" ]; then
+      cat <<'EOF'
+services:
+  web:
+    labels:
+      strut.domain: correct.example.com
+      other.label: should-not-appear
+EOF
+    fi
+  }
+  export -f docker
+
+  run _ssl_detect_domains "demo" "" "" "user" "host" "$TEST_TMP"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"correct.example.com"* ]]
+  [[ "$output" != *"should-not-appear"* ]]
+  [[ "$output" != *"other.label"* ]]
+}
+
+@test "_ssl_detect_domains: extracts the domain from list-form quoted labels" {
+  docker() {
+    if [ "$1" = "compose" ]; then
+      cat <<'EOF'
+services:
+  api:
+    labels:
+      - "strut.domain=api.example.com"
+      - "other=stuff"
+EOF
+    fi
+  }
+  export -f docker
+
+  run _ssl_detect_domains "demo" "" "" "user" "host" "$TEST_TMP"
+  [ "$status" -eq 0 ]
+  [ "$output" = "api.example.com" ]
+}
+
+@test "_ssl_detect_domains: extracts the domain from JSON-format labels (--format json)" {
+  docker() {
+    if [ "$1" = "compose" ]; then
+      cat <<'EOF'
+{
+  "services": {
+    "web": { "labels": { "strut.domain": "json.example.com" } }
+  }
+}
+EOF
+    fi
+  }
+  export -f docker
+
+  run _ssl_detect_domains "demo" "" "" "user" "host" "$TEST_TMP"
+  [ "$status" -eq 0 ]
+  [ "$output" = "json.example.com" ]
+}
+
+@test "_ssl_detect_domains: multiple services, multiple domains, deduplicated and sorted" {
+  docker() {
+    if [ "$1" = "compose" ]; then
+      cat <<'EOF'
+services:
+  web:
+    labels:
+      strut.domain: b.example.com
+  api:
+    labels:
+      strut.domain: a.example.com
+  cache:
+    labels:
+      strut.domain: b.example.com
+EOF
+    fi
+  }
+  export -f docker
+
+  run _ssl_detect_domains "demo" "" "" "user" "host" "$TEST_TMP"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf 'a.example.com\nb.example.com')" ]
+}
+
+@test "_ssl_detect_domains: falls back to DOMAIN/DOMAINS/VIRTUAL_HOST env vars when no label present" {
+  docker() { :; }
+  export -f docker
+  export DOMAIN="env.example.com"
+
+  run _ssl_detect_domains "demo" "" "" "user" "host" "$TEST_TMP"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"env.example.com"* ]]
+}
+
+# ── ssl_auto_provision: end-to-end gating ───────────────────────────────────
+
+@test "ssl_auto_provision: no-op when AUTO_SSL=false" {
+  export AUTO_SSL=false
+  _ssl_provision_one() { echo "SHOULD_NOT_BE_CALLED"; }
+  export -f _ssl_provision_one
+
+  run ssl_auto_provision "demo" "" "" "user" "host" "$TEST_TMP"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"SHOULD_NOT_BE_CALLED"* ]]
+}
+
+@test "ssl_auto_provision: no-op when no SSL_EMAIL configured" {
+  docker() {
+    [ "$1" = "compose" ] && echo 'services: {web: {labels: {strut.domain: example.com}}}'
+  }
+  export -f docker
+  unset SSL_EMAIL
+  _ssl_provision_one() { echo "SHOULD_NOT_BE_CALLED"; }
+  export -f _ssl_provision_one
+
+  run ssl_auto_provision "demo" "" "" "user" "host" "$TEST_TMP"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"SHOULD_NOT_BE_CALLED"* ]]
+}
+
+@test "ssl_auto_provision: detected domain is provisioned when SSL_EMAIL is set" {
+  docker() {
+    if [ "$1" = "compose" ]; then
+      echo "services:"; echo "  web:"; echo "    labels:"; echo "      strut.domain: example.com"
+    fi
+  }
+  export -f docker
+  export SSL_EMAIL="ops@example.com"
+  _ssl_provision_one() { echo "PROVISIONED domain=$1 email=$2"; }
+  export -f _ssl_provision_one
+
+  run ssl_auto_provision "demo" "" "" "user" "host" "$TEST_TMP"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PROVISIONED domain=example.com email=ops@example.com"* ]]
+}
+
+# ── _ssl_provision_one: certbot flags (strut#395) ───────────────────────────
+
+@test "_ssl_provision_one: the --webroot attempt includes -d, --email, --non-interactive, --agree-tos" {
+  docker() { :; }
+  export -f docker
+  # Certificate doesn't exist yet, DNS resolves correctly.
+  openssl() { :; }
+  curl() { echo "1.2.3.4"; }
+  dig() { echo "1.2.3.4"; }
+  export -f openssl curl dig
+
+  certbot() { echo "CERTBOT_CALL $*" >> "$TEST_TMP/certbot_calls"; return 0; }
+  export -f certbot
+
+  run _ssl_provision_one "example.com" "ops@example.com" "" "user" "host" "$TEST_TMP" "demo"
+  [ "$status" -eq 0 ]
+
+  local first_call
+  first_call=$(head -1 "$TEST_TMP/certbot_calls")
+  [[ "$first_call" == *"--webroot"* ]]
+  [[ "$first_call" == *"-d example.com"* ]]
+  [[ "$first_call" == *"--email ops@example.com"* ]]
+  [[ "$first_call" == *"--non-interactive"* ]]
+  [[ "$first_call" == *"--agree-tos"* ]]
+}
+
+@test "_ssl_provision_one: falls back to --standalone (with the same flags) when --webroot fails" {
+  docker() { :; }
+  export -f docker
+  openssl() { :; }
+  curl() { echo "1.2.3.4"; }
+  dig() { echo "1.2.3.4"; }
+  export -f openssl curl dig
+
+  certbot() {
+    echo "CERTBOT_CALL $*" >> "$TEST_TMP/certbot_calls"
+    [[ "$*" == *"--webroot"* ]] && return 1
+    return 0
+  }
+  export -f certbot
+
+  run _ssl_provision_one "example.com" "ops@example.com" "" "user" "host" "$TEST_TMP" "demo"
+  [ "$status" -eq 0 ]
+
+  local calls
+  calls=$(cat "$TEST_TMP/certbot_calls")
+  [[ "$calls" == *"--webroot"* ]]
+  [[ "$calls" == *"--standalone"* ]]
+  # The standalone attempt must ALSO carry -d/--email (already did pre-fix;
+  # guards against a future regression removing them from that branch too).
+  local standalone_call
+  standalone_call=$(grep "standalone" "$TEST_TMP/certbot_calls")
+  [[ "$standalone_call" == *"-d example.com"* ]]
+  [[ "$standalone_call" == *"--email ops@example.com"* ]]
+}
+
+@test "_ssl_provision_one: skips provisioning when DNS doesn't resolve to the VPS" {
+  docker() { :; }
+  openssl() { :; }
+  curl() { echo "1.2.3.4"; }
+  dig() { echo "9.9.9.9"; }  # different IP — DNS not pointed here
+  export -f docker openssl curl dig
+
+  certbot() { echo "SHOULD_NOT_BE_CALLED"; }
+  export -f certbot
+
+  run _ssl_provision_one "example.com" "ops@example.com" "" "user" "host" "$TEST_TMP" "demo"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"does not resolve"* ]]
+  [[ "$output" != *"SHOULD_NOT_BE_CALLED"* ]]
+}


### PR DESCRIPTION
## Summary

Bucket D — three isolated P1 infra bugs from the 2026-07 audit.

- **#393** — `webhook serve`'s handler used bash-only syntax (`${line,,}`, `$'\r'`), but socat's `SYSTEM:` runs its command via `/bin/sh -c` — on stock Debian/Ubuntu that's dash, so the handler died with `Bad substitution` before validating anything. Now writes the handler to a real executable file with a bash shebang instead of passing its text to `sh -c` directly, so the kernel execs it via `#!/usr/bin/env bash` regardless of what `/bin/sh` is. Also made `Content-Length`/signature header parsing tolerant of a missing space after the colon.
- **#394** — `monitoring_deploy` and the alert-channel Alertmanager restarts shelled out to the EOL `docker-compose` v1 binary while the rest of the engine uses the `docker compose` v2 plugin. Switched all six call sites, plus an explicit `docker compose version` pre-flight so a missing plugin fails with its own clear message instead of masquerading as "Invalid docker-compose.yml".
- **#395** — two bugs: the VPS-side git pull in `domain <domain> <email>` hardcoded `origin main` (now `${DEFAULT_BRANCH:-main}`), and auto-SSL's domain detection assumed a label's value renders on the line *after* the key (`grep -A1`) — the real inline rendering `strut.domain: example.com` made it capture an unrelated following line instead. Replaced with same-line extraction correct across YAML inline, YAML list, and `--format json`. Also gave the `--webroot` certbot attempt the `-d`/`--email`/`--non-interactive`/`--agree-tos` flags it was missing — without them it could never succeed and always silently fell through to `--standalone`.

## Test plan
- [x] `bash -n` + `shellcheck -s bash` clean on all touched files
- [x] `tests/test_cmd_webhook.bats` (new) — includes a real `dash` invocation reproducing the exact pre-fix crash, and verifying the fix under the same shell
- [x] `tests/test_ssl_auto.bats` (new) — `ssh` stubbed to run the embedded remote script locally against realistic `docker compose config` output (YAML inline, YAML list, JSON)
- [x] Coverage added to `test_monitor.bats` for the `docker compose` v2 switch and the "plugin missing vs config invalid" distinction
- [x] Full `bats tests/` suite — 2294 passing, only the 6 pre-existing environment-dependent failures remain (cron `PATH` and TTY color-detection)

## Note
While testing #393, found (and separately flagged, not fixed here) an unrelated pre-existing bug: `_all_stacks` in `lib/cmd_webhook.sh` can return exit 1 based on the last `ls` entry's directory-test result even when its actual output is correct, which could trip `set -e` in `_poll_cycle` and silently abort a poll cycle. Out of scope for this PR.