### PR TITLE
test(remote-init): regression test for --dry-run vs global DRY_RUN gating

### DIFF
--- a/tests/test_remote_init.bats
+++ b/tests/test_remote_init.bats
@@ -144,6 +144,39 @@ teardown() { common_teardown; }
   [[ "$output" == *"other/repo"* ]]
 }
 
+@test "cmd_remote_init: --dry-run prevents real ssh execution even when global DRY_RUN is unset" {
+  # Regression test: this file's setup() stubs run_cmd() to a plain echo, so
+  # every other dry-run test above never actually exercises run_cmd's own
+  # DRY_RUN gate (lib/utils.sh:161). Reinstate the real run_cmd here so this
+  # test proves --dry-run alone (with the global DRY_RUN unset/false, i.e.
+  # the top-level `strut remote:init --host ... --dry-run` path) is enough
+  # to stop the real ssh calls, per cmd_remote_init's own DRY_RUN sync at
+  # lib/cmd_remote_init.sh:68-77.
+  unset DRY_RUN
+  export CMD_STACK="my-stack"
+  export CMD_ENV_FILE=""
+
+  run_cmd() {
+    local desc="$1"; shift
+    if [ "$DRY_RUN" = "true" ]; then
+      echo "[DRY-RUN] $desc: $*"
+      return 0
+    else
+      "$@"
+    fi
+  }
+  export -f run_cmd
+
+  local marker="$TEST_TMP/ssh_was_called"
+  ssh() { touch "$marker"; echo "SHOULD NOT RUN FOR REAL: $*"; }
+  export -f ssh
+
+  run cmd_remote_init --host "10.0.0.1" --user "deploy" --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY-RUN"* ]]
+  [ ! -f "$marker" ]
+}
+
 # ── Error cases ───────────────────────────────────────────────────────────────
 
 @test "cmd_remote_init: fails without host" {


### PR DESCRIPTION
## Summary
- The fix in #458 syncs `cmd_remote_init`'s local `dry_run` flag into the global `DRY_RUN` env var so `run_cmd` (lib/utils.sh:161) correctly gates on `--dry-run` even when invoked via the top-level `strut remote:init --host ... --dry-run` path, which bypasses the stack-scoped entrypoint's own `DRY_RUN` export.
- However, none of the existing dry-run tests in `tests/test_remote_init.bats` actually exercised that gating logic — the file's `setup()` stubs `run_cmd()` with a plain `echo`, so those tests pass regardless of whether the real `DRY_RUN` sync exists.
- This PR adds a regression test that restores the real `run_cmd` implementation and stubs `ssh` to leave a marker file if actually invoked, then asserts the marker is never created when `--dry-run` is passed with the global `DRY_RUN` unset/false.

## Test plan
- [x] `bats tests/test_remote_init.bats` — all 20 tests pass with the fix in place
- [x] Verified the new test fails (ssh marker created, non-zero status) when the `DRY_RUN` sync in `lib/cmd_remote_init.sh` is temporarily removed, confirming it catches the regression
- [x] `bats tests/test_remote_init.bats tests/test_cli_remote_init_dispatch.bats` — full 26-test suite passes