### PR TITLE
feat(deploy): health-gate the standard deploy path (#407 item 1)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,8 @@ Requirements: a working Docker daemon (`docker info` must succeed) and the
 `docker pull nginx:alpine`). Individual tests skip cleanly if Docker isn't
 available, so this is safe to run on any dev machine.
 
-A single run takes ~60–90s (deploy pauses 60s waiting for services). In CI
+A single run takes ~30–90s (deploy polls container health until ready
+rather than pausing a fixed 60s). In CI
 they run in their own job — `.github/workflows/integration.yml` — so a
 broken Docker runner doesn't mask failures in the fast unit-test matrix.
 

--- a/lib/deploy.sh
+++ b/lib/deploy.sh
@@ -512,9 +512,24 @@ deploy_stack() {
     return 1
   fi
 
-  echo -n "  Waiting for services to start"
-  for i in $(seq 1 12); do sleep 5; echo -n "."; done
-  echo ""
+  # Health-gate the deploy instead of a fixed 60s sleep (strut#407): poll
+  # this project's own containers (running + Docker health + RestartCount,
+  # via _bg_wait_healthy) until healthy, and fail the deploy on timeout or
+  # crash-loop instead of falling through to the success banner. Stacks
+  # without healthchecks pass as soon as their containers hold "running"
+  # across consecutive polls, so most deploys get FASTER, not slower.
+  declare -F _bg_wait_healthy >/dev/null || source "$LIB/deploy_blue_green.sh"
+  local _deploy_health_timeout="${DEPLOY_HEALTH_TIMEOUT:-60}"
+  local _deploy_health_rc=0
+  _bg_wait_healthy "$stack_dir" "$compose_cmd" "$compose_file" \
+    "$_deploy_health_timeout" "stack" || _deploy_health_rc=$?
+  if [ "$_deploy_health_rc" -ne 0 ]; then
+    error "services did not become healthy within ${_deploy_health_timeout}s — NOT printing the success banner (raise with DEPLOY_HEALTH_TIMEOUT=<seconds>)"
+    # Fire on_health_fail hook (warn-only — never mask the gate's failure)
+    HEALTH_STATUS="$_deploy_health_rc" fire_hook_or_warn on_health_fail "$stack_dir"
+    notify_event deploy.failed stack="$stack" env="$env_name" reason="health_gate_failed"
+    return 1
+  fi
 
   # Reload reverse proxy to pick up any new container IPs
   local proxy="${REVERSE_PROXY:-nginx}"

--- a/lib/deploy_blue_green.sh
+++ b/lib/deploy_blue_green.sh
@@ -212,16 +212,19 @@ _bg_any_container_restarted() {
   return 1
 }
 
-# _bg_wait_healthy <stack_dir> <compose_cmd> <compose_file> [timeout_seconds]
+# _bg_wait_healthy <stack_dir> <compose_cmd> <compose_file> [timeout_seconds] [label]
 #
-# Polls health_run_all (scoped to the green compose project) until it
+# Polls health_check_green (scoped to the target compose project) until it
 # reports healthy or the timeout elapses. Returns 0 healthy, 1 on timeout.
+# `label` names what we're waiting on in log output (default "green") — the
+# standard deploy path reuses this loop with label "stack" (strut#407).
 #
 # We snapshot HEALTH_* globals across the probe so the suite's own state
 # doesn't leak into the caller.
 _bg_wait_healthy() {
   local stack_dir="$1" compose_cmd="$2" compose_file="$3"
   local timeout="${4:-${BLUE_GREEN_HEALTH_TIMEOUT:-30}}"
+  local label="${5:-green}"
   # Overridable only for tests — production callers always get the real 3s
   # poll cadence.
   local interval="${BLUE_GREEN_HEALTH_POLL_INTERVAL:-3}"
@@ -239,7 +242,7 @@ _bg_wait_healthy() {
   local required_consecutive=3
   local consecutive_ok=0
 
-  log "Waiting for green health (timeout: ${timeout}s)"
+  log "Waiting for $label health (timeout: ${timeout}s)"
   while [ "$elapsed" -lt "$timeout" ]; do
     # Use the project-scoped green readiness gate, NOT health_run_all: the
     # latter probes host ports (answered by the still-live blue color, so a
@@ -253,12 +256,12 @@ _bg_wait_healthy() {
       # window a single State snapshot does — it's still nonzero long after
       # the container cycles back to "running".
       if _bg_any_container_restarted "$compose_cmd"; then
-        warn "green container(s) restarted during health checks — not trusting this as healthy"
+        warn "$label container(s) restarted during health checks — not trusting this as healthy"
         consecutive_ok=0
       else
         consecutive_ok=$((consecutive_ok + 1))
         if [ "$consecutive_ok" -ge "$required_consecutive" ]; then
-          ok "green healthy"
+          ok "$label healthy"
           return 0
         fi
       fi

--- a/tests/test_deploy_health_gate.bats
+++ b/tests/test_deploy_health_gate.bats
@@ -1,0 +1,162 @@
+#!/usr/bin/env bats
+# ==================================================
+# tests/test_deploy_health_gate.bats — strut#407 (item 1)
+# ==================================================
+# The standard deploy path used to burn a fixed 60s dot-sleep after
+# `compose up -d` and then print the success banner unconditionally — a
+# crash-looping stack still "deployed successfully". deploy_stack now
+# health-gates via _bg_wait_healthy (the blue-green poll loop, label
+# "stack"): on timeout/crash-loop it fires on_health_fail + deploy.failed
+# and returns non-zero instead of reaching the banner.
+#
+# The wiring is tested here with _bg_wait_healthy stubbed (recording its
+# args); the real poll loop's semantics are covered by the blue-green unit
+# + integration suites. The last two tests exercise the REAL loop just for
+# the new label parameter (default "green" preserved; "stack" honored).
+
+setup() {
+  source "$(dirname "$BATS_TEST_FILENAME")/test_helper/common.bash"
+  load_docker
+
+  source "$CLI_ROOT/lib/config.sh"
+  source "$CLI_ROOT/lib/deploy.sh"
+
+  registry_login() { echo "REGISTRY_LOGIN_CALLED"; }
+  docker_pull_stack() { echo "DOCKER_PULL_CALLED: $*"; }
+  docker_require_images() { return 0; }
+  rollback_save_snapshot() { :; }
+  export_volume_paths() { :; }
+  fire_hook() { return 0; }
+  fire_hook_or_warn() { echo "hook_or_warn $* HEALTH_STATUS=${HEALTH_STATUS:-}" >> "$TEST_TMP/hook_calls"; }
+  fire_first_run_hook() { :; }
+  maybe_apply_db_schema() { :; }
+  # Health gate stub — records args, exits per GATE_EXIT so tests can
+  # drive both outcomes. Predefining it means deploy_stack's lazy
+  # `declare -F || source` keeps the stub instead of the real loop.
+  _bg_wait_healthy() { echo "wait_healthy|$*" >> "$TEST_TMP/gate_calls"; return "${GATE_EXIT:-0}"; }
+  notify_event() { echo "notify_event $*" >> "$TEST_TMP/notify_calls"; }
+  print_banner() { :; }
+  require_cmd() { :; }
+  is_running_on_vps() { return 0; }
+  cmd_validate() { return 0; }
+  diff_warn_env_divergence() { return 0; }
+  export -f registry_login docker_pull_stack docker_require_images \
+            rollback_save_snapshot export_volume_paths fire_hook \
+            fire_hook_or_warn fire_first_run_hook maybe_apply_db_schema \
+            _bg_wait_healthy notify_event print_banner require_cmd \
+            is_running_on_vps cmd_validate diff_warn_env_divergence
+
+  # Fake `docker` — every compose call succeeds; the gate stub is the only
+  # thing that decides this suite's failures.
+  docker() { return 0; }
+  export -f docker
+
+  mkdir -p "$TEST_TMP/stacks/hub"
+  cat > "$TEST_TMP/stacks/hub/docker-compose.yml" <<'EOF'
+services:
+  app:
+    image: hub-app
+EOF
+  cat > "$TEST_TMP/stacks/hub/services.conf" <<'EOF'
+BUILD_MODE=none
+EOF
+  cat > "$TEST_TMP/.prod.env" <<'EOF'
+VPS_HOST=10.0.0.1
+EOF
+
+  export LIB="$CLI_ROOT/lib"
+  export CLI_ROOT="$TEST_TMP"
+  export DRY_RUN="false"
+  export PRE_DEPLOY_VALIDATE="false"
+  export SKIP_VALIDATION="false"
+  : > "$TEST_TMP/notify_calls"
+  : > "$TEST_TMP/gate_calls"
+  : > "$TEST_TMP/hook_calls"
+}
+
+teardown() { common_teardown; }
+
+@test "deploy_stack: healthy gate reaches the success banner and fires deploy.success" {
+  export GATE_EXIT=0
+  run deploy_stack "hub" "$TEST_TMP/.prod.env" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Deploy complete"* ]]
+  run cat "$TEST_TMP/notify_calls"
+  [[ "$output" == *"deploy.success"* ]]
+}
+
+@test "deploy_stack: gate is called with the stack label and 60s default timeout" {
+  export GATE_EXIT=0
+  run deploy_stack "hub" "$TEST_TMP/.prod.env" ""
+  [ "$status" -eq 0 ]
+  run cat "$TEST_TMP/gate_calls"
+  [[ "$output" == *"|$TEST_TMP/stacks/hub "* ]]
+  [[ "$output" == *" 60 stack"* ]]
+}
+
+@test "deploy_stack: DEPLOY_HEALTH_TIMEOUT overrides the gate timeout" {
+  export GATE_EXIT=0
+  export DEPLOY_HEALTH_TIMEOUT=90
+  run deploy_stack "hub" "$TEST_TMP/.prod.env" ""
+  [ "$status" -eq 0 ]
+  run cat "$TEST_TMP/gate_calls"
+  [[ "$output" == *" 90 stack"* ]]
+}
+
+@test "deploy_stack: gate failure returns non-zero instead of reaching the success banner" {
+  export GATE_EXIT=1
+  run deploy_stack "hub" "$TEST_TMP/.prod.env" ""
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"Deploy complete"* ]]
+  [[ "$output" == *"did not become healthy"* ]]
+}
+
+@test "deploy_stack: gate failure fires deploy.failed (reason=health_gate_failed), not deploy.success" {
+  export GATE_EXIT=1
+  run deploy_stack "hub" "$TEST_TMP/.prod.env" ""
+  [ "$status" -ne 0 ]
+  run cat "$TEST_TMP/notify_calls"
+  [[ "$output" == *"deploy.failed"* ]]
+  [[ "$output" == *"reason=health_gate_failed"* ]]
+  [[ "$output" != *"deploy.success"* ]]
+}
+
+@test "deploy_stack: gate failure fires the on_health_fail hook with HEALTH_STATUS exported" {
+  export GATE_EXIT=2
+  run deploy_stack "hub" "$TEST_TMP/.prod.env" ""
+  [ "$status" -ne 0 ]
+  run cat "$TEST_TMP/hook_calls"
+  [[ "$output" == *"on_health_fail"* ]]
+  [[ "$output" == *"HEALTH_STATUS=2"* ]]
+}
+
+# ── Real _bg_wait_healthy: label parameter ────────────────────────────────────
+
+# Sources the real loop with its probes stubbed healthy so it returns after
+# the consecutive-ok threshold. Zero interval keeps it instant (safe here
+# because the probe always passes — the loop can't spin on a 0s interval).
+_run_real_wait_healthy() {
+  unset -f _bg_wait_healthy
+  source "$LIB/deploy_blue_green.sh"
+  health_check_green() { return 0; }
+  _bg_any_container_restarted() { return 1; }
+  ok()   { echo "OK: $*"; }
+  log()  { echo "LOG: $*"; }
+  warn() { echo "WARN: $*" >&2; }
+  BLUE_GREEN_HEALTH_POLL_INTERVAL=0 _bg_wait_healthy "$TEST_TMP/stacks/hub" "docker compose" "compose.yml" 5 "$@"
+}
+
+@test "_bg_wait_healthy: default label stays 'green' for blue-green callers" {
+  run _run_real_wait_healthy
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Waiting for green health"* ]]
+  [[ "$output" == *"green healthy"* ]]
+}
+
+@test "_bg_wait_healthy: 'stack' label is used in log output when passed" {
+  run _run_real_wait_healthy "stack"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Waiting for stack health"* ]]
+  [[ "$output" == *"stack healthy"* ]]
+  [[ "$output" != *"green"* ]]
+}

--- a/tests/test_deploy_up_failure.bats
+++ b/tests/test_deploy_up_failure.bats
@@ -28,6 +28,9 @@ setup() {
   fire_hook_or_warn() { :; }
   fire_first_run_hook() { :; }
   maybe_apply_db_schema() { :; }
+  # Pass the post-up health gate — this suite exercises the `up -d` failure
+  # path; the gate itself is covered in test_deploy_health_gate.bats.
+  _bg_wait_healthy() { return 0; }
   notify_event() { echo "notify_event $*" >> "$TEST_TMP/notify_calls"; }
   print_banner() { :; }
   require_cmd() { :; }
@@ -42,6 +45,7 @@ setup() {
   export -f registry_login docker_pull_stack docker_require_images \
             rollback_save_snapshot export_volume_paths fire_hook \
             fire_hook_or_warn fire_first_run_hook maybe_apply_db_schema \
+            _bg_wait_healthy \
             notify_event print_banner require_cmd is_running_on_vps \
             cmd_validate diff_warn_env_divergence lock_acquire_local \
             lock_release_local lock_is_stale_local lock_force_break_local

--- a/tests/test_timers.bats
+++ b/tests/test_timers.bats
@@ -649,8 +649,8 @@ setup_cmd_timers() {
 # Confirms the post-deploy call site (lib/deploy.sh, after the post_deploy
 # hook) actually fires timers_install with (stack, stack_dir) on a
 # successful deploy. Mirrors the full-success harness in
-# tests/test_deploy_up_failure.bats (same stub set) plus a sleep no-op —
-# deploy_stack's post-`up -d` wait is a real 60s sleep loop otherwise.
+# tests/test_deploy_up_failure.bats (same stub set) plus a passing
+# _bg_wait_healthy — deploy_stack health-gates after `up -d` otherwise.
 
 @test "deploy_stack: fires timers_install with (stack, stack_dir) on a successful deploy" {
   source "$LIB/config.sh"
@@ -669,11 +669,12 @@ setup_cmd_timers() {
   print_banner() { :; }
   require_cmd() { :; }
   is_running_on_vps() { return 1; }
-  sleep() { :; }
+  _bg_wait_healthy() { return 0; }
   export -f registry_login docker_pull_stack docker_require_images \
             rollback_save_snapshot export_volume_paths fire_hook \
             fire_hook_or_warn fire_first_run_hook maybe_apply_db_schema \
-            notify_event print_banner require_cmd is_running_on_vps sleep
+            notify_event print_banner require_cmd is_running_on_vps \
+            _bg_wait_healthy
 
   docker() { return 0; }
   export -f docker


### PR DESCRIPTION
Picks up item 1 of #407: the standard deploy path still burns a fixed 60s dot-sleep after `compose up -d` and then prints the success banner no matter what — a crash-looping stack still "deploys successfully".

This wires the existing blue-green poll loop into that path instead. `_bg_wait_healthy` gains an optional label argument (defaults to "green", so blue-green output is byte-for-byte unchanged), and `deploy_stack` calls it with label "stack" in place of the sleep. Healthy stacks pass as soon as their containers hold running/healthy across the consecutive-poll window, so most deploys get faster, not slower. On timeout or crash-loop the deploy now fails properly: `on_health_fail` hook (warn-only, mirroring `cmd_health`), `deploy.failed` notify with `reason=health_gate_failed`, exit 1 — the banner is never reached. Timeout keeps the old 60s ceiling as its default, overridable via `DEPLOY_HEALTH_TIMEOUT` for slow-starting stacks.

Testing: new `tests/test_deploy_health_gate.bats` (8 tests — gate wiring both directions, timeout override, hook/notify firing, and the label default staying "green"); the two suites that leaned on the old sleep are updated. The gate-failure tests fail on main and pass on this branch. Full unit suite shows no new failures vs main on my machine (same set of pre-existing environment-dependent ones), `shellcheck` is clean on the touched files, and the Docker integration suites (`test_e2e`, `test_rollback_e2e`, `test_blue_green_health_gate`) are 7/7 green with the gate in place — they also run noticeably faster now, so I bumped the timing note in CONTRIBUTING.

Happy to adjust the timeout default, the env var name, or the failure semantics (e.g. warn-only instead of hard fail) if you'd rather ease this in. Thanks!