### PR TITLE
fix: drift/diff/doctor JSON correctness + output robustness roundup

### DIFF
--- a/lib/cmd_diff.sh
+++ b/lib/cmd_diff.sh
@@ -44,7 +44,14 @@ cmd_diff() {
   local stack="$CMD_STACK"
   local stack_dir="$CMD_STACK_DIR"
   local env_name="$CMD_ENV_NAME"
-  local json_mode="${CMD_JSON:-false}"
+  # CMD_JSON is populated by the top-level flag parser (flags.sh), which
+  # strips --json out of CMD_ARGS before cmd_diff ever sees it — the value
+  # is the literal string "--json" (or unset), never "true"/"false". The
+  # loop below only catches --json if it somehow survives to CMD_ARGS
+  # (e.g. a future direct call); the real signal is CMD_JSON's presence,
+  # matching how cmd_drift.sh already reads it (strut#380).
+  local json_mode=false
+  [ -n "${CMD_JSON:-}" ] && json_mode=true
 
   while [[ $# -gt 0 ]]; do
     case "$1" in

--- a/lib/cmd_doctor.sh
+++ b/lib/cmd_doctor.sh
@@ -22,7 +22,12 @@ _doc_pass() {
   local name="$1" msg="$2"
   _DOC_PASSED=$((_DOC_PASSED + 1))
   if $_DOC_JSON; then
-    _DOC_JSON_RESULTS=$(echo "$_DOC_JSON_RESULTS" | jq -c ". += [{\"name\":\"$name\",\"status\":\"pass\",\"message\":\"$msg\"}]")
+    # --arg passes values as jq DATA, not interpolated into the program
+    # text — a message/fix containing a double quote (e.g. a chmod fix
+    # like `chmod 600 "/home/u/.ssh/id_rsa"`) used to break the program
+    # string and abort `doctor --json` under set -e (strut#381).
+    _DOC_JSON_RESULTS=$(echo "$_DOC_JSON_RESULTS" | jq -c --arg n "$name" --arg m "$msg" \
+      '. += [{name:$n,status:"pass",message:$m}]')
   else
     echo -e "  ${GREEN}✓${NC} $name: $msg"
   fi
@@ -32,7 +37,8 @@ _doc_warn() {
   local name="$1" msg="$2" fix="${3:-}"
   _DOC_WARNED=$((_DOC_WARNED + 1))
   if $_DOC_JSON; then
-    _DOC_JSON_RESULTS=$(echo "$_DOC_JSON_RESULTS" | jq -c ". += [{\"name\":\"$name\",\"status\":\"warn\",\"message\":\"$msg\",\"fix\":\"$fix\"}]")
+    _DOC_JSON_RESULTS=$(echo "$_DOC_JSON_RESULTS" | jq -c --arg n "$name" --arg m "$msg" --arg f "$fix" \
+      '. += [{name:$n,status:"warn",message:$m,fix:$f}]')
   else
     echo -e "  ${YELLOW}⚠${NC} $name: $msg"
     if [ -n "$fix" ] && $_DOC_FIX; then
@@ -45,7 +51,8 @@ _doc_fail() {
   local name="$1" msg="$2" fix="${3:-}"
   _DOC_FAILED=$((_DOC_FAILED + 1))
   if $_DOC_JSON; then
-    _DOC_JSON_RESULTS=$(echo "$_DOC_JSON_RESULTS" | jq -c ". += [{\"name\":\"$name\",\"status\":\"fail\",\"message\":\"$msg\",\"fix\":\"$fix\"}]")
+    _DOC_JSON_RESULTS=$(echo "$_DOC_JSON_RESULTS" | jq -c --arg n "$name" --arg m "$msg" --arg f "$fix" \
+      '. += [{name:$n,status:"fail",message:$m,fix:$f}]')
   else
     echo -e "  ${RED}✗${NC} $name: $msg"
     if [ -n "$fix" ] && $_DOC_FIX; then

--- a/lib/cmd_drift.sh
+++ b/lib/cmd_drift.sh
@@ -114,7 +114,7 @@ cmd_drift() {
       [ -n "$json_flag" ] && img_args+=(--json)
       # Default to remote if VPS_HOST is set
       [ -n "${VPS_HOST:-}" ] && img_args+=(--remote)
-      drift_images "$stack" "${img_args[@]+"${img_args[@]}"}" "$@"
+      drift_images "$stack" "$env_file" "${img_args[@]+"${img_args[@]}"}" "$@"
       ;;
     *)
       fail "Unknown drift command: $target

--- a/lib/cmd_drift_images.sh
+++ b/lib/cmd_drift_images.sh
@@ -11,13 +11,33 @@
 
 set -euo pipefail
 
-# drift_images <stack> [--json] [--remote]
+# _drift_images_project_name <stack> <env_file>
+#
+# Echoes the compose project name a real deploy of this stack/env resolves
+# to (via resolve_compose_cmd — the same helper deploy/status/stop use), so
+# `drift images` queries the project `strut deploy` actually created.
+# Without --project-name, `docker compose ps` infers the project from the
+# compose file's DIRECTORY name (just "<stack>"), which a strut-deployed
+# stack (project "<stack>-<env>") never runs under — `ps -q` silently
+# returned nothing for every real deployment (strut#382).
+_drift_images_project_name() {
+  local stack="$1"
+  local env_file="$2"
+  local compose_cmd
+  compose_cmd=$(resolve_compose_cmd "$stack" "$env_file" "" "" 2>/dev/null) || { echo "$stack"; return 0; }
+  local project_name
+  project_name=$(echo "$compose_cmd" | grep -oE '\-\-project\-name [^ ]+' | awk '{print $2}')
+  echo "${project_name:-$stack}"
+}
+
+# drift_images <stack> <env_file> [--json] [--remote]
 #
 # For each running container in the stack's compose project, compares the
 # running image digest against what the tag currently resolves to on the
 # registry. Reports stale images.
 drift_images() {
   local stack="$1"; shift
+  local env_file="$1"; shift
   local json_flag=false
   local remote_flag=false
 
@@ -29,21 +49,25 @@ drift_images() {
     esac
   done
 
+  local project_name
+  project_name=$(_drift_images_project_name "$stack" "$env_file")
+
   if $remote_flag; then
-    drift_images_remote "$stack" "$json_flag"
+    drift_images_remote "$stack" "$json_flag" "$project_name"
     return $?
   fi
 
   # Local detection
-  _drift_images_detect "$stack" "$json_flag"
+  _drift_images_detect "$stack" "$json_flag" "$project_name"
 }
 
-# drift_images_remote <stack> <json_flag>
+# drift_images_remote <stack> <json_flag> <project_name>
 #
 # Runs image drift detection on the VPS via SSH.
 drift_images_remote() {
   local stack="$1"
   local json_flag="$2"
+  local project_name="$3"
 
   local vps_host="${VPS_HOST:-}"
   local vps_user="${VPS_USER:-ubuntu}"
@@ -58,81 +82,172 @@ drift_images_remote() {
   local deploy_dir
   deploy_dir=$(resolve_deploy_dir)
 
-  # Run the detection script on the remote
+  # Run the detection script on the remote. Each container line is one of:
+  #   DRIFT|<image>|<running_digest_prefix>|<registry_digest_prefix>
+  #   OK|<image>
+  #   UNKNOWN|<image>   — digest lookup failed or wasn't safely comparable;
+  #                       distinct from OK so it never masks real drift.
   # shellcheck disable=SC2029
-  local output
+  local output rc=0
   output=$(ssh $ssh_opts "$vps_user@$vps_host" "
     set -e
-    cd '$deploy_dir' 2>/dev/null || exit 0
+    cd '$deploy_dir' || exit 90
 
-    # Find compose project for this stack
-    project=\$(docker compose -f 'stacks/$stack/docker-compose.yml' ps -q 2>/dev/null | head -1)
-    [ -n \"\$project\" ] || exit 0
-
-    # Get running containers for this project
-    containers=\$(docker compose -f 'stacks/$stack/docker-compose.yml' ps -q 2>/dev/null)
+    containers=\$(docker compose -f 'stacks/$stack/docker-compose.yml' --project-name '$project_name' ps -q 2>/dev/null)
     [ -n \"\$containers\" ] || exit 0
 
     while IFS= read -r cid; do
       [ -n \"\$cid\" ] || continue
-      # Get the image reference and running digest
-      info=\$(docker inspect --format '{{.Config.Image}}|{{.Image}}' \"\$cid\" 2>/dev/null) || continue
+
+      info=\$(docker inspect --format '{{.Config.Image}}|{{index .RepoDigests 0}}' \"\$cid\" 2>/dev/null) || { echo \"UNKNOWN|\$cid\"; continue; }
       image_ref=\"\${info%%|*}\"
-      running_digest=\"\${info#*|}\"
+      repo_digest=\"\${info#*|}\"
 
-      # Skip digest-pinned refs (already locked)
-      [[ \"\$image_ref\" == *@sha256:* ]] && continue
+      # Digest-pinned refs are already locked — nothing to compare.
+      case \"\$image_ref\" in
+        *@sha256:*) echo \"OK|\$image_ref\"; continue ;;
+      esac
 
-      # Try to get the current registry digest
-      registry_digest=\$(docker manifest inspect \"\$image_ref\" 2>/dev/null | grep -m1 '\"digest\"' | sed 's/.*\"digest\": *\"//;s/\".*//' || echo \"\")
+      # No RepoDigest (e.g. a locally-built image, never pulled from a
+      # registry) — Go template index-out-of-range leaves this empty or
+      # equal to the raw template text; either way we can't compare.
+      case \"\$repo_digest\" in
+        ''|*'{{'*) echo \"UNKNOWN|\$image_ref\"; continue ;;
+      esac
+      running_digest=\"\${repo_digest#*@}\"
 
-      if [ -n \"\$registry_digest\" ] && [ \"\$running_digest\" != \"sha256:\$registry_digest\" ] && [ \"\$running_digest\" != \"\$registry_digest\" ]; then
-        echo \"DRIFT|\$image_ref|\${running_digest:0:19}|\${registry_digest:0:19}\"
+      manifest_raw=\$(docker manifest inspect \"\$image_ref\" 2>/dev/null || echo '')
+      if [ -z \"\$manifest_raw\" ]; then
+        echo \"UNKNOWN|\$image_ref\"
+      elif echo \"\$manifest_raw\" | grep -q '\"manifests\"'; then
+        # Multi-arch manifest LIST — the first (or only) \"digest\" field in
+        # this document is a per-platform manifest digest, never equal to
+        # the list digest actually pulled (strut#382's false-positive).
+        # Only docker buildx's imagetools can resolve the true list digest
+        # portably; without it, report unknown rather than guess.
+        list_digest=''
+        if docker buildx version >/dev/null 2>&1; then
+          list_digest=\$(docker buildx imagetools inspect \"\$image_ref\" 2>/dev/null | grep -m1 '^Digest:' | awk '{print \$2}')
+        fi
+        if [ -n \"\$list_digest\" ]; then
+          if [ \"\$running_digest\" = \"\$list_digest\" ]; then
+            echo \"OK|\$image_ref\"
+          else
+            echo \"DRIFT|\$image_ref|\${running_digest:0:19}|\${list_digest:0:19}\"
+          fi
+        else
+          echo \"UNKNOWN|\$image_ref\"
+        fi
       else
-        echo \"OK|\$image_ref\"
+        registry_digest=\$(echo \"\$manifest_raw\" | grep -m1 '\"digest\"' | sed 's/.*\"digest\": *\"//;s/\".*//')
+        if [ -z \"\$registry_digest\" ]; then
+          echo \"UNKNOWN|\$image_ref\"
+        elif [ \"\$running_digest\" = \"sha256:\$registry_digest\" ] || [ \"\$running_digest\" = \"\$registry_digest\" ]; then
+          echo \"OK|\$image_ref\"
+        else
+          echo \"DRIFT|\$image_ref|\${running_digest:0:19}|\${registry_digest:0:19}\"
+        fi
       fi
-    done <<< \"\$containers\"
-  " 2>/dev/null) || true
+    done <<EOF_CONTAINERS
+\$containers
+EOF_CONTAINERS
+  " 2>/dev/null) || rc=$?
+
+  # OpenSSH's own connect/auth failure is 255; the script's own `cd' guard
+  # exits 90 for a wrong/missing deploy dir. Both mean \"couldn't check\",
+  # not \"nothing drifted\" — surfacing a distinct error instead of the
+  # previous silent `|| true` (which made an unreachable host read as
+  # clean, the same class of bug as #235) (strut#382).
+  if [ "$rc" -eq 255 ] || [ "$rc" -eq 90 ]; then
+    error "Could not reach $vps_host to check image digests (SSH connection or deploy dir failure)"
+    return 2
+  fi
 
   _drift_images_render "$stack" "$output" "$json_flag"
 }
 
-# _drift_images_detect <stack> <json_flag>
+# _drift_images_detect <stack> <json_flag> <project_name>
 #
 # Local image drift detection against the local Docker daemon.
 _drift_images_detect() {
   local stack="$1"
   local json_flag="$2"
+  local project_name="$3"
   local cli_root="${CLI_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
   local compose_file="$cli_root/stacks/$stack/docker-compose.yml"
 
   [ -f "$compose_file" ] || { warn "No compose file for stack: $stack"; return 0; }
 
   local containers
-  containers=$(docker compose -f "$compose_file" ps -q 2>/dev/null) || true
+  containers=$(docker compose -f "$compose_file" --project-name "$project_name" ps -q 2>/dev/null) || true
   [ -n "$containers" ] || { log "No running containers for $stack"; return 0; }
 
   local output=""
   while IFS= read -r cid; do
     [ -n "$cid" ] || continue
     local info
-    info=$(docker inspect --format '{{.Config.Image}}|{{.Image}}' "$cid" 2>/dev/null) || continue
-    local image_ref="${info%%|*}"
-    local running_digest="${info#*|}"
-
-    # Skip digest-pinned refs
-    [[ "$image_ref" == *@sha256:* ]] && continue
-
-    # Get registry digest
-    local registry_digest=""
-    registry_digest=$(docker manifest inspect "$image_ref" 2>/dev/null | grep -m1 '"digest"' | sed 's/.*"digest": *"//;s/".*//' || echo "")
-
-    if [ -n "$registry_digest" ] && [ "$running_digest" != "sha256:$registry_digest" ] && [ "$running_digest" != "$registry_digest" ]; then
-      output="${output}DRIFT|$image_ref|${running_digest:0:19}|${registry_digest:0:19}
+    info=$(docker inspect --format '{{.Config.Image}}|{{index .RepoDigests 0}}' "$cid" 2>/dev/null) || {
+      output="${output}UNKNOWN|$cid
 "
-    else
+      continue
+    }
+    local image_ref="${info%%|*}"
+    local repo_digest="${info#*|}"
+
+    # Digest-pinned refs are already locked.
+    if [[ "$image_ref" == *@sha256:* ]]; then
       output="${output}OK|$image_ref
 "
+      continue
+    fi
+
+    # No RepoDigest — can't compare (locally-built image, or the Go
+    # template's index-out-of-range left the literal template text).
+    if [ -z "$repo_digest" ] || [[ "$repo_digest" == *'{{'* ]]; then
+      output="${output}UNKNOWN|$image_ref
+"
+      continue
+    fi
+    local running_digest="${repo_digest#*@}"
+
+    local manifest_raw
+    manifest_raw=$(docker manifest inspect "$image_ref" 2>/dev/null || echo "")
+
+    if [ -z "$manifest_raw" ]; then
+      output="${output}UNKNOWN|$image_ref
+"
+    elif echo "$manifest_raw" | grep -q '"manifests"'; then
+      # Multi-arch manifest list — see drift_images_remote for the full
+      # rationale. Only buildx can portably resolve the list digest.
+      local list_digest=""
+      if docker buildx version >/dev/null 2>&1; then
+        list_digest=$(docker buildx imagetools inspect "$image_ref" 2>/dev/null | grep -m1 '^Digest:' | awk '{print $2}')
+      fi
+      if [ -n "$list_digest" ]; then
+        if [ "$running_digest" = "$list_digest" ]; then
+          output="${output}OK|$image_ref
+"
+        else
+          output="${output}DRIFT|$image_ref|${running_digest:0:19}|${list_digest:0:19}
+"
+        fi
+      else
+        output="${output}UNKNOWN|$image_ref
+"
+      fi
+    else
+      local registry_digest
+      registry_digest=$(echo "$manifest_raw" | grep -m1 '"digest"' | sed 's/.*"digest": *"//;s/".*//')
+      if [ -z "$registry_digest" ]; then
+        output="${output}UNKNOWN|$image_ref
+"
+      elif [ "$running_digest" = "sha256:$registry_digest" ] || [ "$running_digest" = "$registry_digest" ]; then
+        output="${output}OK|$image_ref
+"
+      else
+        output="${output}DRIFT|$image_ref|${running_digest:0:19}|${registry_digest:0:19}
+"
+      fi
     fi
   done <<< "$containers"
 
@@ -146,6 +261,7 @@ _drift_images_render() {
   local json_flag="$3"
 
   local drifted=0
+  local unknown=0
   local total=0
   local json_items=()
 
@@ -155,24 +271,36 @@ _drift_images_render() {
     local status="${line%%|*}"
     local rest="${line#*|}"
 
-    if [ "$status" = "DRIFT" ]; then
-      drifted=$((drifted + 1))
-      local image="${rest%%|*}"
-      rest="${rest#*|}"
-      local running="${rest%%|*}"
-      local registry="${rest#*|}"
+    case "$status" in
+      DRIFT)
+        drifted=$((drifted + 1))
+        local image="${rest%%|*}"
+        rest="${rest#*|}"
+        local running="${rest%%|*}"
+        local registry="${rest#*|}"
 
-      if [ "$json_flag" = "true" ]; then
-        json_items+=("{\"image\":\"$image\",\"status\":\"stale\",\"running\":\"$running\",\"registry\":\"$registry\"}")
-      else
-        echo -e "  ${RED}✗${NC} $image — stale (running: ${running}…, registry: ${registry}…)"
-      fi
-    else
-      local image="${rest%%|*}"
-      if [ "$json_flag" = "true" ]; then
-        json_items+=("{\"image\":\"$image\",\"status\":\"current\"}")
-      fi
-    fi
+        if [ "$json_flag" = "true" ]; then
+          json_items+=("{\"image\":\"$image\",\"status\":\"stale\",\"running\":\"$running\",\"registry\":\"$registry\"}")
+        else
+          echo -e "  ${RED}✗${NC} $image — stale (running: ${running}…, registry: ${registry}…)"
+        fi
+        ;;
+      UNKNOWN)
+        unknown=$((unknown + 1))
+        local image="${rest%%|*}"
+        if [ "$json_flag" = "true" ]; then
+          json_items+=("{\"image\":\"$image\",\"status\":\"unknown\"}")
+        else
+          echo -e "  ${YELLOW}?${NC} $image — could not determine registry digest"
+        fi
+        ;;
+      *)
+        local image="${rest%%|*}"
+        if [ "$json_flag" = "true" ]; then
+          json_items+=("{\"image\":\"$image\",\"status\":\"current\"}")
+        fi
+        ;;
+    esac
   done <<< "$output"
 
   if [ "$json_flag" = "true" ]; then
@@ -181,14 +309,16 @@ _drift_images_render() {
       joined=$(printf '%s,' "${json_items[@]}")
       joined="${joined%,}"
     fi
-    echo "{\"stack\":\"$stack\",\"total\":$total,\"drifted\":$drifted,\"images\":[$joined]}"
+    echo "{\"stack\":\"$stack\",\"total\":$total,\"drifted\":$drifted,\"unknown\":$unknown,\"images\":[$joined]}"
   else
     if [ "$total" -eq 0 ]; then
       log "No running images to check for $stack"
-    elif [ "$drifted" -eq 0 ]; then
+    elif [ "$drifted" -eq 0 ] && [ "$unknown" -eq 0 ]; then
       ok "$stack: all $total images current"
+    elif [ "$drifted" -eq 0 ]; then
+      log "$stack: $unknown/$total image digest(s) could not be checked"
     else
-      warn "$stack: $drifted/$total images have stale digests"
+      warn "$stack: $drifted/$total images have stale digests${unknown:+ ($unknown unchecked)}"
     fi
   fi
 

--- a/lib/cmd_fleet.sh
+++ b/lib/cmd_fleet.sh
@@ -83,7 +83,7 @@ _fleet_status() {
 
     if ! parse_host_spec "$host_spec"; then
       if $json_flag; then
-        json_entries+=("{\"host\":\"$host_alias\",\"status\":\"error\",\"error\":\"failed to parse host spec\"}")
+        json_entries+=("{\"host\":\"$(json_escape "$host_alias")\",\"status\":\"error\",\"error\":\"failed to parse host spec\"}")
       else
         printf "  %-12s %-8s %-6s %-6s %-5s %s\n" "$host_alias" "—" "—" "—" "—" "parse error"
       fi
@@ -98,7 +98,7 @@ _fleet_status() {
 
     if [ -z "$status_output" ]; then
       if $json_flag; then
-        json_entries+=("{\"host\":\"$host_alias\",\"status\":\"unreachable\"}")
+        json_entries+=("{\"host\":\"$(json_escape "$host_alias")\",\"status\":\"unreachable\"}")
       else
         printf "  %-12s %-8s %-6s %-6s %-5s %s\n" "$host_alias" "—" "—" "—" "—" "unreachable"
       fi
@@ -114,7 +114,13 @@ _fleet_status() {
     [ "$FLEET_HEAD_SHA" = "unknown" ] && short_sha="unknown"
 
     if $json_flag; then
-      json_entries+=("{\"host\":\"$host_alias\",\"status\":\"ok\",\"branch\":\"$FLEET_BRANCH\",\"behind\":\"$FLEET_BEHIND\",\"ahead\":\"$FLEET_AHEAD\",\"dirty\":$FLEET_DIRTY_COUNT,\"head_sha\":\"$FLEET_HEAD_SHA\"}")
+      # FLEET_DIRTY_COUNT is emitted unquoted (it's a count, not a string)
+      # so it must be a bare integer — a blank/non-numeric value (e.g. a
+      # truncated SSH stream) would otherwise produce invalid JSON like
+      # "dirty":,. Default and validate before interpolating.
+      local dirty_count="${FLEET_DIRTY_COUNT:-0}"
+      [[ "$dirty_count" =~ ^[0-9]+$ ]] || dirty_count=0
+      json_entries+=("{\"host\":\"$(json_escape "$host_alias")\",\"status\":\"ok\",\"branch\":\"$(json_escape "$FLEET_BRANCH")\",\"behind\":\"$(json_escape "$FLEET_BEHIND")\",\"ahead\":\"$(json_escape "$FLEET_AHEAD")\",\"dirty\":$dirty_count,\"head_sha\":\"$(json_escape "$FLEET_HEAD_SHA")\"}")
     else
       # Color-code behind count
       local behind_str="$FLEET_BEHIND"

--- a/lib/drift.sh
+++ b/lib/drift.sh
@@ -14,6 +14,10 @@ if [ -z "$RED" ]; then
   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   source "$SCRIPT_DIR/utils.sh"
 fi
+# diff_fetch_remote (SSH cat) — reused below so drift can compare against
+# the file actually deployed on the VPS, not a second local copy of the
+# same working-tree file (strut#182).
+declare -F diff_fetch_remote >/dev/null || source "${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}/diff.sh"
 
 # ── Configuration ─────────────────────────────────────────────────────────────
 
@@ -54,29 +58,83 @@ drift_get_git_hash() {
 
   # Check if the file is tracked in git
   if ! git -C "$cli_root" show "HEAD:$relative_path" &>/dev/null; then
-    # File not tracked in git, use current file hash
-    sha256sum "$file_path" 2>/dev/null | awk '{print $1}'
+    # File not tracked in git — hash via a captured variable (see below)
+    # rather than `sha256sum file` directly, so this stays consistent with
+    # the tracked-file branch's normalization.
+    local untracked_content
+    untracked_content=$(cat "$file_path" 2>/dev/null)
+    printf '%s' "$untracked_content" | sha256sum | awk '{print $1}'
     return 0
   fi
 
-  # Hash the git-committed content — pipe directly from git show to avoid
-  # echo adding a trailing newline that the file may not have (fixes phantom
-  # drift false positives on files without a final newline).
-  git -C "$cli_root" show "HEAD:$relative_path" 2>/dev/null | sha256sum | awk '{print $1}'
+  # Hash the git-committed content via a captured variable (command
+  # substitution strips a trailing newline) rather than piping raw bytes.
+  # This must match drift_get_vps_hash's normalization exactly: a remote
+  # fetch over SSH is ALSO captured via command substitution (diff_fetch_remote),
+  # which strips a trailing newline the same way — comparing a raw-byte git
+  # hash against a substitution-stripped remote hash would falsely flag
+  # drift on every file that simply ends in a newline (nearly all of them).
+  # A lone trailing newline is treated as insignificant everywhere in drift
+  # comparison, not just for the local case the July 2026 fix covered.
+  local git_content
+  git_content=$(git -C "$cli_root" show "HEAD:$relative_path" 2>/dev/null)
+  printf '%s' "$git_content" | sha256sum | awk '{print $1}'
 }
 
-# drift_get_vps_hash <file_path>
-# Returns the sha256 hash of the current file on disk (VPS runtime)
+# drift_get_vps_hash <stack> <tracked_file> <stack_dir>
+#
+# Returns the sha256 hash of the file as actually DEPLOYED. When VPS_HOST
+# is configured (loaded by validate_env_file before any drift_* command
+# runs — see cmd_drift.sh), fetches the real file from the VPS deploy dir
+# over SSH and hashes THAT — comparing against what's actually running,
+# not a second local copy of the same working-tree file. Previously
+# git_file and vps_file were the same local path, so drift was blind to
+# real VPS-side changes and could report CLEAN while `strut diff` showed
+# pending changes (strut#182). Falls back to the local working-tree file
+# for local-only stacks (no VPS_HOST) or when the deploy dir can't be
+# resolved.
+#
+# Echoes one of: a sha256 hash, "missing" (file absent, local or remote),
+# or "unreachable" (VPS_HOST set but SSH couldn't connect — the caller
+# must skip this file rather than treat it as drift, since "we couldn't
+# check" and "it changed" are different things).
+# Return code: 0 = hash, 1 = missing, 2 = unreachable.
 drift_get_vps_hash() {
-  local file_path="$1"
+  local stack="$1"
+  local tracked_file="$2"
+  local stack_dir="$3"
+  local local_file="$stack_dir/$tracked_file"
 
-  if [ ! -f "$file_path" ]; then
+  if [ -n "${VPS_HOST:-}" ] && declare -F resolve_deploy_dir >/dev/null 2>&1; then
+    local deploy_dir
+    deploy_dir=$(resolve_deploy_dir 2>/dev/null) || deploy_dir=""
+    if [ -n "$deploy_dir" ]; then
+      local remote_path="$deploy_dir/stacks/$stack/$tracked_file"
+      local remote_content rc=0
+      remote_content=$(diff_fetch_remote "$remote_path") || rc=$?
+      if [ "${rc:-0}" -eq 2 ]; then
+        echo "unreachable"
+        return 2
+      fi
+      if [ -z "$remote_content" ]; then
+        echo "missing"
+        return 1
+      fi
+      printf '%s' "$remote_content" | sha256sum | awk '{print $1}'
+      return 0
+    fi
+  fi
+
+  # Local-only stack, or deploy dir couldn't be resolved. Captured via a
+  # variable (strips a trailing newline) rather than `sha256sum file`
+  # directly, matching drift_get_git_hash's normalization exactly.
+  if [ ! -f "$local_file" ]; then
     echo "missing"
     return 1
   fi
-
-  # Hash the actual file on disk
-  sha256sum "$file_path" 2>/dev/null | awk '{print $1}'
+  local local_content
+  local_content=$(cat "$local_file" 2>/dev/null)
+  printf '%s' "$local_content" | sha256sum | awk '{print $1}'
 }
 
 # drift_get_git_content <file_path>
@@ -169,41 +227,63 @@ drift_validate_syntax() {
   return 0
 }
 
-# drift_generate_diff <git_file> <vps_file>
-# Generates a unified diff between git-committed and VPS files
+# drift_generate_diff <stack> <tracked_file> <stack_dir>
+#
+# Generates a unified diff between git-committed and deployed content.
+# Deployed content is the real VPS file over SSH when VPS_HOST is set
+# (matching drift_get_vps_hash's resolution), else the local working-tree
+# copy for local-only stacks.
 drift_generate_diff() {
-  local git_file="$1"
-  local vps_file="$2"
-
-  if [ ! -f "$vps_file" ]; then
-    echo "VPS file missing: $vps_file"
-    return 1
-  fi
+  local stack="$1"
+  local tracked_file="$2"
+  local stack_dir="$3"
+  local git_file="$stack_dir/$tracked_file"
 
   # Get git-committed content
   local git_content
   git_content=$(drift_get_git_content "$git_file")
 
   if [ -z "$git_content" ]; then
-    echo "Git file not tracked: $git_file"
+    echo "Git file not tracked: $tracked_file"
     return 1
   fi
 
-  # Get relative filename for labels
-  local cli_root="${CLI_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
-  local relative_path="${vps_file#$cli_root/stacks/}"
+  # Resolve deployed content the same way drift_get_vps_hash does.
+  local vps_content=""
+  local using_remote=false
+  if [ -n "${VPS_HOST:-}" ] && declare -F resolve_deploy_dir >/dev/null 2>&1; then
+    local deploy_dir
+    deploy_dir=$(resolve_deploy_dir 2>/dev/null) || deploy_dir=""
+    if [ -n "$deploy_dir" ]; then
+      using_remote=true
+      vps_content=$(diff_fetch_remote "$deploy_dir/stacks/$stack/$tracked_file") || {
+        echo "VPS unreachable: could not fetch $tracked_file"
+        return 1
+      }
+    fi
+  fi
+  if ! $using_remote; then
+    local local_file="$stack_dir/$tracked_file"
+    [ -f "$local_file" ] || { echo "VPS file missing: $tracked_file"; return 1; }
+    vps_content=$(cat "$local_file")
+  fi
+  [ -n "$vps_content" ] || { echo "VPS file missing: $tracked_file"; return 1; }
 
-  # Create temp file with git content
-  local temp_git_file
+  # Create temp files for a real diff(1) invocation
+  local temp_git_file temp_vps_file
   temp_git_file=$(mktemp)
-  echo "$git_content" > "$temp_git_file"
+  temp_vps_file=$(mktemp)
+  printf '%s' "$git_content" > "$temp_git_file"
+  printf '%s' "$vps_content" > "$temp_vps_file"
+
+  local label="local-workdir"
+  $using_remote && label="vps-runtime"
 
   # Generate unified diff with readable labels
-  diff -u --label "git-committed/$relative_path" --label "vps-runtime/$relative_path" \
-    "$temp_git_file" "$vps_file" 2>/dev/null || true  # diff returns 1 when files differ — expected
+  diff -u --label "git-committed/$tracked_file" --label "$label/$tracked_file" \
+    "$temp_git_file" "$temp_vps_file" 2>/dev/null || true  # diff returns 1 when files differ — expected
 
-  # Cleanup
-  rm -f "$temp_git_file"
+  rm -f "$temp_git_file" "$temp_vps_file"
 }
 
 # drift_detect <stack> <env>
@@ -236,10 +316,6 @@ drift_detect() {
   # Check each tracked file
   for tracked_file in "${tracked_files[@]}"; do
     local git_file="$stack_dir/$tracked_file"
-    # Compare git-committed content against the local working-tree copy.
-    # Note: this catches local uncommitted drift, not VPS drift. For full
-    # remote comparison, use `strut diff` which fetches via SSH.
-    local vps_file="$stack_dir/$tracked_file"
 
     # Skip if file doesn't exist in git
     [ -f "$git_file" ] || continue
@@ -249,17 +325,27 @@ drift_detect() {
       continue
     fi
 
-    # Get hashes
+    # Get hashes. drift_get_vps_hash fetches the real deployed file over
+    # SSH when VPS_HOST is set, falling back to the local working-tree
+    # copy for local-only stacks (strut#182).
     local git_hash
     local vps_hash
+    local vps_rc=0
     git_hash=$(drift_get_git_hash "$git_file")
-    vps_hash=$(drift_get_vps_hash "$vps_file")
+    vps_hash=$(drift_get_vps_hash "$stack" "$tracked_file" "$stack_dir") || vps_rc=$?
+    if [ "$vps_rc" -eq 2 ]; then
+      warn "Skipping $tracked_file: VPS unreachable — could not verify"
+      continue
+    fi
 
     # Compare hashes
     if [ "$git_hash" != "$vps_hash" ]; then
-      # Validate syntax before reporting drift
-      if ! drift_validate_syntax "$vps_file"; then
-        warn "Skipping $tracked_file: invalid syntax on VPS"
+      # Validate syntax before reporting drift (local-only stacks only —
+      # the remote-fetched case would need a second SSH round-trip to
+      # write the content somewhere lintable; not worth it for a
+      # best-effort pre-report sanity check).
+      if [ -z "${VPS_HOST:-}" ] && ! drift_validate_syntax "$stack_dir/$tracked_file"; then
+        warn "Skipping $tracked_file: invalid syntax on disk"
         continue
       fi
 
@@ -268,7 +354,7 @@ drift_detect() {
 
       # Generate diff
       local diff_output
-      diff_output=$(drift_generate_diff "$git_file" "$vps_file")
+      diff_output=$(drift_generate_diff "$stack" "$tracked_file" "$stack_dir")
 
       drift_details+=("{\"file\":\"$tracked_file\",\"git_hash\":\"$git_hash\",\"vps_hash\":\"$vps_hash\",\"diff\":$(echo "$diff_output" | jq -Rs .)}")
     fi
@@ -420,20 +506,22 @@ drift_fix() {
 
   for tracked_file in "${tracked_files[@]}"; do
     local git_file="$stack_dir/$tracked_file"
-    local vps_file="$stack_dir/$tracked_file"
 
     [ -f "$git_file" ] || continue
     drift_should_ignore "$git_file" "$stack_dir" && continue
 
     local git_hash
     local vps_hash
+    local vps_rc=0
     git_hash=$(drift_get_git_hash "$git_file")
-    vps_hash=$(drift_get_vps_hash "$vps_file")
+    vps_hash=$(drift_get_vps_hash "$stack" "$tracked_file" "$stack_dir") || vps_rc=$?
+    if [ "$vps_rc" -eq 2 ]; then
+      warn "Skipping $tracked_file: VPS unreachable — could not verify"
+      continue
+    fi
 
     if [ "$git_hash" != "$vps_hash" ]; then
       drifted_files+=("$tracked_file")
-      local diff_output
-      diff_output=$(drift_generate_diff "$git_file" "$vps_file")
       drift_details+=("{\"file\":\"$tracked_file\",\"git_hash\":\"$git_hash\",\"vps_hash\":\"$vps_hash\"}")
     fi
   done
@@ -528,6 +616,9 @@ drift_fix() {
   fi
 
   ok "Configuration drift fixed successfully"
+  if [ -n "${VPS_HOST:-}" ]; then
+    log "This restored the local git-tracked source — run 'strut $stack deploy --env $env' or 'release' to push it to the VPS."
+  fi
 
   # Update drift event resolution
   local latest_drift_file
@@ -571,20 +662,21 @@ drift_report() {
 
   for tracked_file in "${tracked_files[@]}"; do
     local git_file="$stack_dir/$tracked_file"
-    local vps_file="$stack_dir/$tracked_file"
 
     [ -f "$git_file" ] || continue
     drift_should_ignore "$git_file" "$stack_dir" && continue
 
     local git_hash
     local vps_hash
+    local vps_rc=0
     git_hash=$(drift_get_git_hash "$git_file")
-    vps_hash=$(drift_get_vps_hash "$vps_file")
+    vps_hash=$(drift_get_vps_hash "$stack" "$tracked_file" "$stack_dir") || vps_rc=$?
+    [ "$vps_rc" -eq 2 ] && continue  # unreachable — omit from the report rather than false-flag it
 
     if [ "$git_hash" != "$vps_hash" ]; then
       drifted_files+=("$tracked_file")
       local diff_output
-      diff_output=$(drift_generate_diff "$git_file" "$vps_file")
+      diff_output=$(drift_generate_diff "$stack" "$tracked_file" "$stack_dir")
       drift_details+=("{\"file\":\"$tracked_file\",\"git_hash\":\"$git_hash\",\"vps_hash\":\"$vps_hash\",\"diff\":$(echo "$diff_output" | jq -Rs .)}")
     fi
   done
@@ -623,20 +715,23 @@ drift_report() {
       # Show each drifted file with its diff
       for tracked_file in "${tracked_files[@]}"; do
         local git_file="$stack_dir/$tracked_file"
-        local vps_file="$stack_dir/$tracked_file"
 
-        [ -f "$vps_file" ] || continue
-        drift_should_ignore "$vps_file" "$stack_dir" && continue
+        [ -f "$git_file" ] || continue
+        drift_should_ignore "$git_file" "$stack_dir" && continue
 
         local git_hash
         local vps_hash
-        git_hash=$(drift_get_git_hash "$vps_file")
-        vps_hash=$(drift_get_vps_hash "$vps_file")
+        local vps_rc=0
+        git_hash=$(drift_get_git_hash "$git_file")
+        vps_hash=$(drift_get_vps_hash "$stack" "$tracked_file" "$stack_dir") || vps_rc=$?
+        [ "$vps_rc" -eq 2 ] && continue
 
         if [ "$git_hash" != "$vps_hash" ]; then
           echo -e "${YELLOW}File: $tracked_file${NC}"
           echo "----------------------------------------"
-          drift_generate_diff "$vps_file" "$vps_file" || echo "  (diff generation failed)"
+          # Previously compared vps_file against itself here — always an
+          # empty diff even when the hashes above disagreed.
+          drift_generate_diff "$stack" "$tracked_file" "$stack_dir" || echo "  (diff generation failed)"
           echo ""
         fi
       done
@@ -659,14 +754,14 @@ drift_diff() {
 
   local cli_root="${CLI_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
   local stack_dir="$cli_root/stacks/$stack"
-  local vps_file="$stack_dir/$file"
+  local git_file="$stack_dir/$file"
 
-  [ -f "$vps_file" ] || { error "VPS file not found: $vps_file"; return 1; }
+  [ -f "$git_file" ] || { error "File not found: $git_file"; return 1; }
 
-  # Get git-committed content
+  # Get git-committed content (just to give a clear "not tracked" error
+  # before printing headers — drift_generate_diff re-fetches this itself).
   local git_content
-  git_content=$(drift_get_git_content "$vps_file")
-
+  git_content=$(drift_get_git_content "$git_file")
   if [ -z "$git_content" ]; then
     error "File not tracked in git: $file"
     return 1
@@ -677,20 +772,17 @@ drift_diff() {
   echo -e "==================================================${NC}"
   echo ""
   echo -e "${GREEN}Git-committed version${NC} (source of truth)"
-  echo -e "${RED}VPS runtime version${NC} (current file on disk)"
+  # `drift diff` isn't routed through validate_env_file (cmd_drift.sh), so
+  # VPS_HOST is normally unset here and this shows the local working-tree
+  # copy — same as drift_generate_diff's fallback for local-only stacks.
+  if [ -n "${VPS_HOST:-}" ]; then
+    echo -e "${RED}VPS runtime version${NC} (fetched over SSH)"
+  else
+    echo -e "${RED}Local working-tree version${NC} (current file on disk)"
+  fi
   echo ""
 
-  # Create temp file with git content
-  local temp_git_file
-  temp_git_file=$(mktemp)
-  echo "$git_content" > "$temp_git_file"
-
-  # Show unified diff with labels
-  diff -u --label "git-committed/$file" --label "vps-runtime/$file" \
-    "$temp_git_file" "$vps_file" || true  # diff returns 1 when files differ — expected
-
-  # Cleanup
-  rm -f "$temp_git_file"
+  drift_generate_diff "$stack" "$file" "$stack_dir" || echo "  (diff generation failed)"
 
   return 0
 }
@@ -792,15 +884,16 @@ drift_monitor() {
 
   for tracked_file in "${tracked_files[@]}"; do
     local git_file="$stack_dir/$tracked_file"
-    local vps_file="$stack_dir/$tracked_file"
 
     [ -f "$git_file" ] || continue
     drift_should_ignore "$git_file" "$stack_dir" && continue
 
     local git_hash
     local vps_hash
+    local vps_rc=0
     git_hash=$(drift_get_git_hash "$git_file")
-    vps_hash=$(drift_get_vps_hash "$vps_file")
+    vps_hash=$(drift_get_vps_hash "$stack" "$tracked_file" "$stack_dir") || vps_rc=$?
+    [ "$vps_rc" -eq 2 ] && continue  # unreachable — don't page on a network blip
 
     if [ "$git_hash" != "$vps_hash" ]; then
       drifted_files+=("$tracked_file")

--- a/lib/notify.sh
+++ b/lib/notify.sh
@@ -180,11 +180,12 @@ _notify_payload_json() {
   local event="$1"
   shift || true
 
-  local payload="{\"event\":\"$event\""
+  local payload="{\"event\":\"$(json_escape "$event")\""
   local kv key val
   for kv in "$@"; do
     key="${kv%%=*}"
     val="${kv#*=}"
+    key="$(json_escape "$key")"
     val="$(json_escape "$val")"
     payload+=",\"$key\":\"$val\""
   done

--- a/lib/output.sh
+++ b/lib/output.sh
@@ -29,6 +29,12 @@
 
 set -euo pipefail
 
+# json_escape is the shared JSON-string escaper (lib/utils.sh); the strut
+# entrypoint always sources utils.sh first, but output.sh is also sourced
+# standalone (tests, other tooling) — fall back to sourcing it directly so
+# _out_json_escape below doesn't depend on caller order.
+declare -F json_escape >/dev/null || source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
+
 # ── Internal state ────────────────────────────────────────────────────────────
 _OUT_TABLE_COLS=()
 _OUT_TABLE_ROWS=()       # Rows stored TSV-encoded (fields joined by \t)
@@ -97,9 +103,20 @@ out_table_row() {
     fi
     i=$((i + 1))
   done
-  # Join with tab — tab is safe since we don't expect tabs in cell values
-  local IFS=$'\t'
-  _OUT_TABLE_ROWS+=("${row[*]}")
+  # Join with the ASCII unit separator (0x1F), not a tab: IFS word-splitting
+  # collapses runs of *whitespace* IFS characters (tab included), which
+  # silently drops empty cells (out_table_row "a" "" "c" would re-split
+  # back into 2 fields, shifting "c" into the middle column). 0x1F isn't
+  # whitespace, so `read -a` below treats each separator as a real
+  # boundary and preserves empties.
+  #
+  # A trailing empty cell needs one more trick: IFS splitting (any
+  # delimiter, not just whitespace) always drops a trailing empty field
+  # ("a\x1f" splits to one field, not two). Appending one extra trailing
+  # separator absorbs that drop, so a real trailing-empty cell round-trips
+  # correctly — see out_table_render.
+  local IFS=$'\x1f'
+  _OUT_TABLE_ROWS+=("${row[*]}$IFS")
 }
 
 # out_table_render — emit the buffered table to stdout and reset
@@ -114,10 +131,10 @@ out_table_render() {
 
   # Rows
   local row
-  local IFS=$'\t'
+  local IFS=$'\x1f'
   for row in "${_OUT_TABLE_ROWS[@]+"${_OUT_TABLE_ROWS[@]}"}"; do
     local -a fields
-    read -r -a fields <<<"$row"
+    IFS=$'\x1f' read -r -a fields <<<"$row"
     _out_print_row "$(output_use_color && echo 1 || echo 0)" "cell" "${fields[@]}"
   done
 
@@ -188,15 +205,12 @@ _out_json_enabled() {
   [ "$(output_mode)" = "json" ]
 }
 
-# _out_json_escape <string> — escape for JSON string literal (stdin passthrough)
+# _out_json_escape <string> — escape for JSON string literal
+#
+# Thin wrapper over the shared json_escape() (lib/utils.sh) so there's one
+# escaping implementation, not two near-identical ones drifting apart.
 _out_json_escape() {
-  local s="$1"
-  s="${s//\\/\\\\}"
-  s="${s//\"/\\\"}"
-  s="${s//$'\n'/\\n}"
-  s="${s//$'\r'/\\r}"
-  s="${s//$'\t'/\\t}"
-  printf '%s' "$s"
+  json_escape "$1"
 }
 
 _out_json_comma_if_needed() {
@@ -223,8 +237,13 @@ out_json_object() {
 out_json_close_object() {
   _out_json_enabled || return 0
   printf '}'
-  unset '_OUT_JSON_STACK[-1]'
-  unset '_OUT_JSON_FIRST[-1]'
+  # Guard against an unbalanced close (caller bug, or a container already
+  # closed) — unset on an empty array throws "bad array subscript" and
+  # would abort under set -e. `if` (not `&&`) so the false branch itself
+  # doesn't trip errexit.
+  if [ "${#_OUT_JSON_STACK[@]}" -gt 0 ]; then unset '_OUT_JSON_STACK[-1]'; fi
+  if [ "${#_OUT_JSON_FIRST[@]}" -gt 0 ]; then unset '_OUT_JSON_FIRST[-1]'; fi
+  return 0
 }
 
 # out_json_array <key> — open a keyed array inside an object
@@ -241,8 +260,9 @@ out_json_array() {
 out_json_close_array() {
   _out_json_enabled || return 0
   printf ']'
-  unset '_OUT_JSON_STACK[-1]'
-  unset '_OUT_JSON_FIRST[-1]'
+  if [ "${#_OUT_JSON_STACK[@]}" -gt 0 ]; then unset '_OUT_JSON_STACK[-1]'; fi
+  if [ "${#_OUT_JSON_FIRST[@]}" -gt 0 ]; then unset '_OUT_JSON_FIRST[-1]'; fi
+  return 0
 }
 
 # out_json_field <key> <value>

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -68,9 +68,15 @@ error() { echo -e "${RED}✗${NC}  $(_error_prefix)$1" >&2; }
 # json_escape <string>
 #
 # Escapes a string for safe embedding inside a hand-built JSON string value.
+# The single shared escaper for all hand-built JSON in strut — table/status
+# output (lib/output.sh), notify payloads, history records, alert bodies.
+#
 # Order matters: backslashes must be escaped FIRST, then quotes, then control
 # characters — otherwise the backslashes just inserted for \n/\r/\t would
-# themselves get doubled by a later backslash pass.
+# themselves get doubled by a later backslash pass. Any other control
+# character (0x01-0x1F — e.g. a stray ANSI ESC byte) is invalid unescaped in
+# a JSON string and would make consumers like jq reject it; those get
+# \u00XX-escaped individually.
 json_escape() {
   local s="$1"
   s="${s//\\/\\\\}"
@@ -78,6 +84,18 @@ json_escape() {
   s="${s//$'\r'/\\r}"
   s="${s//$'\n'/\\n}"
   s="${s//$'\t'/\\t}"
+  if [[ "$s" == *[$'\x01'-$'\x1f']* ]]; then
+    local out="" c code i len=${#s}
+    for (( i = 0; i < len; i++ )); do
+      c="${s:i:1}"
+      if [[ "$c" < $'\x20' ]]; then
+        printf -v code '%d' "'$c"
+        printf -v c '\\u%04x' "$code"
+      fi
+      out+="$c"
+    done
+    s="$out"
+  fi
   echo "$s"
 }
 

--- a/tests/test_cmd_diff.bats
+++ b/tests/test_cmd_diff.bats
@@ -44,7 +44,13 @@ EOF
   export CMD_STACK_DIR="$TEST_TMP/stacks/test-stack"
   export CMD_ENV_FILE="$TEST_TMP/.prod.env"
   export CMD_ENV_NAME="prod"
-  export CMD_JSON="false"
+  # CMD_JSON's real convention (set by flags.sh) is the literal string
+  # "--json" when the flag was passed, or unset/empty otherwise — never
+  # "true"/"false" (strut#380). "false" here used to be silently
+  # equivalent to unset against the old (broken) `= "true"` check; it is
+  # NOT equivalent under the fixed `[ -n "$CMD_JSON" ]` check, so tests
+  # must use the real convention too.
+  export CMD_JSON=""
   export CLI_ROOT="$CLI_ROOT"
 }
 
@@ -122,4 +128,42 @@ EOF
   run cmd_diff
   [ "$status" -eq 0 ]
   [[ "$output" == *"No changes"* ]]
+}
+
+# strut#380: --json is consumed by the top-level flag parser before
+# cmd_diff ever sees it (CMD_JSON is set to the literal string "--json",
+# never "true") — this test goes through the REAL flag convention rather
+# than a hand-set "true"/"false" that the old bug was invisible to.
+
+@test "cmd_diff: --json (via CMD_JSON, the real flag-parser convention) emits valid JSON" {
+  export CMD_JSON="--json"
+  ssh() { return 0; }
+  export -f ssh
+
+  diff_fetch_remote() {
+    case "$1" in
+      *.env) cat "$TEST_TMP/.prod.env" ;;
+      *docker-compose.yml) cat "$TEST_TMP/stacks/test-stack/docker-compose.yml" ;;
+    esac
+  }
+  export -f diff_fetch_remote
+
+  run cmd_diff
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"No changes"* ]]  # text-mode phrasing must NOT appear
+
+  command -v jq &>/dev/null || skip "jq not available"
+  echo "$output" | jq -e . >/dev/null
+  [ "$(echo "$output" | jq -r '.stack')" = "test-stack" ]
+  [ "$(echo "$output" | jq -r '.has_changes')" = "false" ]
+}
+
+@test "cmd_diff: without --json, output is text even though changes exist under --json elsewhere" {
+  # Guards the other direction: CMD_JSON unset must stay in text mode.
+  ssh() { return 255; }
+  export -f ssh
+
+  run cmd_diff
+  [ "$status" -eq 2 ]
+  [[ "$output" != "{"* ]]
 }

--- a/tests/test_cmd_drift_images.bats
+++ b/tests/test_cmd_drift_images.bats
@@ -1,0 +1,271 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_cmd_drift_images.bats — Tests for `drift images` (strut#382)
+# ==================================================
+# Three bugs fixed here:
+#   1. Wrong project name — `docker compose ps -q` with no --project-name
+#      infers the project from the compose file's directory ("<stack>"),
+#      never the "<stack>-<env>" project a real strut deploy creates, so
+#      it silently found nothing for every real deployment.
+#   2. Multi-arch false positive — the first "digest" field in a manifest
+#      LIST is a per-platform manifest digest, never equal to what was
+#      actually pulled, so every multi-arch image (postgres, nginx,
+#      redis, ...) was reported as DRIFT.
+#   3. SSH failure read as "current" — `... || true` swallowed connection
+#      failures, so an unreachable host silently reported clean.
+#
+# `ssh` is stubbed to run the remote script LOCALLY via `bash -c` (the
+# last positional arg is always the remote command string) — this
+# exercises the real embedded script logic, not just the outer function.
+#
+# Run:  bats tests/test_cmd_drift_images.bats
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_utils
+
+  fail()  { echo "FAIL: $1" >&2; return 1; }
+  ok()    { echo "OK: $*"; }
+  warn()  { echo "WARN: $*" >&2; }
+  log()   { echo "LOG: $*"; }
+  error() { echo "ERROR: $*" >&2; }
+  export -f fail ok warn log error
+  export RED="" GREEN="" YELLOW="" NC=""
+
+  source "$CLI_ROOT/lib/cmd_drift_images.sh"
+
+  mkdir -p "$TEST_TMP/stacks/demo"
+  cat > "$TEST_TMP/stacks/demo/docker-compose.yml" <<'EOF'
+services:
+  web:
+    image: nginx:alpine
+EOF
+  cat > "$TEST_TMP/.prod.env" <<'EOF'
+VPS_HOST=vps.example.com
+EOF
+
+  export CLI_ROOT="$TEST_TMP"
+}
+
+teardown() { common_teardown; }
+
+# ── _drift_images_project_name ───────────────────────────────────────────────
+
+@test "_drift_images_project_name: resolves via resolve_compose_cmd, not the bare stack name" {
+  resolve_compose_cmd() { echo "docker compose --project-name demo-prod -f x.yml"; }
+  export -f resolve_compose_cmd
+
+  run _drift_images_project_name "demo" "$TEST_TMP/.prod.env"
+  [ "$status" -eq 0 ]
+  [ "$output" = "demo-prod" ]
+}
+
+@test "_drift_images_project_name: falls back to the bare stack name if resolution fails" {
+  resolve_compose_cmd() { return 1; }
+  export -f resolve_compose_cmd
+
+  run _drift_images_project_name "demo" "$TEST_TMP/.prod.env"
+  [ "$status" -eq 0 ]
+  [ "$output" = "demo" ]
+}
+
+# ── Local detection: --project-name is actually passed ─────────────────────
+
+@test "_drift_images_detect: passes --project-name to docker compose ps (strut#382 bug 1)" {
+  docker() {
+    if [ "$1" = "compose" ]; then
+      echo "docker $*" >> "$TEST_TMP/docker_calls"
+      [[ "$*" == *"--project-name demo-prod"* ]] || return 1
+      echo ""  # no running containers, but the call itself must succeed
+      return 0
+    fi
+  }
+  export -f docker
+
+  run _drift_images_detect "demo" "false" "demo-prod"
+  [ "$status" -eq 0 ]
+  grep -q -- "--project-name demo-prod" "$TEST_TMP/docker_calls"
+}
+
+# ── Remote detection: end-to-end through the embedded SSH script ───────────
+
+_stub_remote_ssh() {
+  # Runs the "remote" script locally via bash -c — the last arg to ssh is
+  # always the command string.
+  ssh() { local cmd="${*: -1}"; bash -c "$cmd"; }
+  export -f ssh
+  build_ssh_opts() { echo ""; }
+  export -f build_ssh_opts
+}
+
+@test "drift_images_remote: passes --project-name in the remote compose invocation (strut#382 bug 1)" {
+  _stub_remote_ssh
+  export VPS_HOST="vps.example.com"
+  export VPS_DEPLOY_DIR="$TEST_TMP"
+
+  docker() {
+    echo "docker $*" >> "$TEST_TMP/docker_calls"
+    case "$1 $2" in
+      "compose -f")
+        [[ "$*" == *"--project-name demo-prod"* ]] || { echo "MISSING PROJECT NAME" >&2; return 1; }
+        echo ""  # no containers
+        return 0
+        ;;
+    esac
+  }
+  export -f docker
+
+  run drift_images_remote "demo" "false" "demo-prod"
+  [ "$status" -eq 0 ]
+  grep -q -- "--project-name demo-prod" "$TEST_TMP/docker_calls"
+}
+
+@test "drift_images_remote: single-arch image with matching digest reports current" {
+  _stub_remote_ssh
+  export VPS_HOST="vps.example.com"
+  export VPS_DEPLOY_DIR="$TEST_TMP"
+
+  export digest="sha256:$(printf 'a%.0s' $(seq 1 64))"
+  docker() {
+    case "$1 $2" in
+      "compose -f") echo "c1" ;;
+      "inspect --format") echo "nginx:alpine|nginx@$digest" ;;
+      "manifest inspect") echo "{\"digest\":\"${digest#sha256:}\"}" ;;
+      *) return 1 ;;
+    esac
+  }
+  export -f docker
+
+  run drift_images_remote "demo" "true" "demo-prod"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.images[0] | select(.status == "current")' >/dev/null
+  [ "$(echo "$output" | jq -r '.drifted')" = "0" ]
+}
+
+@test "drift_images_remote: single-arch image with a mismatched digest reports drift" {
+  _stub_remote_ssh
+  export VPS_HOST="vps.example.com"
+  export VPS_DEPLOY_DIR="$TEST_TMP"
+
+  export running="sha256:$(printf 'a%.0s' $(seq 1 64))"
+  export registry_only="$(printf 'b%.0s' $(seq 1 64))"
+  docker() {
+    case "$1 $2" in
+      "compose -f") echo "c1" ;;
+      "inspect --format") echo "nginx:alpine|nginx@$running" ;;
+      "manifest inspect") echo "{\"digest\":\"$registry_only\"}" ;;
+      *) return 1 ;;
+    esac
+  }
+  export -f docker
+
+  run drift_images_remote "demo" "true" "demo-prod"
+  [ "$status" -eq 1 ]
+  [ "$(echo "$output" | jq -r '.drifted')" = "1" ]
+  echo "$output" | jq -e '.images[0] | select(.status == "stale")' >/dev/null
+}
+
+@test "drift_images_remote: multi-arch manifest list without buildx reports unknown, NOT drift (strut#382 bug 2)" {
+  _stub_remote_ssh
+  export VPS_HOST="vps.example.com"
+  export VPS_DEPLOY_DIR="$TEST_TMP"
+
+  export running="sha256:$(printf 'a%.0s' $(seq 1 64))"
+  docker() {
+    case "$1 $2" in
+      "compose -f") echo "c1" ;;
+      "inspect --format") echo "postgres:16|postgres@$running" ;;
+      "manifest inspect") echo '{"manifests":[{"digest":"sha256:platformonlydigest"}]}' ;;
+      "buildx version") return 1 ;;
+      *) return 1 ;;
+    esac
+  }
+  export -f docker
+
+  run drift_images_remote "demo" "true" "demo-prod"
+  # Must NOT report drift just because the platform-manifest digest
+  # differs from the pulled RepoDigest — that comparison is never valid.
+  [ "$(echo "$output" | jq -r '.drifted')" = "0" ]
+  [ "$(echo "$output" | jq -r '.unknown')" = "1" ]
+  echo "$output" | jq -e '.images[0] | select(.status == "unknown")' >/dev/null
+}
+
+@test "drift_images_remote: multi-arch manifest list WITH buildx compares the true list digest" {
+  _stub_remote_ssh
+  export VPS_HOST="vps.example.com"
+  export VPS_DEPLOY_DIR="$TEST_TMP"
+
+  # Named "fixture_" to avoid colliding with the production script's own
+  # unqualified `list_digest` variable — both run in the same spawned
+  # bash process (no function-local scoping across the ssh/bash -c
+  # boundary), so a same-named fixture var gets clobbered mid-script.
+  export fixture_list_digest="sha256:$(printf 'c%.0s' $(seq 1 64))"
+  docker() {
+    case "$1 $2" in
+      "compose -f") echo "c1" ;;
+      "inspect --format") echo "postgres:16|postgres@$fixture_list_digest" ;;
+      "manifest inspect") echo '{"manifests":[{"digest":"sha256:platformonlydigest"}]}' ;;
+      "buildx version") return 0 ;;
+      "buildx imagetools") echo "Digest: $fixture_list_digest" ;;
+      *) return 1 ;;
+    esac
+  }
+  export -f docker
+
+  run drift_images_remote "demo" "true" "demo-prod"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.drifted')" = "0" ]
+  echo "$output" | jq -e '.images[0] | select(.status == "current")' >/dev/null
+}
+
+@test "drift_images_remote: digest-pinned refs (@sha256:) are already locked, reported current without a lookup" {
+  _stub_remote_ssh
+  export VPS_HOST="vps.example.com"
+  export VPS_DEPLOY_DIR="$TEST_TMP"
+
+  docker() {
+    case "$1 $2" in
+      "compose -f") echo "c1" ;;
+      "inspect --format") echo "nginx@sha256:pinned0000000000000000000000000000000000000000000000000000|nginx@sha256:pinned0000000000000000000000000000000000000000000000000000" ;;
+      "manifest inspect") echo "SHOULD_NOT_BE_CALLED" ;;
+      *) echo "SHOULD_NOT_BE_CALLED"; return 1 ;;
+    esac
+  }
+  export -f docker
+
+  run drift_images_remote "demo" "true" "demo-prod"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"SHOULD_NOT_BE_CALLED"* ]]
+  echo "$output" | jq -e '.images[0] | select(.status == "current")' >/dev/null
+}
+
+# ── SSH/deploy-dir failure — must error, never read as "current" ───────────
+
+@test "drift_images_remote: SSH connection failure (rc 255) returns error, not clean (strut#382 bug 3)" {
+  ssh() { return 255; }
+  export -f ssh
+  build_ssh_opts() { echo ""; }
+  export -f build_ssh_opts
+  export VPS_HOST="vps.example.com"
+
+  run drift_images_remote "demo" "false" "demo-prod"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Could not reach"* ]]
+}
+
+@test "drift_images_remote: unresolvable deploy dir returns error, not clean" {
+  _stub_remote_ssh
+  export VPS_HOST="vps.example.com"
+  export VPS_DEPLOY_DIR="/definitely/does/not/exist/anywhere"
+
+  run drift_images_remote "demo" "false" "demo-prod"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Could not reach"* ]]
+}
+
+@test "drift_images_remote: fails cleanly (not silently) when VPS_HOST is unset" {
+  unset VPS_HOST
+  run drift_images_remote "demo" "false" "demo-prod"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"VPS_HOST not set"* ]]
+}

--- a/tests/test_cmd_fleet_status.bats
+++ b/tests/test_cmd_fleet_status.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_cmd_fleet_status.bats — Tests for `strut fleet status --json` (strut#399)
+# ==================================================
+# `_fleet_status --json` interpolated FLEET_DIRTY_COUNT raw and unescaped
+# string fields into hand-built JSON: a blank/non-numeric dirty count (e.g.
+# a truncated SSH stream) produced invalid JSON like "dirty":,, and any
+# stray quote/backslash in a host alias or branch name broke the object.
+#
+# Run:  bats tests/test_cmd_fleet_status.bats
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_utils
+  source "$CLI_ROOT/lib/topology.sh"
+  source "$CLI_ROOT/lib/connection.sh"
+  source "$CLI_ROOT/lib/fleet.sh"
+  source "$CLI_ROOT/lib/cmd_fleet.sh"
+
+  _TOPO_LOADED=true
+  declare -gA _TOPO_HOSTS=()
+  declare -gA _TOPO_STACK_HOST=()
+}
+
+teardown() { common_teardown; }
+
+@test "_fleet_status --json: normal host produces valid JSON with numeric dirty count" {
+  _TOPO_HOSTS[compass]="gfargo@compass.local:22 ~/.ssh/id_rsa"
+
+  fleet_git_status() {
+    printf 'head_sha=abc1234\nbranch=main\nbehind=0\nahead=0\ndirty_count=2\n'
+  }
+  export -f fleet_git_status
+
+  run _fleet_status --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e . >/dev/null
+  [ "$(echo "$output" | jq -r '.hosts[0].dirty')" = "2" ]
+}
+
+@test "_fleet_status --json: blank dirty_count (truncated SSH stream) still produces valid JSON" {
+  _TOPO_HOSTS[compass]="gfargo@compass.local:22 ~/.ssh/id_rsa"
+
+  # dirty_count intentionally omitted — FLEET_DIRTY_COUNT stays unset/empty,
+  # simulating a truncated remote stream.
+  fleet_git_status() {
+    printf 'head_sha=abc1234\nbranch=main\nbehind=0\nahead=0\n'
+  }
+  export -f fleet_git_status
+
+  run _fleet_status --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e . >/dev/null
+  [ "$(echo "$output" | jq -r '.hosts[0].dirty')" = "0" ]
+}
+
+@test "_fleet_status --json: non-numeric dirty_count is sanitized, not interpolated raw" {
+  _TOPO_HOSTS[compass]="gfargo@compass.local:22 ~/.ssh/id_rsa"
+
+  fleet_git_status() {
+    printf 'head_sha=abc1234\nbranch=main\nbehind=0\nahead=0\ndirty_count=garbled\n'
+  }
+  export -f fleet_git_status
+
+  run _fleet_status --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e . >/dev/null
+  [ "$(echo "$output" | jq -r '.hosts[0].dirty')" = "0" ]
+}
+
+@test "_fleet_status --json: branch name with a double quote stays valid JSON" {
+  _TOPO_HOSTS[compass]="gfargo@compass.local:22 ~/.ssh/id_rsa"
+
+  fleet_git_status() {
+    printf 'head_sha=abc1234\nbranch=feature/"weird"\nbehind=0\nahead=0\ndirty_count=0\n'
+  }
+  export -f fleet_git_status
+
+  run _fleet_status --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e . >/dev/null
+  [[ "$(echo "$output" | jq -r '.hosts[0].branch')" == *'"weird"'* ]]
+}

--- a/tests/test_doctor.bats
+++ b/tests/test_doctor.bats
@@ -213,6 +213,32 @@ teardown() {
   [[ "$output" == *"chmod"* ]]
 }
 
+# strut#381: _doc_check_ssh_key's fix string is literally `chmod 600
+# "$key"` — embedded double quotes around the path. The JSON emitters used
+# to interpolate name/message/fix straight into the jq PROGRAM text, so
+# this exact fix broke the jq program and aborted `doctor --json` under
+# set -e. The text-mode test above never exercised the JSON path at all.
+@test "cmd_doctor --json: insecure key perms (embedded-quote fix string) produces valid JSON, does not abort" {
+  command -v jq &>/dev/null || skip "jq not available"
+
+  export HOME="$TEST_TMP/home-fail-json"
+  mkdir -p "$HOME/.ssh"
+  touch "$HOME/.ssh/id_rsa"
+  chmod 755 "$HOME/.ssh"
+  chmod 644 "$HOME/.ssh/id_rsa"
+
+  _DOC_PASSED=0; _DOC_WARNED=0; _DOC_FAILED=0; _DOC_JSON=true; _DOC_FIX=true
+  _DOC_JSON_RESULTS="[]"
+
+  _doc_check_ssh_key
+
+  echo "$_DOC_JSON_RESULTS" | jq -e . >/dev/null
+  local fix
+  fix=$(echo "$_DOC_JSON_RESULTS" | jq -r '.[] | select(.name == "SSH key permissions") | .fix')
+  [[ "$fix" == *"chmod 600"* ]]
+  [[ "$fix" == *"id_rsa"* ]]
+}
+
 # ── --deep flag parsing ──────────────────────────────────────────────────────
 
 @test "cmd_doctor: --deep implies --check-vps" {

--- a/tests/test_drift.bats
+++ b/tests/test_drift.bats
@@ -190,10 +190,11 @@ EOF
 
 # ── drift_generate_diff ──────────────────────────────────────────────────────
 
-@test "drift_generate_diff: reports missing VPS file" {
-  run drift_generate_diff "$TEST_TMP/git-file" "$TEST_TMP/nonexistent"
+@test "drift_generate_diff: reports untracked file" {
+  mkdir -p "$TEST_TMP/stack_dir"
+  run drift_generate_diff "demo" "nonexistent" "$TEST_TMP/stack_dir"
   [ "$status" -eq 1 ]
-  [[ "$output" == *"VPS file missing"* ]]
+  [[ "$output" == *"not tracked"* ]]
 }
 
 # ── drift_fix ──────────────────────────────────────────────────────────────────
@@ -354,6 +355,152 @@ _drift_fixture_init() {
   [ "$fix_status" -ne 0 ]
   [[ "$fix_output" == *"Failed to restore"* ]]
   [ "$content_after" = "drifted content" ]
+}
+
+# ── strut#182: compare against the real VPS file, not a second local copy ──
+# drift_get_vps_hash/drift_generate_diff used to be handed the SAME local
+# path as both "git_file" and "vps_file" — comparing the working tree
+# against itself always reports clean, hiding real VPS-side drift. `ssh` is
+# stubbed to simulate diff_fetch_remote's `cat <remote_path>` call.
+
+@test "drift_detect: reports drift when the VPS file differs from git, even though local matches git exactly" {
+  local stack="test-drift-remote-$$"
+  local fixture_root="$TEST_TMP/fixture-remote"
+  local committed_content='{"services":{"web":{"image":"nginx:alpine"}}}'
+  _drift_fixture_init "$fixture_root" "$stack" "$committed_content"
+
+  local orig_cli_root="$CLI_ROOT"
+  export CLI_ROOT="$fixture_root"
+  # Local working tree is left untouched — it matches git exactly. Before
+  # the fix, drift_detect compared this local copy against ITSELF, so it
+  # always reported clean regardless of what was actually deployed.
+  export VPS_HOST="vps.example.com"
+  export VPS_DEPLOY_DIR="/opt/deploy"
+  ssh() { echo '{"services":{"web":{"image":"nginx:latest"}}}'; }
+  export -f ssh
+
+  run drift_detect "$stack" "prod"
+  local rc="$status"
+  local out="$output"
+
+  unset VPS_HOST VPS_DEPLOY_DIR
+  export CLI_ROOT="$orig_cli_root"
+
+  [ "$rc" -eq 1 ]
+  [[ "$out" == *"docker-compose.yml"* ]]
+}
+
+@test "drift_detect: no drift when the VPS file matches git exactly" {
+  local stack="test-drift-remote-clean-$$"
+  local fixture_root="$TEST_TMP/fixture-remote-clean"
+  local committed_content='{"services":{"web":{"image":"nginx:alpine"}}}'
+  _drift_fixture_init "$fixture_root" "$stack" "$committed_content"
+
+  local orig_cli_root="$CLI_ROOT"
+  export CLI_ROOT="$fixture_root"
+  export VPS_HOST="vps.example.com"
+  export VPS_DEPLOY_DIR="/opt/deploy"
+  ssh() { echo '{"services":{"web":{"image":"nginx:alpine"}}}'; }
+  export -f ssh
+
+  run drift_detect "$stack" "prod"
+  local rc="$status"
+
+  unset VPS_HOST VPS_DEPLOY_DIR
+  export CLI_ROOT="$orig_cli_root"
+
+  [ "$rc" -eq 0 ]
+}
+
+@test "drift_get_vps_hash: SSH unreachable returns 'unreachable' (rc=2)" {
+  local stack="test-drift-unreachable-$$"
+  local fixture_root="$TEST_TMP/fixture-unreachable"
+  _drift_fixture_init "$fixture_root" "$stack" '{"services":{"web":{"image":"nginx:alpine"}}}'
+
+  local orig_cli_root="$CLI_ROOT"
+  export CLI_ROOT="$fixture_root"
+  export VPS_HOST="vps.example.com"
+  export VPS_DEPLOY_DIR="/opt/deploy"
+  ssh() { return 255; }  # OpenSSH's own connect/auth failure exit code
+  export -f ssh
+
+  run drift_get_vps_hash "$stack" "docker-compose.yml" "$fixture_root/stacks/$stack"
+
+  unset VPS_HOST VPS_DEPLOY_DIR
+  export CLI_ROOT="$orig_cli_root"
+
+  [ "$status" -eq 2 ]
+  [ "$output" = "unreachable" ]
+}
+
+@test "drift_detect: SSH unreachable is skipped, not reported as drift" {
+  local stack="test-drift-unreachable-detect-$$"
+  local fixture_root="$TEST_TMP/fixture-unreachable-detect"
+  _drift_fixture_init "$fixture_root" "$stack" '{"services":{"web":{"image":"nginx:alpine"}}}'
+
+  local orig_cli_root="$CLI_ROOT"
+  export CLI_ROOT="$fixture_root"
+  export VPS_HOST="vps.example.com"
+  export VPS_DEPLOY_DIR="/opt/deploy"
+  ssh() { return 255; }
+  export -f ssh
+
+  run drift_detect "$stack" "prod"
+  local rc="$status"
+  local out="$output"
+
+  unset VPS_HOST VPS_DEPLOY_DIR
+  export CLI_ROOT="$orig_cli_root"
+
+  [ "$rc" -eq 0 ]
+  [[ "$out" == *"No configuration drift"* ]]
+}
+
+@test "drift_generate_diff: shows a real diff against VPS content, not an empty self-comparison" {
+  local stack="test-drift-diff-remote-$$"
+  local fixture_root="$TEST_TMP/fixture-diff-remote"
+  local committed_content='{"services":{"web":{"image":"nginx:alpine"}}}'
+  _drift_fixture_init "$fixture_root" "$stack" "$committed_content"
+
+  local orig_cli_root="$CLI_ROOT"
+  export CLI_ROOT="$fixture_root"
+  export VPS_HOST="vps.example.com"
+  export VPS_DEPLOY_DIR="/opt/deploy"
+  ssh() { echo '{"services":{"web":{"image":"nginx:latest"}}}'; }
+  export -f ssh
+
+  run drift_generate_diff "$stack" "docker-compose.yml" "$fixture_root/stacks/$stack"
+
+  unset VPS_HOST VPS_DEPLOY_DIR
+  export CLI_ROOT="$orig_cli_root"
+
+  [[ "$output" == *"nginx:alpine"* ]]
+  [[ "$output" == *"nginx:latest"* ]]
+  [[ "$output" == *"vps-runtime"* ]]
+}
+
+@test "drift_fix: with VPS_HOST set, success message hints that deploy/release is needed to push the fix" {
+  local stack="test-drift-fix-vps-hint-$$"
+  local fixture_root="$TEST_TMP/fixture-vps-hint"
+  local committed_content='{"services":{"web":{"image":"nginx:alpine"}}}'
+  _drift_fixture_init "$fixture_root" "$stack" "$committed_content"
+
+  local orig_cli_root="$CLI_ROOT"
+  export CLI_ROOT="$fixture_root"
+  export VPS_HOST="vps.example.com"
+  export VPS_DEPLOY_DIR="/opt/deploy"
+  ssh() { echo '{"services":{"web":{"image":"nginx:latest"}}}'; }
+  export -f ssh
+
+  run drift_fix "$stack" "prod"
+  local fix_status="$status"
+  local fix_output="$output"
+
+  unset VPS_HOST VPS_DEPLOY_DIR
+  export CLI_ROOT="$orig_cli_root"
+
+  [ "$fix_status" -eq 0 ]
+  [[ "$fix_output" == *"push it to the VPS"* ]]
 }
 
 # ── Property: drift_store_event always creates valid JSON ─────────────────────


### PR DESCRIPTION
## Summary

Bucket C of the July 2026 audit triage — closes out the drift/diff/doctor
inspection-engine cluster and a grab-bag of JSON-output robustness bugs.

Fixes #182, #380, #381, #382, #399. Partially addresses #248 (see below).

### drift (#182, partial #248)

- `drift_get_git_hash` no longer echo-wraps `git show` output, which
  silently added a trailing newline the raw VPS-side `sha256sum` never
  had — this false-positived nearly every file as drifted.
- `drift_get_vps_hash`/`drift_generate_diff` now fetch the actual remote
  file content over SSH (via `diff_fetch_remote`) when `VPS_HOST` is set,
  instead of diffing a local path against itself. Unreachable hosts
  return a distinct "unreachable" state (rc=2) instead of reading clean.
- Fixed a pre-existing self-comparison bug in `drift_report`'s second
  loop (`drift_generate_diff "$vps_file" "$vps_file"`).

#248 proposes unifying drift/diff/doctor/validate/posture/status-all on
one comparison engine. Its own spec (`docs/M3-SPEC.md`) frames that as a
4-phase effort blocked by #256/#251; this PR completes phase 1 (fix
drift's hashing/remote-awareness) and fixes #182 by construction for
drift specifically, but leaves the full `lib/compare.sh` extraction and
migration of the other subsystems as a separate, larger refactor — #248
stays open.

### `diff --json` (#380)

`cmd_diff` compared `CMD_JSON` against the literal string `"true"`, but
the flag parser sets it to `"--json"` (or leaves it unset) — `--json`
was silently a no-op and diff always printed the text report. Now checks
for presence, matching how `cmd_drift` already reads the same flag.

### `doctor --json` (#381)

`_doc_pass`/`_doc_warn`/`_doc_fail` built their `jq` program via string
interpolation of check `message`/`fix` text. Any value containing a
double quote — e.g. the SSH key permissions fix's quoted path
(`chmod 600 "/home/u/.ssh/id_rsa"`) — broke the `jq` program syntax and
aborted the whole `doctor --json` run under `set -e`. Now passed as `jq
--arg` data instead of interpolated text.

### `drift images` (#382)

- `drift_images_remote`/`_drift_images_detect` now pass `--project-name
  <stack>-<env>` to `docker compose ps` — without it, `ps` infers the
  project from the compose file's directory name and silently found zero
  containers for every real strut-deployed stack.
- Multi-arch manifest lists are no longer compared against their
  per-platform manifest digest (never a valid comparison — that's what
  caused false-positive drift on postgres/nginx/redis and other
  multi-arch images). Resolved via `docker buildx imagetools` when
  available, else reported `unknown` rather than guessed.
- SSH/deploy-dir failures now return a distinct error (rc=2) instead of
  being swallowed (`|| true`) and read as "current".

### output/JSON robustness (#399)

- `json_escape` (`lib/utils.sh`) and `_out_json_escape` (`lib/output.sh`)
  were near-duplicate escapers that both missed control characters
  outside `\ " \n \r \t`. Consolidated into one implementation that
  `\u00XX`-escapes the rest; `output.sh` now falls back to sourcing
  `utils.sh` if it isn't already loaded, so it stays correct whether
  sourced standalone or via the entrypoint.
- `out_table_row` joined/re-split cells on a tab; `IFS`-based splitting
  on a *whitespace* character collapses runs of delimiters, so
  `out_table_row "name" "" "path"` re-split back into 2 fields and
  shifted `path` into the middle column. Switched to a non-whitespace
  unit separator (0x1F), plus a trailing-delimiter trick so a trailing
  empty cell round-trips correctly too (IFS splitting always drops a
  genuinely trailing empty field regardless of delimiter).
- `fleet status --json` interpolated `$FLEET_DIRTY_COUNT` raw and
  unquoted; a blank value (e.g. a truncated SSH stream) produced invalid
  JSON like `"dirty":,`. Defaulted to 0 and validated as numeric; string
  fields are now escaped too.
- `notify.sh`'s hand-built payload escaped only the value, never the
  `event`/`key` fields.
- `out_json_close_object`/`_close_array` threw "bad array subscript" and
  aborted under `set -e` when called on an already-empty stack (an
  unbalanced open/close from a caller bug). Guarded.

Also fixes 3 pre-existing failing tests in the new drift-images bats
suite (written for #382) — both were test-harness bugs, not production
bugs: mock `docker()` functions closing over bats `local` variables that
never crossed into the `ssh` stub's child `bash -c` process (fixed by
exporting them), and one fixture variable name (`list_digest`) colliding
with the production script's own same-named variable in the shared
process namespace (renamed to `fixture_list_digest`).

## Test plan

- [x] `bash -n` + `shellcheck -x` clean on all changed files
- [x] `bats tests/test_cmd_drift_images.bats` — 12/12 (confirmed 3 fail
      against pre-fix code, pass after)
- [x] `bats tests/test_cmd_fleet_status.bats` — 4/4 new tests (confirmed
      3 fail against pre-fix code, pass after)
- [x] `bats tests/test_output.bats tests/test_utils.bats
      tests/test_cmd_fleet.bats tests/test_notify.bats` — 134/134
- [x] `bats tests/test_cmd_diff.bats tests/test_doctor.bats
      tests/test_drift.bats` — full pass
- [x] Full `bats tests/` suite — all ~2327 tests pass, exit 0