### PR TITLE
fix: workflow tapes — monospace font + arrow/checkmark icons

### DIFF
--- a/bin/tapes/shims/workflow-deploy.sh
+++ b/bin/tapes/shims/workflow-deploy.sh
@@ -3,7 +3,7 @@ strut() {
   case "$2" in
     release)
       sleep 0.4
-      printf '→ Syncing repository on VPS...\n'
+      printf '→ Connecting to VPS (prod)...\n'
       sleep 0.6
       printf '→ Pulling images: ghcr.io/acme/my-app:latest\n'
       sleep 0.8
@@ -11,7 +11,11 @@ strut() {
       sleep 0.6
       printf '→ Deploying containers (3/3)...\n'
       sleep 0.6
-      printf '\033[32m✓\033[0m Health check: 3/3 services healthy\n'
+      printf '  \033[32m✓\033[0m Health check: api       healthy\n'
+      sleep 0.2
+      printf '  \033[32m✓\033[0m Health check: worker    healthy\n'
+      sleep 0.2
+      printf '  \033[32m✓\033[0m Health check: postgres  healthy\n'
       sleep 0.4
       printf '\033[1;33m✓ my-app deployed successfully — 12s\033[0m\n' ;;
     *) echo "unknown command: strut $*" ;;

--- a/bin/tapes/shims/workflow-init.sh
+++ b/bin/tapes/shims/workflow-init.sh
@@ -3,12 +3,14 @@ strut() {
   case "$1" in
     init)
       sleep 0.3
-      printf '\033[32m✓\033[0m Created strut.conf\n'
-      sleep 0.2
-      printf '\033[32m✓\033[0m Created stacks/ directory\n'
+      printf '→ Initializing project...\n'
+      sleep 0.4
+      printf '  \033[32m✓\033[0m Created strut.conf\n'
       sleep 0.25
-      printf '\033[32m✓\033[0m Registry configured: ghcr.io/acme\n'
-      sleep 0.2
+      printf '  \033[32m✓\033[0m Created stacks/ directory\n'
+      sleep 0.25
+      printf '  \033[32m✓\033[0m Registry configured: ghcr.io/acme\n'
+      sleep 0.3
       printf '\033[1;33m✓ Project initialized\033[0m\n' ;;
     *) echo "unknown command: strut $*" ;;
   esac

--- a/bin/tapes/shims/workflow-scaffold.sh
+++ b/bin/tapes/shims/workflow-scaffold.sh
@@ -3,14 +3,16 @@ strut() {
   case "$1" in
     scaffold)
       sleep 0.3
-      printf '\033[32m✓\033[0m stacks/my-app/docker-compose.yml\n'
+      printf '→ Scaffolding stack: my-app\n'
+      sleep 0.4
+      printf '  \033[32m✓\033[0m stacks/my-app/docker-compose.yml\n'
       sleep 0.2
-      printf '\033[32m✓\033[0m stacks/my-app/services.conf\n'
+      printf '  \033[32m✓\033[0m stacks/my-app/services.conf\n'
       sleep 0.2
-      printf '\033[32m✓\033[0m stacks/my-app/.env.template\n'
+      printf '  \033[32m✓\033[0m stacks/my-app/.env.template\n'
       sleep 0.2
-      printf '\033[32m✓\033[0m stacks/my-app/Dockerfile\n'
-      sleep 0.2
+      printf '  \033[32m✓\033[0m stacks/my-app/Dockerfile\n'
+      sleep 0.3
       printf '\033[1;33m✓ Stack scaffolded — edit .env and deploy\033[0m\n' ;;
     *) echo "unknown command: strut $*" ;;
   esac

--- a/bin/tapes/workflow-deploy.tape
+++ b/bin/tapes/workflow-deploy.tape
@@ -4,6 +4,7 @@
 # Story: Show `strut release` deploying containers with health checks.
 
 Set Shell "bash"
+Set FontFamily "JetBrains Mono"
 Set FontSize 20
 Set Padding 24
 Set Theme "Catppuccin Mocha"
@@ -23,4 +24,4 @@ Show
 # ── Scene: Deploy ─────────────────────────────────────────────────────────────
 Sleep 800ms
 Type "strut my-app release --env prod" Enter
-Sleep 4000ms
+Sleep 4500ms

--- a/bin/tapes/workflow-init.tape
+++ b/bin/tapes/workflow-init.tape
@@ -4,6 +4,7 @@
 # Story: Show `strut init` creating the project scaffold in one clean beat.
 
 Set Shell "bash"
+Set FontFamily "JetBrains Mono"
 Set FontSize 20
 Set Padding 24
 Set Theme "Catppuccin Mocha"

--- a/bin/tapes/workflow-scaffold.tape
+++ b/bin/tapes/workflow-scaffold.tape
@@ -4,6 +4,7 @@
 # Story: Show `strut scaffold` generating stack files in one clean beat.
 
 Set Shell "bash"
+Set FontFamily "JetBrains Mono"
 Set FontSize 20
 Set Padding 24
 Set Theme "Catppuccin Mocha"


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @gfargo :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Fix

Update workflow VHS tapes to produce properly styled GIF recordings.

### Changes

**Tapes** (`bin/tapes/workflow-*.tape`):
- Add `Set FontFamily "JetBrains Mono"` — fixes proportional font fallback that caused bad kerning in the first recording

**Shims** (`bin/tapes/shims/workflow-*.sh`):
- Add leading `→` arrows for progress steps (matches ship.sh, backup-restore.sh, etc.)
- Use indented `  ✓` green checkmarks for sub-items
- Bold gold `✓` for final success message
- Proper sleep timing between lines for readability

### Before/After Style

**Before** (flat, no arrows):
```
✓ Created strut.conf
✓ Created stacks/ directory
✓ Registry configured: ghcr.io/acme
✓ Project initialized
```

**After** (matches existing demos):
```
→ Initializing project...
  ✓ Created strut.conf
  ✓ Created stacks/ directory
  ✓ Registry configured: ghcr.io/acme
✓ Project initialized
```

Companion GIF update: https://github.com/gfargo/strut-www/compare/fix/workflow-gifs-v2