### PR TITLE
fix(deploy): health-gate follow-ups — rename, skip flag, docs, timeout test

### DIFF
--- a/lib/cmd_deploy.sh
+++ b/lib/cmd_deploy.sh
@@ -144,6 +144,7 @@ _usage_deploy() {
   echo "  --services <profile> Service profile (messaging|ui|full)"
   echo "  --pull-only          Pull images without restarting containers"
   echo "  --skip-validation    Skip pre-deploy config validation and hooks"
+  echo "  --skip-health-gate   Skip post-up health polling (for one-shot/migration stacks)"
   echo "  --force-unlock       Break an existing deploy lock before acquiring"
   echo "  --no-lock            Skip lock acquisition (advanced; recovery only)"
   echo "  --blue-green         Stand up new version alongside current, health-gate,"
@@ -301,6 +302,7 @@ cmd_deploy() {
   # Parse deploy-specific flags
   local pull_only=false
   local skip_validation=false
+  local skip_health_gate=false
   local force_unlock=false
   local skip_lock=false
   local force_local=false
@@ -312,6 +314,7 @@ cmd_deploy() {
     case $1 in
       --pull-only) pull_only=true; shift ;;
       --skip-validation) skip_validation=true; shift ;;
+      --skip-health-gate) skip_health_gate=true; shift ;;
       --force-unlock) force_unlock=true; shift ;;
       --no-lock) skip_lock=true; shift ;;
       --force-local) force_local=true; shift ;;
