### PR TITLE
feat: add VHS tapes for individual workflow steps

### DIFF
--- a/bin/tapes/shims/workflow-deploy.sh
+++ b/bin/tapes/shims/workflow-deploy.sh
@@ -1,0 +1,19 @@
+# Canned strut output for the workflow-deploy demo (no real execution).
+strut() {
+  case "$2" in
+    release)
+      sleep 0.4
+      printf '→ Syncing repository on VPS...\n'
+      sleep 0.6
+      printf '→ Pulling images: ghcr.io/acme/my-app:latest\n'
+      sleep 0.8
+      printf '→ Running migrations...\n'
+      sleep 0.6
+      printf '→ Deploying containers (3/3)...\n'
+      sleep 0.6
+      printf '\033[32m✓\033[0m Health check: 3/3 services healthy\n'
+      sleep 0.4
+      printf '\033[1;33m✓ my-app deployed successfully — 12s\033[0m\n' ;;
+    *) echo "unknown command: strut $*" ;;
+  esac
+}

--- a/bin/tapes/shims/workflow-init.sh
+++ b/bin/tapes/shims/workflow-init.sh
@@ -1,0 +1,15 @@
+# Canned strut output for the workflow-init demo (no real execution).
+strut() {
+  case "$1" in
+    init)
+      sleep 0.3
+      printf '\033[32m✓\033[0m Created strut.conf\n'
+      sleep 0.2
+      printf '\033[32m✓\033[0m Created stacks/ directory\n'
+      sleep 0.25
+      printf '\033[32m✓\033[0m Registry configured: ghcr.io/acme\n'
+      sleep 0.2
+      printf '\033[1;33m✓ Project initialized\033[0m\n' ;;
+    *) echo "unknown command: strut $*" ;;
+  esac
+}

--- a/bin/tapes/shims/workflow-scaffold.sh
+++ b/bin/tapes/shims/workflow-scaffold.sh
@@ -1,0 +1,17 @@
+# Canned strut output for the workflow-scaffold demo (no real execution).
+strut() {
+  case "$1" in
+    scaffold)
+      sleep 0.3
+      printf '\033[32m✓\033[0m stacks/my-app/docker-compose.yml\n'
+      sleep 0.2
+      printf '\033[32m✓\033[0m stacks/my-app/services.conf\n'
+      sleep 0.2
+      printf '\033[32m✓\033[0m stacks/my-app/.env.template\n'
+      sleep 0.2
+      printf '\033[32m✓\033[0m stacks/my-app/Dockerfile\n'
+      sleep 0.2
+      printf '\033[1;33m✓ Stack scaffolded — edit .env and deploy\033[0m\n' ;;
+    *) echo "unknown command: strut $*" ;;
+  esac
+}

--- a/bin/tapes/workflow-deploy.tape
+++ b/bin/tapes/workflow-deploy.tape
@@ -1,0 +1,26 @@
+# workflow-deploy.tape — Focused deploy step for the "Three commands" section
+# Used for: strut-www homepage workflow tab 03
+#
+# Story: Show `strut release` deploying containers with health checks.
+
+Set Shell "bash"
+Set FontSize 20
+Set Padding 24
+Set Theme "Catppuccin Mocha"
+Set CursorBlink false
+Set TypingSpeed 40ms
+Set WindowBar Colorful
+
+Output ../output/gif/workflow-deploy.gif
+
+# ── Hidden setup ──────────────────────────────────────────────────────────────
+Hide
+Type `export PS1="~/project $ "` Enter
+Type "source shims/workflow-deploy.sh" Enter
+Type "clear" Enter
+Show
+
+# ── Scene: Deploy ─────────────────────────────────────────────────────────────
+Sleep 800ms
+Type "strut my-app release --env prod" Enter
+Sleep 4000ms

--- a/bin/tapes/workflow-init.tape
+++ b/bin/tapes/workflow-init.tape
@@ -1,0 +1,26 @@
+# workflow-init.tape — Focused init step for the "Three commands" section
+# Used for: strut-www homepage workflow tab 01
+#
+# Story: Show `strut init` creating the project scaffold in one clean beat.
+
+Set Shell "bash"
+Set FontSize 20
+Set Padding 24
+Set Theme "Catppuccin Mocha"
+Set CursorBlink false
+Set TypingSpeed 40ms
+Set WindowBar Colorful
+
+Output ../output/gif/workflow-init.gif
+
+# ── Hidden setup ──────────────────────────────────────────────────────────────
+Hide
+Type `export PS1="~/project $ "` Enter
+Type "source shims/workflow-init.sh" Enter
+Type "clear" Enter
+Show
+
+# ── Scene: Init ───────────────────────────────────────────────────────────────
+Sleep 800ms
+Type "strut init --registry ghcr --org acme" Enter
+Sleep 2500ms

--- a/bin/tapes/workflow-scaffold.tape
+++ b/bin/tapes/workflow-scaffold.tape
@@ -1,0 +1,26 @@
+# workflow-scaffold.tape — Focused scaffold step for the "Three commands" section
+# Used for: strut-www homepage workflow tab 02
+#
+# Story: Show `strut scaffold` generating stack files in one clean beat.
+
+Set Shell "bash"
+Set FontSize 20
+Set Padding 24
+Set Theme "Catppuccin Mocha"
+Set CursorBlink false
+Set TypingSpeed 40ms
+Set WindowBar Colorful
+
+Output ../output/gif/workflow-scaffold.gif
+
+# ── Hidden setup ──────────────────────────────────────────────────────────────
+Hide
+Type `export PS1="~/project $ "` Enter
+Type "source shims/workflow-scaffold.sh" Enter
+Type "clear" Enter
+Show
+
+# ── Scene: Scaffold ───────────────────────────────────────────────────────────
+Sleep 800ms
+Type "strut scaffold my-app" Enter
+Sleep 2500ms


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @gfargo :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Summary

Adds three focused VHS tape files for the strut-www homepage "Three commands. That's it." section, giving each tab its own dedicated GIF recording.

### New Files

**Tapes:**
- `bin/tapes/workflow-init.tape` — records `strut init --registry ghcr --org acme`
- `bin/tapes/workflow-scaffold.tape` — records `strut scaffold my-app`
- `bin/tapes/workflow-deploy.tape` — records `strut my-app release --env prod`

**Shims:**
- `bin/tapes/shims/workflow-init.sh` — canned init output
- `bin/tapes/shims/workflow-scaffold.sh` — canned scaffold output
- `bin/tapes/shims/workflow-deploy.sh` — canned deploy output

### Usage

```bash
./bin/record.sh tapes/workflow-init.tape
./bin/record.sh tapes/workflow-scaffold.tape
./bin/record.sh tapes/workflow-deploy.tape
```

Or record all at once:
```bash
./bin/record.sh
```

Then sync to strut-www:
```bash
cd ../strut-www && npm run sync-demos
```

### Context

Companion to [strut-www PR #5](https://github.com/gfargo/strut-www/pull/5) which updates the homepage workflow section to display these individual GIFs in a tabbed layout.