### PR TITLE
fix(mcp): wrap responses with Content-Length framing (stdio transport spec)

### DIFF
--- a/lib/mcp/protocol.sh
+++ b/lib/mcp/protocol.sh
@@ -89,13 +89,24 @@ mcp_serve() {
   done
 }
 
+# _mcp_write — write a Content-Length framed message to stdout.
+# MCP stdio transport spec requires both directions use Content-Length framing.
+# The body is a single JSON line; we prepend the Content-Length header block.
+_mcp_write() {
+  local body="$1"
+  local len=${#body}
+  printf 'Content-Length: %d\r\n\r\n%s' "$len" "$body"
+}
+
 # _mcp_respond <id> <result_json>
 _mcp_respond() {
   local id="$1"
   local result="$2"
-  printf '{"jsonrpc":"2.0","id":%s,"result":%s}\n' \
+  local body
+  body=$(printf '{"jsonrpc":"2.0","id":%s,"result":%s}' \
     "$(jq -n --arg id "$id" 'if ($id | test("^[0-9]+$")) then ($id | tonumber) else $id end')" \
-    "$result"
+    "$result")
+  _mcp_write "$body"
 }
 
 # _mcp_error <id> <code> <message>
@@ -103,10 +114,12 @@ _mcp_error() {
   local id="$1"
   local code="$2"
   local message="$3"
-  printf '{"jsonrpc":"2.0","id":%s,"error":{"code":%d,"message":%s}}\n' \
+  local body
+  body=$(printf '{"jsonrpc":"2.0","id":%s,"error":{"code":%d,"message":%s}}' \
     "$(jq -n --arg id "$id" 'if ($id | test("^[0-9]+$")) then ($id | tonumber) else $id end')" \
     "$code" \
-    "$(jq -n --arg m "$message" '$m')"
+    "$(jq -n --arg m "$message" '$m')")
+  _mcp_write "$body"
 }
 
 # _mcp_initialize — return server capabilities

--- a/tests/test_mcp_protocol.bats
+++ b/tests/test_mcp_protocol.bats
@@ -143,3 +143,33 @@ _serve() {
   [ "$status" -eq 0 ]
   [[ "$output" == *'"id":1'* ]]
 }
+
+@test "responses use Content-Length framing (MCP stdio transport spec)" {
+  local msg='{"jsonrpc":"2.0","id":1,"method":"ping"}'
+  local infile="$TEST_TMP/in"
+  printf '%s\n' "$msg" > "$infile"
+
+  local outfile="$TEST_TMP/out"
+  _serve "$infile" > "$outfile"
+  # Output must start with Content-Length header
+  local first_line
+  first_line=$(head -c 50 "$outfile")
+  [[ "$first_line" == Content-Length:* ]]
+}
+
+@test "Content-Length value matches actual body byte count" {
+  local msg='{"jsonrpc":"2.0","id":1,"method":"ping"}'
+  local infile="$TEST_TMP/in"
+  printf '%s\n' "$msg" > "$infile"
+
+  local outfile="$TEST_TMP/out"
+  _serve "$infile" > "$outfile"
+  # Parse the Content-Length value and compare to actual body bytes
+  local declared_len body
+  declared_len=$(sed -n '1s/Content-Length: //p' "$outfile" | tr -d '\r')
+  # Body starts after \r\n\r\n (the blank line separator)
+  body=$(sed '1,/^\r$/d' "$outfile")
+  local actual_len
+  actual_len=$(printf '%s' "$body" | wc -c | tr -d ' ')
+  [ "$declared_len" -eq "$actual_len" ]
+}


### PR DESCRIPTION
## Summary

Fixes #468 — Backport Content-Length framed stdio output to complete the MCP stdio transport fix.

## Problem

The MCP stdio transport spec requires **both directions** to use Content-Length framing. After #442, `_mcp_read_message` correctly handles Content-Length framed **input** from clients like Kiro and VS Code Copilot. However, responses were still written as bare newline-delimited JSON (`{"jsonrpc":"2.0",...}\n`).

Clients that strictly follow the spec (Kiro, VS Code Copilot, Cursor) could not parse the unframed responses — they'd wait for a `Content-Length` header that never came, resulting in the "no tools" symptom even after a successful `initialize` handshake.

## Changes

- Add `_mcp_write()` — wraps any response body with `Content-Length: N\r\n\r\n` before writing to stdout
- Update `_mcp_respond()` and `_mcp_error()` to use `_mcp_write()` instead of raw `printf`
- Add 2 new tests asserting output framing and byte-count accuracy

## Output format

Before:
```
{"jsonrpc":"2.0","id":1,"result":{}}\n
```

After:
```
Content-Length: 36\r\n
\r\n
{"jsonrpc":"2.0","id":1,"result":{}}
```

## Testing

- All 10 MCP protocol tests pass (8 existing + 2 new)
- Verified manually: full handshake (initialize → notifications/initialized → tools/list) returns properly framed responses
- Raw newline-delimited JSON input still works (backward compatible with Claude Code)

## Acceptance criteria from #468

- [x] `strut mcp serve` works in Kiro (Content-Length framed responses)
- [x] `strut mcp serve` works with raw JSON clients (Claude Code regression test passes)
- [x] Backportable to 0.41.x (no dependencies on 0.42.0 features)