@@ -325,6 +328,7 @@ cmd_deploy() {
 
   # Export for deploy_stack to read
   export SKIP_VALIDATION="$skip_validation"
+  export DEPLOY_SKIP_HEALTH_GATE="$skip_health_gate"
 
   # ── Concurrency lock ─────────────────────────────────────────────────────
   # Prevents two deploys racing against the same stack/env. Honor --no-lock

--- a/lib/deploy.sh
+++ b/lib/deploy.sh
@@ -518,17 +518,23 @@ deploy_stack() {
   # crash-loop instead of falling through to the success banner. Stacks
   # without healthchecks pass as soon as their containers hold "running"
   # across consecutive polls, so most deploys get FASTER, not slower.
-  declare -F _bg_wait_healthy >/dev/null || source "$LIB/deploy_blue_green.sh"
-  local _deploy_health_timeout="${DEPLOY_HEALTH_TIMEOUT:-60}"
-  local _deploy_health_rc=0
-  _bg_wait_healthy "$stack_dir" "$compose_cmd" "$compose_file" \
-    "$_deploy_health_timeout" "stack" || _deploy_health_rc=$?
-  if [ "$_deploy_health_rc" -ne 0 ]; then
-    error "services did not become healthy within ${_deploy_health_timeout}s — NOT printing the success banner (raise with DEPLOY_HEALTH_TIMEOUT=<seconds>)"
-    # Fire on_health_fail hook (warn-only — never mask the gate's failure)
-    HEALTH_STATUS="$_deploy_health_rc" fire_hook_or_warn on_health_fail "$stack_dir"
-    notify_event deploy.failed stack="$stack" env="$env_name" reason="health_gate_failed"
-    return 1
+  # Skip with --skip-health-gate or DEPLOY_SKIP_HEALTH_GATE=1 (for one-shot
+  # containers / migration stacks that exit immediately after up).
+  if [ "${DEPLOY_SKIP_HEALTH_GATE:-false}" = "true" ] || [ "${DEPLOY_SKIP_HEALTH_GATE:-0}" = "1" ]; then
+    log "Health gate skipped (DEPLOY_SKIP_HEALTH_GATE)"
+  else
+    declare -F _bg_wait_healthy >/dev/null || source "$LIB/deploy_blue_green.sh"
+    local _deploy_health_timeout="${DEPLOY_HEALTH_TIMEOUT:-60}"
+    local _deploy_health_rc=0
+    _bg_wait_healthy "$stack_dir" "$compose_cmd" "$compose_file" \
+      "$_deploy_health_timeout" "stack" || _deploy_health_rc=$?
+    if [ "$_deploy_health_rc" -ne 0 ]; then
+      error "services did not become healthy within ${_deploy_health_timeout}s — NOT printing the success banner (raise with DEPLOY_HEALTH_TIMEOUT=<seconds>)"
+      # Fire on_health_fail hook (warn-only — never mask the gate's failure)
+      HEALTH_STATUS="$_deploy_health_rc" fire_hook_or_warn on_health_fail "$stack_dir"
+      notify_event deploy.failed stack="$stack" env="$env_name" reason="health_gate_failed"
+      return 1
+    fi
   fi
 
   # Reload reverse proxy to pick up any new container IPs

--- a/lib/deploy_blue_green.sh
+++ b/lib/deploy_blue_green.sh
@@ -214,7 +214,7 @@ _bg_any_container_restarted() {
 
 # _bg_wait_healthy <stack_dir> <compose_cmd> <compose_file> [timeout_seconds] [label]
 #
-# Polls health_check_green (scoped to the target compose project) until it
+# Polls health_check_project (scoped to the target compose project) until it
 # reports healthy or the timeout elapses. Returns 0 healthy, 1 on timeout.
 # `label` names what we're waiting on in log output (default "green") — the
 # standard deploy path reuses this loop with label "stack" (strut#407).
@@ -223,6 +223,9 @@ _bg_any_container_restarted() {
 # doesn't leak into the caller.
 _bg_wait_healthy() {
   local stack_dir="$1" compose_cmd="$2" compose_file="$3"
+  # Standard deploy (deploy.sh) always passes arg 4 explicitly (DEPLOY_HEALTH_TIMEOUT,
+  # default 60s). The BLUE_GREEN_HEALTH_TIMEOUT fallback only applies when called from
+  # the blue-green path without an explicit timeout argument.
   local timeout="${4:-${BLUE_GREEN_HEALTH_TIMEOUT:-30}}"
   local label="${5:-green}"
   # Overridable only for tests — production callers always get the real 3s
@@ -248,7 +251,7 @@ _bg_wait_healthy() {
     # latter probes host ports (answered by the still-live blue color, so a
     # dead green would pass) and host-global resources (a load spike during
     # pull would fail a healthy deploy). Subshell keeps its counters local.
-    if ( health_check_green "$(basename "$stack_dir")" "$compose_cmd" "$compose_file" >/dev/null 2>&1 ); then
+    if ( health_check_project "$(basename "$stack_dir")" "$compose_cmd" "$compose_file" >/dev/null 2>&1 ); then
       # Check RestartCount on every passing poll, not just once we've hit
       # the consecutive threshold: a restart spotted on poll 2 should reset
       # progress immediately instead of waiting to be re-derived at the end.

--- a/lib/health.sh
+++ b/lib/health.sh
@@ -21,7 +21,7 @@ _health_record() {
   local status="$1" name="$2" message="$3" details="${4:-}"
 
   # Counters/overall status must update regardless of output mode — callers
-  # like health_check_green() poll in JSON mode (to suppress human output)
+  # like health_check_project() poll in JSON mode (to suppress human output)
   # and rely on HEALTH_PASSED/HEALTH_FAILED/HEALTH_WARNED to judge readiness.
   case "$status" in
     pass) HEALTH_PASSED=$((HEALTH_PASSED + 1)) ;;
@@ -129,17 +129,18 @@ health_check_containers() {
   $HEALTH_JSON_OUTPUT || echo ""
 }
 
-# health_check_green <stack> <compose_cmd> <compose_file>
+# health_check_project <stack> <compose_cmd> <compose_file>
 #
-# Project-scoped readiness gate for a blue-green color. Judges ONLY the target
-# project's own containers (running + Docker health) — never host ports (which
-# the other, still-live color answers) and never host-global resources (load
-# spikes during image pull are not a reason to fail a deploy). Intended to be
-# polled until healthy or timeout.
+# Project-scoped readiness gate. Judges ONLY the target project's own
+# containers (running + Docker health) — never host ports (which the other,
+# still-live color answers in blue-green) and never host-global resources
+# (load spikes during image pull are not a reason to fail a deploy). Intended
+# to be polled until healthy or timeout. Used by both the blue-green and
+# standard deploy paths.
 #
 # Returns: 0 when every container is running and healthy (or has no healthcheck),
 #          1 otherwise (a container is down, unhealthy, or still starting).
-health_check_green() {
+health_check_project() {
   local compose_cmd="$2" compose_file="$3"
   local prev_json="$HEALTH_JSON_OUTPUT"
   HEALTH_JSON_OUTPUT=true  # suppress human output while polling
@@ -150,6 +151,9 @@ health_check_green() {
   # merely "running but not yet healthy" (warn) — the latter keeps us polling.
   [ "$HEALTH_PASSED" -gt 0 ] && [ "$HEALTH_FAILED" -eq 0 ] && [ "$HEALTH_WARNED" -eq 0 ]
 }
+
+# Backward-compat alias — external hooks/scripts may reference the old name.
+health_check_green() { health_check_project "$@"; }
 
 # health_check_application <stack_dir>
 #

--- a/tests/test_deploy_blue_green.bats
+++ b/tests/test_deploy_blue_green.bats
@@ -721,8 +721,8 @@ EOF
 # ── Wait-healthy: restart resets progress instead of accepting early ────────
 
 @test "_bg_wait_healthy: a restart spotted mid-poll resets progress rather than being missed" {
-  health_check_green() { return 0; }
-  export -f health_check_green
+  health_check_project() { return 0; }
+  export -f health_check_project
 
   local poll_count_file="$TEST_TMP/restart_poll_count"
   echo 0 > "$poll_count_file"
@@ -745,8 +745,8 @@ EOF
 }
 
 @test "_bg_wait_healthy: never accepts a container that keeps restarting" {
-  health_check_green() { return 0; }
-  export -f health_check_green
+  health_check_project() { return 0; }
+  export -f health_check_project
   _bg_any_container_restarted() { return 0; }
   export -f _bg_any_container_restarted
 

--- a/tests/test_deploy_health_gate.bats
+++ b/tests/test_deploy_health_gate.bats
@@ -130,6 +130,26 @@ teardown() { common_teardown; }
   [[ "$output" == *"HEALTH_STATUS=2"* ]]
 }
 
+@test "deploy_stack: DEPLOY_SKIP_HEALTH_GATE=true skips the gate entirely" {
+  export GATE_EXIT=1
+  export DEPLOY_SKIP_HEALTH_GATE=true
+  run deploy_stack "hub" "$TEST_TMP/.prod.env" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Deploy complete"* ]]
+  [[ "$output" == *"Health gate skipped"* ]]
+  # Gate stub was never called
+  run cat "$TEST_TMP/gate_calls"
+  [ -z "$output" ]
+}
+
+@test "deploy_stack: DEPLOY_SKIP_HEALTH_GATE=1 also skips the gate" {
+  export GATE_EXIT=1
+  export DEPLOY_SKIP_HEALTH_GATE=1
+  run deploy_stack "hub" "$TEST_TMP/.prod.env" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Deploy complete"* ]]
+}
+
 # ── Real _bg_wait_healthy: label parameter ────────────────────────────────────
 
 # Sources the real loop with its probes stubbed healthy so it returns after
@@ -138,7 +158,7 @@ teardown() { common_teardown; }
 _run_real_wait_healthy() {
   unset -f _bg_wait_healthy
   source "$LIB/deploy_blue_green.sh"
-  health_check_green() { return 0; }
+  health_check_project() { return 0; }
   _bg_any_container_restarted() { return 1; }
   ok()   { echo "OK: $*"; }
   log()  { echo "LOG: $*"; }
@@ -159,4 +179,20 @@ _run_real_wait_healthy() {
   [[ "$output" == *"Waiting for stack health"* ]]
   [[ "$output" == *"stack healthy"* ]]
   [[ "$output" != *"green"* ]]
+}
+
+@test "_bg_wait_healthy: returns non-zero on timeout when health never passes" {
+  run bash -c '
+    source "'"$LIB"'/deploy_blue_green.sh"
+    source "'"$CLI_ROOT"'/lib/health.sh"
+    health_check_project() { return 1; }
+    _bg_any_container_restarted() { return 1; }
+    ok()   { echo "OK: $*"; }
+    log()  { echo "LOG: $*"; }
+    warn() { echo "WARN: $*" >&2; }
+    export STRUT_HOME="'"$CLI_ROOT"'"
+    BLUE_GREEN_HEALTH_POLL_INTERVAL=1 _bg_wait_healthy "'"$TEST_TMP/stacks/hub"'" "docker compose" "compose.yml" 2
+  '
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"healthy"* ]]
 }


### PR DESCRIPTION
## Summary

Batches all 4 follow-up nits from the #471 review into one PR.

## Changes

### #472 — Rename `health_check_green` → `health_check_project`

The function probes a compose project's containers regardless of deploy strategy. Renamed to reflect that. `health_check_green()` remains as a one-line backward-compat alias so existing hooks/scripts don't break.

### #473 — Add `--skip-health-gate` / `DEPLOY_SKIP_HEALTH_GATE`

Opt-out for stacks with intentionally short-lived containers (one-shot migrations, seed scripts) that exit after `up -d`. When set, the health poll is skipped entirely and the deploy falls through to the success banner.

- `--skip-health-gate` CLI flag on `deploy`
- `DEPLOY_SKIP_HEALTH_GATE=true` or `=1` env var

### #474 — Clarify timeout arg comment

Added a comment above `local timeout="${4:-${BLUE_GREEN_HEALTH_TIMEOUT:-30}}"` explaining that the standard deploy path always provides arg 4 explicitly, so `BLUE_GREEN_HEALTH_TIMEOUT` only affects the blue-green caller.

### #475 — Timeout-path test

New test that sources the real `_bg_wait_healthy` with `health_check_project` stubbed to always fail, confirming non-zero exit after the timeout elapses (~2s with 1s poll interval).

## Testing

- All 11 deploy health gate tests pass
- shellcheck clean on all modified files

Closes #472, closes #473, closes #474, closes #475
