### PR TITLE
docs: document VHS demo recording conventions

### DIFF
--- a/.kiro/steering/demo-recordings.md
+++ b/.kiro/steering/demo-recordings.md
@@ -71,10 +71,14 @@ Generated GIFs in `bin/output/` are **gitignored** — the `.tape` + shim files 
 ## Syncing to the Marketing Site
 
 ```bash
-cd ../strut-www && npm run sync-demos
+cd .www && npm run sync-demos
 ```
 
-This copies `bin/output/gif/*.gif` and `bin/output/png/*.png` into `public/demos/`. Commit the GIFs in strut-www — VHS cannot run in Vercel's build environment, so assets must be generated ahead of time and checked in.
+The strut-www repo is checked out inside this one as `.www/`, and its `sync-demos` script
+reads `../bin/output/` — so it only works from that nested location. It copies
+`bin/output/gif/*.gif` and `bin/output/png/*.png` into `public/demos/`. Commit the GIFs in
+strut-www: VHS cannot run in Vercel's build environment, so assets must be generated ahead
+of time and checked in.
 
 ## Running VHS in a Linux Container / CI
 

--- a/.kiro/steering/demo-recordings.md
+++ b/.kiro/steering/demo-recordings.md
@@ -1,0 +1,92 @@
+---
+inclusion: fileMatch
+fileMatchPattern: "bin/**,bin/tapes/**"
+description: "VHS tape authoring and GIF generation for marketing/docs assets"
+---
+
+# Demo Recording Pipeline (VHS)
+
+Terminal demos in `bin/` are recorded with [Charm VHS](https://github.com/charmbracelet/vhs) and consumed by the marketing site (strut-www) and README. See `bin/README.md` for the full reference — this file covers the conventions an agent must follow when adding or fixing a recording.
+
+## Non-Negotiables
+
+**Always set an explicit monospace font.** Every tape must include:
+
+```tape
+Set FontFamily "JetBrains Mono"
+```
+
+Without it, VHS falls back to whatever the host provides. On a machine with no monospace font installed (most Linux containers, CI runners) that fallback is a *proportional* font, which silently produces broken kerning and misaligned columns. The GIF still renders, so this fails quietly — it is only caught by eye. Never omit `FontFamily`.
+
+**Output never comes from the real CLI.** Each tape sources a matching `bin/tapes/shims/<name>.sh` that defines a fake `strut()` printing canned output. This keeps recordings deterministic and avoids stray errors, SSH, or Docker. A tape and its shim are always added/edited together.
+
+## Shim Output Conventions
+
+Match the existing recordings or the new GIF will look out of place next to them:
+
+| Element | Format | Use |
+|---------|--------|-----|
+| Progress step | `→ Doing a thing...` | Top-level action, unindented |
+| Sub-item success | `  \033[32m✓\033[0m Detail` | Two-space indent, green check |
+| Final success | `\033[1;33m✓ Summary\033[0m` | Bold gold, closes the scene |
+| Error / warning | `\033[1;31m✗ text\033[0m` | Red |
+| Service status dot | `\033[32m●\033[0m` | Green |
+| Dim label | `\033[90m[api]\033[0m` | Log prefixes |
+
+Structure a scene as: arrow steps → indented checks → one gold summary line. Use `sleep` between `printf` calls for staged reveal, and make the tape's trailing `Sleep` at least as long as the shim's total internal sleep time or the recording cuts off mid-output.
+
+## Standard Tape Header
+
+```tape
+Set Shell "bash"
+Set FontFamily "JetBrains Mono"
+Set FontSize 20
+Set Padding 24
+Set Theme "Catppuccin Mocha"
+Set CursorBlink false
+Set TypingSpeed 40ms
+Set WindowBar Colorful
+
+Output ../output/gif/<name>.gif
+
+Hide
+Type `export PS1="~/project $ "` Enter
+Type "source shims/<name>.sh" Enter
+Type "clear" Enter
+Show
+```
+
+Output paths are relative to the tape file. `Catppuccin Mocha` is chosen because it maps cleanly onto the Charcoal/Bone/Gold brand palette.
+
+## Recording
+
+```bash
+./bin/record.sh                            # all tapes
+./bin/record.sh tapes/workflow-init.tape   # one tape
+./bin/optimize.sh --lossy --colors 64      # runs automatically after record.sh
+```
+
+Generated GIFs in `bin/output/` are **gitignored** — the `.tape` + shim files are the source of truth. The committed copies live in the strut-www repo because they are served as static assets.
+
+## Syncing to the Marketing Site
+
+```bash
+cd ../strut-www && npm run sync-demos
+```
+
+This copies `bin/output/gif/*.gif` and `bin/output/png/*.png` into `public/demos/`. Commit the GIFs in strut-www — VHS cannot run in Vercel's build environment, so assets must be generated ahead of time and checked in.
+
+## Running VHS in a Linux Container / CI
+
+The pipeline is macOS-first (`brew install vhs gifsicle`) but does run headless. Requirements:
+
+- `vhs` — `go install github.com/charmbracelet/vhs@latest`
+- `ffmpeg` — static build works fine (no distro package on Amazon Linux 2023)
+- `ttyd` — single binary from the ttyd releases page
+- A monospace font installed **and** `fc-cache -f` run, or `FontFamily` resolves to nothing
+- Chromium — VHS drives it via go-rod. Running as root requires `--no-sandbox`, which VHS does not expose, so wrap the Chromium binary in a shell script that injects the flag
+- `gifsicle` is optional; skipping it just means no post-optimization
+
+## Naming
+
+One tape per story, named for the story: `workflow-init`, `ship`, `rollback`. Tapes under `bin/tapes/live/` run **real** commands against a real VPS via `bin/record-live.sh` and need credentials in `~/.strut-live.env` — keep those separate from the shimmed tapes.

--- a/.kiro/steering/development-workflow.md
+++ b/.kiro/steering/development-workflow.md
@@ -150,6 +150,10 @@ Key maintenance tasks:
 - **Docs**: Auto-fetched from wiki via ISR (1hr revalidation) — no manual sync needed
 - **Changelog**: `/changelog` page fetches from GitHub Releases API
 - **After releases**: Push version update to `.www` repo to trigger Vercel redeploy
+- **Terminal demo GIFs**: Recorded here via VHS (`bin/tapes/`), then synced into the
+  site with `npm run sync-demos`. Generated GIFs are gitignored in this repo but
+  committed in strut-www since they're served as static assets. See
+  `.kiro/steering/demo-recordings.md` and `bin/README.md`.
 
 ## Wiki Updates
 

--- a/bin/README.md
+++ b/bin/README.md
@@ -7,9 +7,15 @@ Captures real terminal recordings of `strut` commands using [Charm VHS](https://
 ```bash
 brew install vhs        # terminal recorder (pulls in ffmpeg + ttyd)
 brew install gifsicle   # lossless GIF optimization
+brew install font-jetbrains-mono   # the font tapes pin via Set FontFamily
 ```
 
 Verify: `vhs --version && gifsicle --version`
+
+> **A monospace font must be installed.** Tapes pin `Set FontFamily "JetBrains Mono"`.
+> If that font is missing, VHS falls back to whatever the system offers — on a bare
+> Linux box that's a *proportional* font, and the GIF renders with broken kerning
+> without any error. See [Running headless](#running-headless-linux--ci).
 
 ## Usage
 
@@ -34,11 +40,21 @@ bin/
 ├── README.md           # This file
 ├── record.sh           # Main driver — renders tapes, optimizes output
 ├── optimize.sh         # Lossless GIF optimization (gifsicle -O3)
+├── record-live.sh      # Renders live/*.tape against a real VPS (needs credentials)
 ├── tapes/              # VHS tape files (the "screenplays")
 │   ├── hero-deploy.tape        # Init → scaffold → deploy flow (hero GIF)
+│   ├── workflow-init.tape      # strut init — homepage workflow tab 01
+│   ├── workflow-scaffold.tape  # strut scaffold — homepage workflow tab 02
+│   ├── workflow-deploy.tape    # strut release — homepage workflow tab 03
+│   ├── ship.tape               # Commit → push → rebuild
+│   ├── local-dev.tape          # Start → sync-db → logs
+│   ├── rollback.tape           # Failed health → rollback
 │   ├── backup-restore.tape     # Backup + verify workflow (feature GIF)
 │   ├── drift-detect.tape       # Drift detection + auto-fix (feature GIF)
-│   └── health-status.tape      # Health check overview (still PNG)
+│   ├── secrets.tape            # Secret rotation
+│   ├── health-status.tape      # Health check overview (still PNG)
+│   ├── shims/                  # Per-tape strut() stubs printing canned output
+│   └── live/                   # Tapes that run REAL commands against a VPS
 └── output/             # Generated assets (gitignored except .gitkeep)
     ├── gif/            # Optimized animated GIFs
     └── png/            # Still screenshots
@@ -58,6 +74,7 @@ Every tape follows this pattern:
 ```tape
 # ── Settings (determinism + brand) ────────────────────────
 Set Shell "bash"
+Set FontFamily "JetBrains Mono"
 Set FontSize 20
 Set Padding 24
 Set Theme "Catppuccin Mocha"
@@ -90,14 +107,34 @@ for staged reveal). See `shims/hero-deploy.sh` for the canonical example.
 
 ### Key conventions
 
+- **Font is pinned** — every tape sets `Set FontFamily "JetBrains Mono"`. Never omit this (see Prerequisites)
 - **Output paths** are relative to the tape file: `../output/gif/` and `../output/png/`
 - **Output comes from a shim** (`shims/<name>.sh`), never the real CLI — no live VPS, no stray errors, no visible `printf` lines
 - **Embedded quotes** in a typed command (e.g. `-m 'msg'`) need a backtick Type: `` Type `strut ... -m 'msg'` `` then `Enter` on the next line
-- **Gold accent** for success: `\\033[1;33m✓ text\\033[0m`
+- **Arrow steps** for progress: `→ Doing a thing...` (unindented)
+- **Indented green checks** for sub-items: `  \\033[32m✓\\033[0m Detail`
+- **Gold accent** for the closing success line: `\\033[1;33m✓ text\\033[0m`
 - **Red** for errors/warnings: `\\033[1;31m✗ text\\033[0m`
 - **Green dots** for status: `\\033[32m●\\033[0m`
 - **PS1 prompt** is set to `~/project $ ` for consistency across all tapes
 - **Sleep timings** — hold long enough for a viewer to read, short enough to stay tight
+
+### Scene shape
+
+Structure output as arrow steps → indented checks → one gold summary line:
+
+```
+→ Connecting to VPS (prod)...
+→ Pulling images: ghcr.io/acme/my-app:latest
+→ Deploying containers (3/3)...
+  ✓ Health check: api       healthy
+  ✓ Health check: worker    healthy
+  ✓ Health check: postgres  healthy
+✓ my-app deployed successfully — 12s
+```
+
+A GIF that skips the arrows or the indentation reads as visually inconsistent when
+placed next to the others on the marketing site.
 
 ### GIF vs PNG
 
@@ -164,6 +201,9 @@ Set FontSize 16    # smaller font → smaller canvas (VHS auto-sizes)
 | File | Optimized | Notes |
 |------|-----------|-------|
 | hero-deploy.gif | ~132 KB | init → scaffold → deploy |
+| workflow-init.gif | ~48 KB | strut init (homepage tab 01) |
+| workflow-scaffold.gif | ~52 KB | strut scaffold (homepage tab 02) |
+| workflow-deploy.gif | ~67 KB | strut release (homepage tab 03) |
 | ship.gif | ~32 KB | commit → push → rebuild |
 | local-dev.gif | ~120 KB | start → sync-db → logs |
 | rollback.gif | ~76 KB | failed health → rollback |
@@ -175,9 +215,54 @@ Sizes dropped sharply after moving to shims (no error output or visible
 `printf` frames). For aggressive reduction, trim Sleep durations and increase
 TypingSpeed first.
 
+## Syncing to the marketing site
+
+Generated GIFs in `bin/output/` are gitignored — the `.tape` and shim files are the
+source of truth here. The marketing site commits its own copies because they're
+served as static assets:
+
+```bash
+cd ../strut-www && npm run sync-demos
+```
+
+VHS can't run in Vercel's build environment (needs Chromium + ttyd + ffmpeg), so
+assets are always generated ahead of time and checked into strut-www.
+
+## Running headless (Linux / CI)
+
+The pipeline is macOS-first but works headless. On a bare Linux container you need:
+
+| Dependency | Install |
+|------------|---------|
+| `vhs` | `go install github.com/charmbracelet/vhs@latest` |
+| `ffmpeg` | Static build from [johnvansickle.com](https://johnvansickle.com/ffmpeg/) — no distro package on Amazon Linux 2023 |
+| `ttyd` | Single binary from [ttyd releases](https://github.com/tsl0922/ttyd/releases) |
+| JetBrains Mono | Drop the TTFs in `/usr/share/fonts/` then run `fc-cache -f` |
+| Chromium | Any recent build; VHS drives it through go-rod |
+
+Two gotchas specific to containers:
+
+1. **Fonts need `fc-cache -f`.** Copying TTFs into place isn't enough — without
+   refreshing the fontconfig cache, `Set FontFamily` silently resolves to nothing.
+2. **Chromium refuses to run as root** without `--no-sandbox`, and VHS doesn't expose
+   a way to pass browser flags. Wrap the binary:
+
+   ```bash
+   mv /path/to/chrome /path/to/chrome-real
+   cat > /path/to/chrome <<'EOF'
+   #!/bin/bash
+   exec /path/to/chrome-real --no-sandbox --disable-gpu --disable-dev-shm-usage "$@"
+   EOF
+   chmod +x /path/to/chrome
+   ```
+
+`gifsicle` is optional — skipping it only means no post-render optimization.
+
 ## Design Decisions
 
-- **Deterministic**: tapes pin timing, theme, cursor blink, and prompt
+- **Deterministic**: tapes pin timing, theme, font, cursor blink, and prompt — nothing
+  is left to the host environment, because host-dependent fallbacks (especially fonts)
+  fail silently rather than loudly
 - **Brand-aligned**: Catppuccin Mocha maps well to our Charcoal/Bone/Gold palette
 - **No real infra**: a hidden per-tape `strut()` shim prints canned output — no SSH, no Docker, no VPS, and no stray errors from real commands
 - **Web-ready**: all GIFs are losslessly optimized as a pipeline step
@@ -203,6 +288,12 @@ TypingSpeed first.
 Full DSL: https://github.com/charmbracelet/vhs
 
 ## Troubleshooting
+
+**Text has uneven spacing / columns don't line up**  
+The tape is missing `Set FontFamily "JetBrains Mono"`, or that font isn't installed on
+the recording machine, so VHS fell back to a proportional font. Add the directive, install
+the font, run `fc-cache -f` on Linux, and re-record. This produces no error — it's only
+visible by looking at the GIF.
 
 **Real strut errors in the GIF (e.g. "Project already initialized", "Env file not found")**  
 The tape's `strut()` shim didn't load, so the typed command ran the *real* strut against the fixture. Ensure the Hide block sources the shim (`Type "source shims/<name>.sh" Enter`) and that a matching `shims/<name>.sh` exists and defines `strut()` for that command.

--- a/bin/README.md
+++ b/bin/README.md
@@ -222,11 +222,13 @@ source of truth here. The marketing site commits its own copies because they're
 served as static assets:
 
 ```bash
-cd ../strut-www && npm run sync-demos
+cd .www && npm run sync-demos
 ```
 
-VHS can't run in Vercel's build environment (needs Chromium + ttyd + ffmpeg), so
-assets are always generated ahead of time and checked into strut-www.
+The site repo is checked out inside this one as `.www/`; its `sync-demos` script reads
+`../bin/output/`, so it only works from there. VHS can't run in Vercel's build environment
+(needs Chromium + ttyd + ffmpeg), so assets are always generated ahead of time and
+checked into strut-www.
 
 ## Running headless (Linux / CI)
 


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @gfargo :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Why

The VHS pipeline knowledge lived only in people's heads, and the gap caused two rounds of bad GIFs on the workflow section: first a proportional-font fallback that broke kerning, then shim output that skipped the `→`/`✓` conventions every other demo uses. Both failed silently — the recordings rendered fine, they just looked wrong.

## Changes

**New: `.kiro/steering/demo-recordings.md`** (fileMatch on `bin/**`)
- `Set FontFamily "JetBrains Mono"` is documented as non-negotiable, with the reason it fails quietly
- Shim output conventions as a lookup table (arrows, indented checks, gold summary, error/status colors)
- Standard tape header to copy
- Headless/container requirements

**`bin/README.md`**
- Font listed under Prerequisites with a callout on the silent fallback
- `Set FontFamily` added to the tape anatomy example and Key Conventions
- New "Scene shape" example showing the arrow → indented check → gold summary structure
- New "Running headless (Linux / CI)" section: dependency table plus the two container gotchas (`fc-cache -f`, wrapping Chromium for `--no-sandbox`)
- New "Syncing to the marketing site" section clarifying `.www/` is nested and why GIFs are committed there but gitignored here
- Troubleshooting entry for uneven text spacing
- Tape listing and size table refreshed (were missing `workflow-*`, `ship`, `local-dev`, `rollback`, `secrets`, `shims/`, `live/`)

**`.kiro/steering/development-workflow.md`**
- The `.www` section now points at the demo pipeline

Docs only — no tapes, shims, or scripts touched.

Companion: https://github.com/gfargo/strut-www/pull/7