### PR TITLE
fix: config/topology INI-parser divergence + scaffold safety guards

### DIFF
--- a/lib/cmd_scaffold.sh
+++ b/lib/cmd_scaffold.sh
@@ -33,6 +33,15 @@ cmd_scaffold() {
   local first="${1:-}"
   [ -n "$first" ] || fail "Usage: strut scaffold <new-stack-name> [--recipe <recipe>]"
 
+  # `--help`/`-h` was previously treated as a literal stack name — nothing
+  # else intercepts it before the "create a stack" path below (strut#403).
+  case "$first" in
+    --help|-h)
+      _usage_scaffold
+      return 0
+      ;;
+  esac
+
   # ── Subcommand: list ────────────────────────────────
   if [ "$first" = "list" ]; then
     shift
@@ -55,6 +64,25 @@ cmd_scaffold() {
   local new_name="$first"
   shift || true
 
+  # Any other flag-shaped first positional (--recipe, an unrecognized
+  # flag, etc.) is a usage error, not a stack name — without this,
+  # `strut scaffold --recipe python-api` silently named the stack
+  # "--recipe" and failed confusingly downstream (strut#403).
+  #
+  # The explicit `return 1` after each fail() below matters: fail() exits
+  # in production, but tests stub it to return, and a bare `check ||
+  # fail "msg"` only aborts the surrounding function under errexit — bats'
+  # `run` disables errexit for the call it wraps, so without the explicit
+  # return, execution would fall through and scaffold the invalid name
+  # anyway (belt-and-suspenders, same pattern as load_strut_config).
+  case "$new_name" in
+    -*) fail "Missing stack name. Usage: strut scaffold <new-stack-name> [--recipe <recipe>]"; return 1 ;;
+  esac
+  [[ "$new_name" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || {
+    fail "Invalid stack name: '$new_name' (must start with a letter/digit and contain only letters, digits, '.', '_', '-')"
+    return 1
+  }
+
   # ── Parse flags ─────────────────────────────────────
   local recipe_flag=""
   while [[ $# -gt 0 ]]; do
@@ -65,12 +93,17 @@ cmd_scaffold() {
     esac
   done
 
-  local target
-  if [ -n "${PROJECT_ROOT:-}" ]; then
-    target="$PROJECT_ROOT/stacks/$new_name"
-  else
-    target="$CLI_ROOT/stacks/$new_name"
-  fi
+  # Without a project, CLI_ROOT falls back to STRUT_HOME (the engine
+  # install), so scaffolding here silently pollutes ~/.strut/stacks/ and
+  # the stack "disappears" once a project is later initialized (strut#403).
+  # Stack-scoped commands already guard this at the entrypoint; scaffold
+  # is dispatched as a top-level command and never went through that check.
+  [ -n "${PROJECT_ROOT:-}" ] || {
+    fail "Not inside a strut project (no strut.conf found walking up from $PWD). Run 'strut init' to create one, or cd into an existing project."
+    return 1
+  }
+
+  local target="$PROJECT_ROOT/stacks/$new_name"
   [ -d "$target" ] && fail "Stack already exists: $target"
 
   local templates_dir="${STRUT_HOME:-$CLI_ROOT}/templates"

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -64,20 +64,26 @@ _preprocess_config() {
       continue
     fi
 
-    # Lines inside a section use "key = value" format (spaces around =).
-    # A bash-style assignment (KEY=value, no spaces around =) or another
-    # section header signals the end of the section.
+    # Lines inside a section use topology.sh's own "key = value" /
+    # "key=value" shape (strut#377 — same matcher, spaces optional on
+    # both sides, so a valid space-less entry like "web=ubuntu@1.2.3.4"
+    # is recognized as content rather than mistaken for having left the
+    # section). Because that shape is indistinguishable from a plain
+    # bash assignment, content alone can no longer signal the section's
+    # end — a blank line does (every fixture in this codebase uses blank
+    # lines exactly as block separators: before a header, or before
+    # global content resumes; never as filler between two entries of the
+    # same section), matching a new header, or EOF.
     if [ "$_in_section" = "true" ]; then
-      # Stay in section for: blank lines and comments
-      if [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]]; then
+      if [ -z "$line" ]; then
+        _in_section=false
+      elif [[ "$line" =~ ^[[:space:]]*# ]]; then
         continue
-      fi
-      # Section content: "key = value" (has space before =)
-      if [[ "$line" =~ ^[[:space:]]*[a-zA-Z0-9_-]+[[:space:]]+= ]]; then
+      elif [[ "$line" =~ ^[[:space:]]*[a-zA-Z0-9_-]+[[:space:]]*= ]]; then
         continue
+      else
+        _in_section=false
       fi
-      # Anything else (bash assignment KEY=val, other content) = left section
-      _in_section=false
     fi
 
     if [[ "$line" =~ ^[[:space:]]*include[[:space:]]*=[[:space:]]*(.+)$ ]]; then

--- a/lib/topology.sh
+++ b/lib/topology.sh
@@ -59,7 +59,10 @@ topology_load() {
     [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
 
     # Detect section headers
-    if [[ "$line" =~ ^\[([a-zA-Z_-]+)\]$ ]]; then
+    # Trailing-whitespace-tolerant, matching config.sh's preprocessor
+    # header regex (strut#377) — the two used to disagree, so a header
+    # with trailing spaces parsed under one and not the other.
+    if [[ "$line" =~ ^\[([a-zA-Z_-]+)\][[:space:]]*$ ]]; then
       section="${BASH_REMATCH[1]}"
       continue
     fi

--- a/tests/integration/test_recipes_e2e.bats
+++ b/tests/integration/test_recipes_e2e.bats
@@ -27,6 +27,19 @@ setup_file() {
   export CLI_ROOT
   export STRUT_HOME="$CLI_ROOT"
 
+  # `strut scaffold` now requires a real project (PROJECT_ROOT resolved via
+  # a strut.conf) to exist before it will write anything (strut#403 — it
+  # used to silently fall back to writing into CLI_ROOT/STRUT_HOME, which
+  # is exactly this engine checkout). Every recipe here is scaffolded
+  # straight into this repo's own stacks/ dir and cleaned up below, so
+  # give it a throwaway strut.conf for the duration of this file only.
+  _WROTE_STRUT_CONF=false
+  if [ ! -f "$CLI_ROOT/strut.conf" ]; then
+    : > "$CLI_ROOT/strut.conf"
+    _WROTE_STRUT_CONF=true
+  fi
+  export _WROTE_STRUT_CONF
+
   # Track every stack we scaffold so teardown nukes them even if a test
   # aborts partway.
   export SCAFFOLDED_STACKS_FILE="$(mktemp)"
@@ -34,6 +47,10 @@ setup_file() {
 }
 
 teardown_file() {
+  if [ "${_WROTE_STRUT_CONF:-false}" = "true" ]; then
+    rm -f "$CLI_ROOT/strut.conf"
+  fi
+
   # Best-effort cleanup of anything we scaffolded or deployed.
   if [ -f "${SCAFFOLDED_STACKS_FILE:-}" ]; then
     while IFS= read -r entry; do

--- a/tests/test_anonymize.bats
+++ b/tests/test_anonymize.bats
@@ -263,6 +263,7 @@ EOF
 
 @test "scaffold: creates anonymize.conf template" {
   source "$CLI_ROOT/lib/cmd_scaffold.sh"
+  export PROJECT_ROOT="$CLI_ROOT"
 
   local stack_name="test-anon-scaffold-$$"
   run cmd_scaffold "$stack_name"

--- a/tests/test_cli_dispatch.bats
+++ b/tests/test_cli_dispatch.bats
@@ -98,10 +98,16 @@ setup() {
 }
 
 @test "strut scaffold with existing stack fails" {
-  local cli_root="$(dirname "$CLI")"
-  mkdir -p "$cli_root/stacks/existing-stack"
-  run bash "$CLI" scaffold existing-stack
-  rm -rf "$cli_root/stacks/existing-stack"
+  # scaffold now requires PROJECT_ROOT (strut#403 — otherwise it silently
+  # wrote into the engine's own stacks/ dir), so this needs a real project
+  # dir with a strut.conf rather than reusing the engine repo directly.
+  local project_dir
+  project_dir="$(mktemp -d)"
+  touch "$project_dir/strut.conf"
+  mkdir -p "$project_dir/stacks/existing-stack"
+
+  run env STRUT_PROJECT="$project_dir" bash "$CLI" scaffold existing-stack
+  rm -rf "$project_dir"
   [ "$status" -ne 0 ]
   [[ "$output" == *"already exists"* ]]
 }

--- a/tests/test_config_include.bats
+++ b/tests/test_config_include.bats
@@ -348,6 +348,45 @@ EOF
   [[ "$result" != *"myhost"* ]]
 }
 
+@test "preprocess_config: space-less 'key=value' entry inside a section doesn't leak past the section (strut#377)" {
+  cat > "$TEST_TMP/nospace.conf" <<'EOF'
+REGISTRY_TYPE=ghcr
+
+[hosts]
+web=ubuntu@1.2.3.4
+db = ubuntu@2.3.4.5
+
+BANNER_TEXT=after-sections
+EOF
+
+  run preprocess_config "$TEST_TMP/nospace.conf"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"REGISTRY_TYPE=ghcr"* ]]
+  [[ "$output" == *"BANNER_TEXT=after-sections"* ]]
+  # Neither section-content line (spaced or not) should have leaked out
+  # to be sourced as a bash statement.
+  [[ "$output" != *"web=ubuntu"* ]]
+  [[ "$output" != *"db = ubuntu"* ]]
+  [[ "$output" != *"db ="* ]]
+}
+
+@test "load_strut_config: does not abort on a [hosts] section with space-less entries (strut#377)" {
+  cat > "$TEST_TMP/strut.conf" <<'EOF'
+REGISTRY_TYPE=ecr
+
+[hosts]
+web=ubuntu@1.2.3.4
+db=ubuntu@2.3.4.5
+
+[stacks]
+api=web
+EOF
+
+  export PROJECT_ROOT="$TEST_TMP"
+  run load_strut_config
+  [ "$status" -eq 0 ]
+}
+
 @test "load_strut_config: works with [hosts] and [stacks] sections present" {
   cat > "$TEST_TMP/strut.conf" <<'EOF'
 REGISTRY_TYPE=ecr

--- a/tests/test_scaffold.bats
+++ b/tests/test_scaffold.bats
@@ -188,20 +188,67 @@ _hostile_names() {
   done < <(_hostile_names)
 }
 
-@test "scaffold: hostile-character stack name substitutes cleanly, no STACK_NAME_PLACEHOLDER left" {
+@test "scaffold: hostile-character stack name is rejected outright, not sanitized-then-scaffolded (strut#403)" {
+  # A stack name with a space/slash/quote/etc. would break directory paths,
+  # Docker Compose project naming, and every downstream shell interpolation
+  # that treats it as a bare identifier — strut#403 added name validation
+  # so these are rejected up front instead of relying on sed-escaping to
+  # make substitution merely "safe" for an otherwise-invalid name.
   local i=0
   while IFS= read -r name_part; do
     i=$((i + 1))
     local stack_name="hostile-$i-${name_part}"
 
-    cmd_scaffold "$stack_name"
+    run cmd_scaffold "$stack_name"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid stack name"* ]]
 
     local target="$TEST_TMP/stacks/$stack_name"
-    [ -f "$target/docker-compose.yml" ]
-
-    run grep -r "STACK_NAME_PLACEHOLDER" "$target"
-    [ "$status" -ne 0 ] || { echo "FAIL: STACK_NAME_PLACEHOLDER survived for stack name '$stack_name'"; return 1; }
+    [ ! -d "$target" ]
   done < <(_hostile_names)
+}
+
+# ── strut#403: --help interception, invalid names, no-project guard ──────────
+
+@test "scaffold --help: prints usage instead of creating a stack literally named '--help'" {
+  run cmd_scaffold --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage:"* ]]
+  [ ! -d "$TEST_TMP/stacks/--help" ]
+}
+
+@test "scaffold -h: prints usage instead of creating a stack literally named '-h'" {
+  run cmd_scaffold -h
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage:"* ]]
+  [ ! -d "$TEST_TMP/stacks/-h" ]
+}
+
+@test "scaffold --recipe python-api (no name): fails with a usage error, does not scaffold a stack named '--recipe'" {
+  run cmd_scaffold --recipe python-api
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Missing stack name"* ]]
+  [ ! -d "$TEST_TMP/stacks/--recipe" ]
+}
+
+@test "scaffold: rejects a name starting with a dot or dash" {
+  run cmd_scaffold ".hidden-stack"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid stack name"* ]]
+}
+
+@test "scaffold: accepts names with letters, digits, dots, underscores, and dashes" {
+  run cmd_scaffold "my-app_2.0"
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_TMP/stacks/my-app_2.0" ]
+}
+
+@test "scaffold: fails clearly instead of scaffolding into CLI_ROOT/STRUT_HOME when PROJECT_ROOT is unset" {
+  unset PROJECT_ROOT
+  run cmd_scaffold "test-stack"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Not inside a strut project"* ]]
+  [ ! -d "$CLI_ROOT/stacks/test-stack" ]
 }
 
 # ── Unit tests ────────────────────────────────────────────────────────────────

--- a/tests/test_topology.bats
+++ b/tests/test_topology.bats
@@ -85,6 +85,34 @@ EOF
   [ "${_TOPO_STACK_HOST[plane]}" = "compass" ]
 }
 
+@test "topology_load: tolerates trailing whitespace on a section header, matching config.sh's preprocessor (strut#377)" {
+  printf 'REGISTRY_TYPE=none\n\n[hosts] \ncompass = gfargo@compass.local:22 ~/.ssh/id_rsa\n\n[stacks]  \nplane = compass\n' > "$TEST_TMP/strut.conf"
+
+  export PROJECT_ROOT="$TEST_TMP"
+  topology_load
+
+  [ "${_TOPO_HOSTS[compass]}" = "gfargo@compass.local:22 ~/.ssh/id_rsa" ]
+  [ "${_TOPO_STACK_HOST[plane]}" = "compass" ]
+}
+
+@test "topology_load: parses space-less 'key=value' host/stack entries (strut#377)" {
+  cat > "$TEST_TMP/strut.conf" <<'EOF'
+REGISTRY_TYPE=none
+
+[hosts]
+web=ubuntu@1.2.3.4
+
+[stacks]
+api=web
+EOF
+
+  export PROJECT_ROOT="$TEST_TMP"
+  topology_load
+
+  [ "${_TOPO_HOSTS[web]}" = "ubuntu@1.2.3.4" ]
+  [ "${_TOPO_STACK_HOST[api]}" = "web" ]
+}
+
 @test "topology_load: no-op when no strut.conf exists" {
   export PROJECT_ROOT="$TEST_TMP/nonexistent"
   topology_load


### PR DESCRIPTION
## Summary

Fixes #377 and #403 (the last two of the six items queued to Ready for
Agent this session).

### #377 — config.sh/topology.sh INI-parser divergence

`preprocess_config`'s section-content matcher required a space before
`=` to distinguish INI section content (`key = value`) from "we left
the section" (any bash-shaped `KEY=value`). A space-less `[hosts]`
entry (`web=ubuntu@1.2.3.4`, which `topology.sh` parses fine) tripped
this heuristic — the preprocessor thought it had left the section, so
the *next* entry leaked through as a raw line and got sourced as bash.
A normally-spaced entry like `db = ...` isn't valid bash syntax, so
this killed config load entirely under `set -e` — even `strut
--version` would die on a project with this pattern in `strut.conf`.

Fix: both parsers now share one key/value matcher (spaces optional on
both sides of `=`) and one header regex (trailing-whitespace
tolerant). Since the shared matcher can no longer distinguish "still
in section" from "left the section" by content shape, the preprocessor
now uses a **blank line** as the section-end signal — the one boundary
every existing `strut.conf` convention in this codebase already uses
consistently (before a header, or before global content resumes; never
as filler between two entries of the same section).

### #403 — scaffold: `--help`, invalid names, no-project guard

`strut scaffold` had no name validation and no `--help` interception:
- `strut scaffold --help` created a stack literally named `--help`
- `strut scaffold --recipe python-api` (no name) named the stack `--recipe`
- Scaffolding outside a project (no `PROJECT_ROOT`) silently wrote into
  `~/.strut/stacks/` via `CLI_ROOT`'s engine-install fallback — the
  stack "disappears" the moment a real project is later initialized

Fix: `--help`/`-h` print usage; names are validated against
`^[A-Za-z0-9][A-Za-z0-9._-]*$`; a missing `PROJECT_ROOT` now fails
clearly with the same "not inside a strut project" message stack
commands already use, instead of writing into the engine dir.

### Note on scope

This branch originally also carried fixes for #376, #378, #401, and
#406. A concurrent agent session merged equivalent (in some cases more
thorough) fixes for all four first — #457, #458, #461, #462 — before
this branch was pushed. That work was discarded here in favor of the
already-merged versions to avoid duplicating/conflicting with them.

## Test plan

- [x] `bash -n` + `shellcheck -x` clean on all changed files
- [x] `bats tests/test_config_include.bats tests/test_topology.bats` —
      full pass, including new regression tests for both the
      space-less-entry-inside-a-section case and the
      trailing-whitespace header case (confirmed both fail pre-fix)
- [x] `bats tests/test_scaffold.bats tests/test_anonymize.bats
      tests/test_cli_dispatch.bats` — full pass, including new tests
      for `--help`/`-h` interception, invalid-name rejection, and the
      no-`PROJECT_ROOT` guard (confirmed all fail pre-fix)
- [x] Full `bats tests/` suite — only the 6 pre-existing macOS-only
      environment failures (cron-PATH, `touch -d`, `script -c`
      portability — confirmed present on clean `main` too, unrelated
      to this change)