### PR TITLE
fix(mcp): protect stdin during entrypoint init — fixes Kiro 60s timeout

### DIFF
--- a/lib/cmd_mcp.sh
+++ b/lib/cmd_mcp.sh
@@ -54,6 +54,13 @@ cmd_mcp() {
 _mcp_cmd_serve() {
   command -v jq >/dev/null 2>&1 || fail "strut mcp serve requires 'jq' (apt install jq / brew install jq)"
 
+  # Restore the real client stdin (saved to fd 8 by the entrypoint's MCP
+  # stdin protection guard). Without this, mcp_serve would read /dev/null
+  # and exit immediately.
+  if [ "${_STRUT_MCP_STDIN_SAVED:-false}" = "true" ]; then
+    exec 0<&8 8<&-
+  fi
+
   local strut_home="${STRUT_HOME:-${CLI_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}}"
   source "$strut_home/lib/mcp/protocol.sh"
   mcp_serve

--- a/strut
+++ b/strut
@@ -81,6 +81,19 @@ LIB="$STRUT_HOME/lib"
 STRUT_LIB="$LIB"
 export STRUT_LIB
 
+# ── MCP stdin protection ──────────────────────────────────────────────────────
+# When invoked as `strut mcp serve`, the client (Kiro, VS Code, etc.) holds
+# stdin open as a pipe and writes JSON-RPC messages to it. The ~40 lib files
+# sourced below must not accidentally consume that data (any `read` without an
+# explicit fd, or a subshell inheriting stdin, could swallow the client's
+# initialize message). Save stdin to fd 8 and reopen /dev/null for the source
+# phase; _mcp_cmd_serve restores it before entering the serve loop.
+_STRUT_MCP_STDIN_SAVED=false
+if [ "${1:-}" = "mcp" ] && [ "${2:-}" = "serve" ]; then
+  exec 8<&0 0</dev/null
+  _STRUT_MCP_STDIN_SAVED=true
+fi
+
 # Source config first, then load project config
 source "$LIB/config.sh"
 find_project_root || true  # OK if not in a project (init, --version, etc.)


### PR DESCRIPTION
## Summary Fixes the 60-second MCP connection timeout in Kiro (and any other MCP client using stdio transport). ## Root Cause When Kiro spawns `strut mcp serve`, it holds stdin open as a pipe and writes JSON-RPC messages. The strut entrypoint sources ~40 lib files before dispatching to the `mcp` case block. Something in that init phase consumes the `initialize` message from stdin before `mcp_serve` ever reads it — the client waits 60s for a response that will never come. ## Fix When args are `mcp serve`, save stdin to fd 8 and redirect fd 0 from `/dev/null` before the source phase. `_mcp_cmd_serve` restores the real client stdin from fd 8 just before entering the serve loop. ```bash # In strut entrypoint (before source phase): if [ "${1:-}" = "mcp" ] && [ "${2:-}" = "serve" ]; then exec 8<&0 0</dev/null _STRUT_MCP_STDIN_SAVED=true fi # In _mcp_cmd_serve (before mcp_serve): if [ "${_STRUT_MCP_STDIN_SAVED:-false}" = "true" ]; then exec 0<&8 8<&- fi ``` ## Testing - All 10 MCP protocol tests pass - Full handshake (Content-Length framed input + newline-delimited output) verified - Pipe-based input works: `echo '...' | ./strut mcp serve` responds instantly - No impact on any other strut command (guard only triggers for `mcp serve`) 