### PR TITLE
fix(mcp): use newline-delimited JSON output per MCP stdio spec

### DIFF
--- a/lib/mcp/protocol.sh
+++ b/lib/mcp/protocol.sh
@@ -89,13 +89,13 @@ mcp_serve() {
   done
 }
 
-# _mcp_write — write a Content-Length framed message to stdout.
-# MCP stdio transport spec requires both directions use Content-Length framing.
-# The body is a single JSON line; we prepend the Content-Length header block.
+# _mcp_write — write a single JSON-RPC message to stdout.
+# MCP stdio transport spec: one message per line, newline-delimited, no
+# embedded newlines, no header layer. Each call emits one complete JSON
+# object followed by \n.
 _mcp_write() {
   local body="$1"
-  local len=${#body}
-  printf 'Content-Length: %d\r\n\r\n%s' "$len" "$body"
+  printf '%s\n' "$body"
 }
 
 # _mcp_respond <id> <result_json>

--- a/tests/test_mcp_protocol.bats
+++ b/tests/test_mcp_protocol.bats
@@ -144,32 +144,33 @@ _serve() {
   [[ "$output" == *'"id":1'* ]]
 }
 
-@test "responses use Content-Length framing (MCP stdio transport spec)" {
+@test "responses use newline-delimited JSON (MCP stdio transport spec)" {
   local msg='{"jsonrpc":"2.0","id":1,"method":"ping"}'
   local infile="$TEST_TMP/in"
   printf '%s\n' "$msg" > "$infile"
 
   local outfile="$TEST_TMP/out"
   _serve "$infile" > "$outfile"
-  # Output must start with Content-Length header
-  local first_line
-  first_line=$(head -c 50 "$outfile")
-  [[ "$first_line" == Content-Length:* ]]
+  # Output must be a single JSON line ending with newline
+  local line_count
+  line_count=$(wc -l < "$outfile" | tr -d ' ')
+  [ "$line_count" -eq 1 ]
+  # Must be valid JSON
+  jq empty < "$outfile"
+  [[ "$(cat "$outfile")" == *'"jsonrpc":"2.0"'* ]]
 }
 
-@test "Content-Length value matches actual body byte count" {
+@test "response is a complete JSON object on one line (no Content-Length headers)" {
   local msg='{"jsonrpc":"2.0","id":1,"method":"ping"}'
   local infile="$TEST_TMP/in"
   printf '%s\n' "$msg" > "$infile"
 
   local outfile="$TEST_TMP/out"
   _serve "$infile" > "$outfile"
-  # Parse the Content-Length value and compare to actual body bytes
-  local declared_len body
-  declared_len=$(sed -n '1s/Content-Length: //p' "$outfile" | tr -d '\r')
-  # Body starts after \r\n\r\n (the blank line separator)
-  body=$(sed '1,/^\r$/d' "$outfile")
-  local actual_len
-  actual_len=$(printf '%s' "$body" | wc -c | tr -d ' ')
-  [ "$declared_len" -eq "$actual_len" ]
+  # Must NOT contain Content-Length header
+  [[ "$(cat "$outfile")" != *"Content-Length"* ]]
+  # Must be parseable as JSON-RPC response
+  local result_id
+  result_id=$(jq -r '.id' < "$outfile")
+  [ "$result_id" = "1" ]
 }


### PR DESCRIPTION
## Summary

Fixes the 60-second MCP connection timeout in Kiro.

## Root Cause

The [MCP stdio transport spec](https://modelcontextprotocol.io/specification/draft/basic/transports/stdio) states:

> "Messages are delimited by newlines, and MUST NOT contain embedded newlines."
> "There is no header layer."

Our `_mcp_write` was wrapping responses in `Content-Length` headers (LSP-style framing). Kiro's MCP client follows the spec and reads stdout line-by-line looking for a complete JSON object terminated by `\n`. It never saw one — the `Content-Length: N\r\n\r\n{...}` output doesn't end with a newline after the JSON body, so the client's readline hung until the 60s timeout.

## Fix

`_mcp_write` now emits one JSON object per line (`printf '%s\n' "$body"`) — the canonical MCP stdio wire format.

Input-side Content-Length parsing is **retained** in `_mcp_read_message` since some older/alternate clients still send framed input. This makes strut's MCP server maximally compatible: it accepts both framing styles on input but always responds with spec-compliant newline-delimited JSON.

## Before / After

Before (broken):
```
Content-Length: 36\r\n\r\n{"jsonrpc":"2.0","id":1,"result":{}}
```

After (correct):
```
{"jsonrpc":"2.0","id":1,"result":{}}\n
```

## Testing

- All 10 MCP protocol tests pass (updated 2 output-format tests)
- Full handshake verified: initialize → notifications/initialized → tools/list returns 15 tools
- Input-side Content-Length framing still works (backward compat for Claude Code etc.)
